### PR TITLE
Seek for other sitecustomize.py to import

### DIFF
--- a/news/422.bugfix.md
+++ b/news/422.bugfix.md
@@ -1,0 +1,1 @@
+Ensure another sitecustomize imported if exist.

--- a/news/422.bugfix.md
+++ b/news/422.bugfix.md
@@ -1,1 +1,1 @@
-Ensure another sitecustomize imported if exist.
+Seek for other sitecustomize.py to import.

--- a/pdm/pep582/sitecustomize.py
+++ b/pdm/pep582/sitecustomize.py
@@ -41,10 +41,24 @@ def get_pypackages_path(maxdepth=5):
                 return result
 
 
-def main():
+def ensure_another_sitecustomize_imported():
+    import imp
 
+    try:
+        f, pathname, desc = imp.find_module("sitecustomize", sys.path)
+        try:
+            imp.load_module("another_sitecustomize", f, pathname, desc)
+        finally:
+            f.close()
+    except ImportError:
+        pass
+
+
+def main():
     self_path = os.path.normcase(os.path.dirname(os.path.abspath(__file__)))
     sys.path[:] = [path for path in sys.path if os.path.normcase(path) != self_path]
+
+    ensure_another_sitecustomize_imported()
 
     libpath = get_pypackages_path()
     if not libpath:

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import subprocess
 import textwrap
@@ -214,3 +215,42 @@ def test_run_with_another_project_root(project, invoke, capfd):
             assert ret.exit_code == 0
             out, _ = capfd.readouterr()
             assert out.strip() == "2.24.0"
+
+
+@pytest.mark.parametrize("python_version", ["2.7", "3.6", "3.7", "3.8", "3.9"])
+def test_import_another_sitecustomize(python_version, project, invoke, capfd):
+    project.meta["requires-python"] = ">=2.7"
+    project.write_pyproject()
+    # a script for checking another sitecustomize is imported
+    project.root.joinpath("foo.py").write_text(
+        textwrap.dedent(
+            """
+            import sys
+            module = sys.modules.get('another_sitecustomize')
+            if module:
+                print(module.__file__)
+            """
+        )
+    )
+    # ensure there have at least one sitecustomize can be imported
+    # there may have more than one sitecustomize.py in sys.path
+    project.root.joinpath("sitecustomize.py").write_text("# do nothing")
+    env = os.environ.copy()
+    paths = [str(project.root)]
+    original_paths = env.get("PYTHONPATH", "")
+    if original_paths:
+        paths.insert(0, original_paths)
+    env["PYTHONPATH"] = os.pathsep.join(paths)
+    # invoke pdm commands
+    invoke = functools.partial(invoke, env=env, obj=project)
+    invoke(["use", "-f", python_version])
+    project._environment = None
+    capfd.readouterr()
+    with cd(project.root):
+        invoke(["run", "python", "foo.py"])
+    # only the first and second sitecustomize module will be imported
+    # as sitecustomize and another_sitecustomize
+    # the first one is pdm.pep582.sitecustomize for sure
+    # the second one maybe not the dummy module injected here
+    out, _ = capfd.readouterr()
+    assert out.strip()

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -217,7 +217,7 @@ def test_run_with_another_project_root(project, invoke, capfd):
             assert out.strip() == "2.24.0"
 
 
-def test_import_another_sitecustomize(python_version, project, invoke, capfd):
+def test_import_another_sitecustomize(project, invoke, capfd):
     project.meta["requires-python"] = ">=2.7"
     project.write_pyproject()
     # a script for checking another sitecustomize is imported

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -217,7 +217,6 @@ def test_run_with_another_project_root(project, invoke, capfd):
             assert out.strip() == "2.24.0"
 
 
-@pytest.mark.parametrize("python_version", ["2.7", "3.6", "3.7", "3.8", "3.9"])
 def test_import_another_sitecustomize(python_version, project, invoke, capfd):
     project.meta["requires-python"] = ">=2.7"
     project.write_pyproject()
@@ -243,7 +242,6 @@ def test_import_another_sitecustomize(python_version, project, invoke, capfd):
     env["PYTHONPATH"] = os.pathsep.join(paths)
     # invoke pdm commands
     invoke = functools.partial(invoke, env=env, obj=project)
-    invoke(["use", "-f", python_version])
     project._environment = None
     capfd.readouterr()
     with cd(project.root):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,14 +41,14 @@ def test_basic_integration(python_version, project_no_init, strict_invoke):
 
 @pytest.mark.integration
 @pytest.mark.parametrize("python_version", ["2.7", "3.6", "3.7", "3.8", "3.9"])
