### PR TITLE
Update `run` to support `pyenv` shims on macOS

### DIFF
--- a/news/535.bugfix.md
+++ b/news/535.bugfix.md
@@ -1,0 +1,1 @@
+Update `run` to support `pyenv` shims on macOS.

--- a/pdm/cli/commands/run.py
+++ b/pdm/cli/commands/run.py
@@ -95,7 +95,9 @@ class Command(BaseCommand):
         else:
             if chdir:
                 os.chdir(project.root)
-            os.execv(expanded_command, expanded_args)
+            os.execv(
+                project.python_executable, [project.python_executable] + expanded_args
+            )
 
     def _normalize_script(
         self, script: Any


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

This is an attempt to fix #494, where PDM fails with "OSError: [Errno 8] Exec format error" when using pyenv shims on macOS. This error appears to be specific to macOS; I was unable to recreate it in a Linux Docker image.

Per https://stackoverflow.com/a/49131318, I believe this error happens when the shebang points to a text file instead of a binary. Manual testing confirms this error happens when the shebang points to `~/.pyenv/shims/python` and not when the shebang points to `~/.pyenv/versions/3.9.6/bin/python3.9` (the executable instead of the shim) or when invoked by passing the Python executable/shim as the first argument to `execv`.

Passing `project.python_executable` seems more straightforward than rewriting the shebang, since it's non-trivial to detect the shim's target, but feel free to suggest another approach.

I spent a little time looking at testing this only to realize it's not really testable, since the modified code is in a code path that's intentionally not executed when running tests. I did try modifying https://github.com/pdm-project/pdm/blob/main/pdm/cli/commands/run.py#L94 but it breaks a bunch of existing tests without adding clear value because it's not testing the modified code. Besides, this code is exercised when running `pdm run test`, so if it doesn't work, the test suite will fail.

Fixes #494.