### PR TITLE
add mypy pre-commit hook

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -5,4 +5,3 @@ disallow_untyped_defs = true
 
 [mypy-pdm._vendor.*]
 ignore_errors = True
-

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+files = pdm/**/*.py
+ignore_missing_imports = true
+disallow_untyped_defs = true
+
+[mypy-pdm._vendor.*]
+ignore_errors = True
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,9 @@ repos:
     rev: 5.8.0
     hooks:
       - id: isort
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.812
+    hooks:
+      - id: mypy
+        files: ^pdm/

--- a/news/427.misc.md
+++ b/news/427.misc.md
@@ -1,0 +1,1 @@
+Add [mypy](https://github.com/python/mypy) config file

--- a/news/430.misc.md
+++ b/news/430.misc.md
@@ -1,0 +1,1 @@
+Add [mypy](https://github.com/python/mypy) pre-commit hook

--- a/pdm/cli/utils.py
+++ b/pdm/cli/utils.py
@@ -5,7 +5,7 @@ import os
 from argparse import Action
 from collections import ChainMap
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Sequence, Set
 
 import cfonts
 import tomlkit
@@ -23,6 +23,8 @@ from pdm.models.specifiers import get_specifier
 from pdm.project import Project
 
 if TYPE_CHECKING:
+    from typing import Dict, Iterable, List, Optional, Tuple
+
     from resolvelib.resolvers import RequirementInformation, ResolutionImpossible
 
     from pdm.models.candidates import Candidate
@@ -134,12 +136,10 @@ class Package:
     def __hash__(self) -> int:
         return hash(self.name)
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         return f"<Package {self.name}=={self.version}>"
 
-    def __eq__(self, value: object) -> bool:
-        if not isinstance(value, Package):
-            return False
+    def __eq__(self, value: Package) -> bool:
         return self.name == value.name
 
 
@@ -152,11 +152,11 @@ def build_dependency_graph(working_set: WorkingSet) -> DirectedGraph:
     def add_package(key: str, dist: Distribution) -> Package:
         name, extras = strip_extras(key)
         extras = extras or ()
-        reqs: Dict[str, Requirement] = {}
+        reqs = {}
         if dist:
-            requirements = (
+            requirements = [
                 Requirement.from_pkg_requirement(r) for r in dist.requires(extras)
-            )
+            ]
             for req in requirements:
                 reqs[req.identify()] = req
             version = dist.version
@@ -252,7 +252,7 @@ def format_reverse_package(
     requires: str = "",
     prefix: str = "",
     visited: Optional[Set[str]] = None,
-) -> str:
+):
     """Format one package for output reverse dependency graph."""
     if visited is None:
         visited = set()
@@ -462,29 +462,29 @@ def compatible_dev_flag(project: Project, dev: Optional[bool]) -> bool:
 
 
 def translate_sections(
-    project: Project, default: bool, dev: bool, sections: Iterable[str]
-) -> Iterable[str]:
+    project: Project, default: bool, dev: bool, sections: Sequence[str]
+) -> Sequence[str]:
     """Translate default, dev and sections containing ":all" into a list of sections"""
     optional_groups = set(project.meta.optional_dependencies or [])
     dev_groups = set(project.tool_settings.get("dev-dependencies", []))
-    sections_set = set(sections)
+    sections = set(sections)
     if dev is None:
         dev = True
-    if sections_set & dev_groups:
+    if sections & dev_groups:
         if not dev:
             raise PdmUsageError(
                 "--prod is not allowed with dev sections and should be left"
             )
     elif dev:
-        sections_set.update(dev_groups)
+        sections.update(dev_groups)
     if ":all" in sections:
-        sections_set.discard(":all")
-        sections_set.update(optional_groups)
+        sections.discard(":all")
+        sections.update(optional_groups)
     if default:
-        sections_set.add("default")
+        sections.add("default")
     # Sorts the result in ascending order instead of in random order
     # to make this function pure
-    return sorted(sections_set)
+    return sorted(sections)
 
 
 def merge_dictionary(target: dict, input: dict) -> None:

