### PR TITLE
Fix 404 link on doc page

### DIFF
--- a/docs/docs/usage/dependency.md
+++ b/docs/docs/usage/dependency.md
@@ -29,7 +29,7 @@ dependencies = []
 If `pyproject.toml` is already present, it will be updated with the metadata. The metadata format follows the
 [PEP 621 specification](https://www.python.org/dev/peps/pep-0621/)
 
-For details of the meaning of each field in `pyproject.toml`, please refer to [Project File](/pyproject/pep62.md).
+For details of the meaning of each field in `pyproject.toml`, please refer to [Project File](/pyproject/pep621/).
 
 ## Add dependencies
 


### PR DESCRIPTION
## Describe what you have changed in this PR.
The PEP621 link to the project metadata goes to https://pdm.fming.dev/pyproject/pep621.md (which 404). It should go to https://pdm.fming.dev/pyproject/pep621/ instead

