### PR TITLE
Remove redundant `-d` with `pdm install` in setup_dev.py

### DIFF
--- a/setup_dev.py
+++ b/setup_dev.py
@@ -34,7 +34,7 @@ def main():
 
     subprocess.check_call([venv_pdm, "use", sys.executable])
     subprocess.check_call([venv_pdm, "config", "parallel_install", "false"])
-    subprocess.check_call([venv_pdm, "install", "-dvv"])
+    subprocess.check_call([venv_pdm, "install", "-vv"])
 
     pdm_path = (
         BASE_DIR


### PR DESCRIPTION
## Pull Request Check List

~~- [ ] A news fragment is added in `news/` describing what is new.~~
~~- [ ] Test cases added for changed code.~~

## Describe what you have changed in this PR.

Fixes notification:

> [CHANGE IN 1.5.0]: dev-dependencies are included by default and `-d/--dev` is redundant