### PR TITLE
Fix test_find_python_in_path: Check only up to version only when MacOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,8 @@ this section.
 To make sure the tests suites can run rightly, you need to install [Git LFS](https://git-lfs.github.com/), then
 ```bash
 $ git lfs install
+# If you have already cloned the repository, execute the below command as well.
+$ git lfs pull
 ```
 
 Then, you need to install base dependencies in a venv. Although PDM uses local package directory to install

--- a/news/348.bugfix.rst
+++ b/news/348.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a test failure when using homebrew installed python.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 import sys
 
 import pytest
@@ -50,10 +51,18 @@ def test_expend_env_vars_in_auth(given, expected, monkeypatch):
 def test_find_python_in_path(tmp_path):
 
     assert utils.find_python_in_path(sys.executable) == pathlib.Path(sys.executable)
+
+    posix_path_to_executable = pathlib.Path(sys.executable).as_posix().lower()
+    if sys.platform == "darwin":
+        found_version_of_executable = re.split(
+            r"(python@[\d.]*\d+)", posix_path_to_executable
+        )
+        posix_path_to_executable = "".join(found_version_of_executable[0:2])
     assert (
         utils.find_python_in_path(sys.prefix)
         .as_posix()
         .lower()
-        .startswith(pathlib.Path(sys.executable).as_posix().lower())
+        .startswith(posix_path_to_executable)
     )
+
     assert not utils.find_python_in_path(tmp_path)


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

- Fixes https://github.com/pdm-project/pdm/issues/347.
- On MacOS, python's `sys.prefix` and `sys.executable` are different. So this tests must have failed.
- I changed this test into "find the sys.executable path up to version just like `/usr/local/Cellar/python@3.9`, and compare it to sys.prefix with `startwith`" only when MacOS.


![ss 5](https://user-images.githubusercontent.com/41639488/112742438-7ccde980-8fc9-11eb-9408-87fa6f6b2bd5.png)


I checked this test with ubuntu on docker as well, and it runs correctly.