--- a/pdm/cli/utils.py
+++ b/pdm/cli/utils.py
@@ -5,7 +5,7 @@ import os
 from argparse import Action
 from collections import ChainMap
 from pathlib import Path
-from typing import TYPE_CHECKING, Sequence, Set
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Set, Tuple
 
 import cfonts
 import tomlkit
@@ -23,8 +23,6 @@ from pdm.models.specifiers import get_specifier
 from pdm.project import Project
 
 if TYPE_CHECKING:
-    from typing import Dict, Iterable, List, Optional, Tuple
-
     from resolvelib.resolvers import RequirementInformation, ResolutionImpossible
 
     from pdm.models.candidates import Candidate
@@ -136,10 +134,12 @@ class Package:
     def __hash__(self) -> int:
         return hash(self.name)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<Package {self.name}=={self.version}>"
 
-    def __eq__(self, value: Package) -> bool:
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, Package):
+            return False
         return self.name == value.name
 
 
@@ -152,11 +152,11 @@ def build_dependency_graph(working_set: WorkingSet) -> DirectedGraph:
     def add_package(key: str, dist: Distribution) -> Package:
         name, extras = strip_extras(key)
         extras = extras or ()
-        reqs = {}
+        reqs: Dict[str, Requirement] = {}
         if dist:
-            requirements = [
+            requirements = (
                 Requirement.from_pkg_requirement(r) for r in dist.requires(extras)
-            ]
+            )
             for req in requirements:
                 reqs[req.identify()] = req
             version = dist.version
@@ -252,7 +252,7 @@ def format_reverse_package(
     requires: str = "",
     prefix: str = "",
     visited: Optional[Set[str]] = None,
-):
+) -> str:
     """Format one package for output reverse dependency graph."""
     if visited is None:
         visited = set()
@@ -462,29 +462,29 @@ def compatible_dev_flag(project: Project, dev: Optional[bool]) -> bool:
 
 
 def translate_sections(
-    project: Project, default: bool, dev: bool, sections: Sequence[str]
-) -> Sequence[str]:
+    project: Project, default: bool, dev: bool, sections: Iterable[str]
+) -> Iterable[str]:
     """Translate default, dev and sections containing ":all" into a list of sections"""
     optional_groups = set(project.meta.optional_dependencies or [])
     dev_groups = set(project.tool_settings.get("dev-dependencies", []))
-    sections = set(sections)
+    sections_set = set(sections)
     if dev is None:
         dev = True
-    if sections & dev_groups:
+    if sections_set & dev_groups:
         if not dev:
             raise PdmUsageError(
                 "--prod is not allowed with dev sections and should be left"
             )
     elif dev:
-        sections.update(dev_groups)
+        sections_set.update(dev_groups)
     if ":all" in sections:
-        sections.discard(":all")
-        sections.update(optional_groups)
+        sections_set.discard(":all")
+        sections_set.update(optional_groups)
     if default:
-        sections.add("default")
+        sections_set.add("default")
     # Sorts the result in ascending order instead of in random order
     # to make this function pure
-    return sorted(sections)
+    return sorted(sections_set)
 
 
 def merge_dictionary(target: dict, input: dict) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ release = "python tasks/release.py"
 test = "pytest tests/"
 doc = {shell = "cd docs && mkdocs serve", help = "Start the dev server for doc preview"}
 lint = "pre-commit run --all-files"
-typecheck = "mypy ./pdm"
+typecheck = "mypy"
 
 [tool.pdm.dev-dependencies]
 test = [


### PR DESCRIPTION
this pull request adds a mypy pre-commit hook.

This is kind of the nuclear option, as this will throw a *lot* of errors for any file that gets touched in a commit. That could be very noisy.

It would also be a strong incentive to refactor and fix type errors ;) ...

I'll just leave this here @frostming and you can decide what you want to do with this. Maybe the best thing is to keep it on the back burner until more of the errors are squashed?

this is stacked on #427, so it can be rebased if that is merged