-def test_import_another_sitecustomize(python_version, project_no_init, strict_invoke):
-    project = project_no_init
-    # check django and another sitecustomize are imported
+def test_import_another_sitecustomize(python_version, project, strict_invoke):
+    project.meta["requires-python"] = ">=2.7"
+    project.write_pyproject()
+    # check another sitecustomize is imported
     project.root.joinpath("foo.py").write_text(
         textwrap.dedent(
             """
             import sys
-            import django
             with open("output", "w") as f:
                 module = sys.modules.get('another_sitecustomize')
                 if module:
@@ -67,10 +67,8 @@ def test_import_another_sitecustomize(python_version, project_no_init, strict_in
     env["PYTHONPATH"] = os.pathsep.join(paths)
     # invoke pdm commands
     strict_invoke = functools.partial(strict_invoke, env=env, obj=project)
-    strict_invoke(["init"], input="\ny\n\n\n\n\n\n>=2.7\n")
     strict_invoke(["use", "-f", python_version])
     project._environment = None
-    strict_invoke(["add", "django"])
     with cd(project.root):
         strict_invoke(["run", "python", "foo.py"])
     # only the first and second sitecustomize module will be imported

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,3 @@
-import functools
-import os
-import textwrap
-
 import pytest
 
 from pdm.utils import cd
@@ -37,42 +33,3 @@ def test_basic_integration(python_version, project_no_init, strict_invoke):
     assert not any(
         line.strip().lower().startswith("django") for line in result.output.splitlines()
     )
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize("python_version", ["2.7", "3.6", "3.7", "3.8", "3.9"])
-def test_import_another_sitecustomize(python_version, project, strict_invoke):
-    project.meta["requires-python"] = ">=2.7"
-    project.write_pyproject()
-    # check another sitecustomize is imported
-    project.root.joinpath("foo.py").write_text(
-        textwrap.dedent(
-            """
-            import sys
-            with open("output", "w") as f:
-                module = sys.modules.get('another_sitecustomize')
-                if module:
-                    f.write(module.__file__)
-            """
-        )
-    )
-    # ensure there have at least one sitecustomize can be imported
-    # there may have more than one sitecustomize.py in sys.path
-    project.root.joinpath("sitecustomize.py").write_text("# do nothing")
-    env = os.environ.copy()
-    paths = [str(project.root)]
-    original_paths = env.get("PYTHONPATH", "")
-    if original_paths:
-        paths.insert(0, original_paths)
-    env["PYTHONPATH"] = os.pathsep.join(paths)
-    # invoke pdm commands
-    strict_invoke = functools.partial(strict_invoke, env=env, obj=project)
-    strict_invoke(["use", "-f", python_version])
-    project._environment = None
-    with cd(project.root):
-        strict_invoke(["run", "python", "foo.py"])
-    # only the first and second sitecustomize module will be imported
-    # as sitecustomize and another_sitecustomize
-    # the first one is pdm.pep582.sitecustomize for sure
-    # the second one maybe not the dummy module injected here
-    assert project.root.joinpath("output").read_text().strip()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,7 @@
+import functools
+import os
+import textwrap
+
 import pytest
 
 from pdm.utils import cd
@@ -33,3 +37,44 @@ def test_basic_integration(python_version, project_no_init, strict_invoke):
     assert not any(
         line.strip().lower().startswith("django") for line in result.output.splitlines()
     )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("python_version", ["2.7", "3.6", "3.7", "3.8", "3.9"])
+def test_import_another_sitecustomize(python_version, project_no_init, strict_invoke):
+    project = project_no_init
+    # check django and another sitecustomize are imported
+    project.root.joinpath("foo.py").write_text(
+        textwrap.dedent(
+            """
+            import sys
+            import django
+            with open("output", "w") as f:
+                module = sys.modules.get('another_sitecustomize')
+                if module:
+                    f.write(module.__file__)
+            """
+        )
+    )
+    # ensure there have at least one sitecustomize can be imported
+    # there may have more than one sitecustomize.py in sys.path
+    project.root.joinpath("sitecustomize.py").write_text("# do nothing")
+    env = os.environ.copy()
+    paths = [str(project.root)]
+    original_paths = env.get("PYTHONPATH", "")
+    if original_paths:
+        paths.insert(0, original_paths)
+    env["PYTHONPATH"] = os.pathsep.join(paths)
+    # invoke pdm commands
+    strict_invoke = functools.partial(strict_invoke, env=env, obj=project)
+    strict_invoke(["init"], input="\ny\n\n\n\n\n\n>=2.7\n")
+    strict_invoke(["use", "-f", python_version])
+    project._environment = None
+    strict_invoke(["add", "django"])
+    with cd(project.root):
+        strict_invoke(["run", "python", "foo.py"])
+    # only the first and second sitecustomize module will be imported
+    # as sitecustomize and another_sitecustomize
+    # the first one is pdm.pep582.sitecustomize for sure
+    # the second one maybe not the dummy module injected here
+    assert project.root.joinpath("output").read_text().strip()


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Try to use nix to build an isolating environment for PDM development. But pdm can not co-exist with Python packages in nix due to the import mechanism that Python only imports module once by name.
The Python in nix using sitecustomize.py to import packages and PDM also using it to enable PEP582 globally. 

Hence, we need to **make sure that another sitecustomize.py gets imported if it exists**. So PDM can make PEP582 enabling globally, and  Python in nix also can import its packages.
