### PR TITLE
Fix wrong mypy configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,21 +22,22 @@ repos:
     hooks:
       - id: mypy
         args:
-          - --follow-imports=skip
-        files: | # incremental 'fully-typed' list
-          (?x)^(
-              pdm\/__init__\.py|
-              pdm\/__main__\.py|
-              pdm\/exceptions\.py|
-              pdm\/formats\/.*\.py|
-              pdm\/installers\/.*\.py|
-              pdm\/models\/auth\.py|
-              pdm\/models\/caches\.py|
-              pdm\/models\/python\.py|
-              pdm\/models\/setup\.py|
-              pdm\/models\/specifiers\.py|
-              pdm\/models\/versions\.py|
-              pdm\/project\/config\.py|
-              pdm\/termui\.py|
-              pdm\/utils\.py|
-          )$
+          - pdm
+          - |
+            --exclude=(?x)^(
+              (?!pdm\/__init__\.py)
+              (?!pdm\/__main__\.py)
+              (?!pdm\/exceptions\.py)
+              (?!pdm\/formats\/.*\.py)
+              (?!pdm\/installers\/.*\.py)
+              (?!pdm\/models\/auth\.py)
+              (?!pdm\/models\/caches\.py)
+              (?!pdm\/models\/python\.py)
+              (?!pdm\/models\/setup\.py)
+              (?!pdm\/models\/specifiers\.py)
+              (?!pdm\/models\/versions\.py)
+              (?!pdm\/project\/config\.py)
+              (?!pdm\/termui\.py)
+              (?!pdm\/utils\.py)
+            ).*\.py$ # incremental 'fully-typed' list
+        pass_filenames: false

--- a/news/451.misc.md
+++ b/news/451.misc.md
@@ -1,0 +1,1 @@
+Fix wrong mypy configuration.

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,10 +41,10 @@ exclude_lines =
 ignore_errors = true
 
 [mypy]
+follow_imports = silent
 ignore_missing_imports = True
 disallow_incomplete_defs = True
 disallow_untyped_calls = True
 disallow_untyped_defs = True
 disallow_untyped_decorators = True
-files = pdm/**/*.py
 exclude = pdm/(_vendor/|pep582/|models/in_process/(get_abi_tag|pep508)\.py)


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Fix the wrong Mypy configuration. It would be better that change to execute `mypy pdm` instead of executing `mypy` with `files=pdm/**/*.py` because `files=...` ignores `exclude=...`.

`follow_imports = silent` is for avoiding that it reports errors which came from `pdm/_vendor`.
