### PR TITLE
Define minimal version for click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {text = "MIT"}
 dependencies = [
     "appdirs",
     "atoml~=1.0",
-    "click",
+    "click>=7",
     "distlib>=0.3.1",
     "importlib-metadata; python_version < \"3.8\"",
     "pdm-pep517<0.8.0,>=0.7.0",


### PR DESCRIPTION
## Pull Request Check List

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

I installed PDM in an environment that had a few other dependencies and got this error:

```
> pdm init -v
Creating a pyproject.toml for PDM...
Please enter the Python interpreter to use
0. /usr/bin/python (2.7)
1. /usr/local/bin/python3 (3.9)
2. /usr/local/bin/python3.9 (3.9)
3. /usr/bin/python3 (3.8)
4. /usr/bin/python2 (2.7)
5. /usr/bin/pythonw (2.7)
6. /usr/bin/python2.7 (2.7)
7. /usr/local/opt/python@3.9/bin/python3.9 (3.9)
Traceback (most recent call last):
  File "/usr/local/bin/pdm", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/site-packages/pdm/core.py", line 185, in main
    return Core().main(args)
  File "/usr/local/lib/python3.9/site-packages/pdm/core.py", line 146, in main
    raise cast(Exception, err).with_traceback(traceback)
  File "/usr/local/lib/python3.9/site-packages/pdm/core.py", line 141, in main
    f(options.project, options)
  File "/usr/local/lib/python3.9/site-packages/pdm/cli/commands/init.py", line 45, in handle
    actions.do_use(project)
  File "/usr/local/lib/python3.9/site-packages/pdm/cli/actions.py", line 485, in do_use
    selection = click.prompt(
TypeError: prompt() got an unexpected keyword argument 'show_choices'
```

I had click 6.7 installed in this environment, bumping click to 7.0 fixed the issue.