### PR TITLE
Fix tomli deprecation warning

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -500,7 +500,7 @@ summary = "Python Library for Tom's Obvious, Minimal Language"
 
 [[package]]
 name = "tomli"
-version = "1.0.4"
+version = "1.2.0"
 requires_python = ">=3.6"
 summary = "A lil' TOML parser"
 
@@ -571,7 +571,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "3.1"
-content_hash = "sha256:ef1810dc6aa55d1080c66929b119e303156dfa40818c2174443864343b51a073"
+content_hash = "sha256:c93eeb307e2c2ce0adef7d134855f3f6825305c2bbcaacc5ffba1918cd005cfb"
 
 [metadata.files]
 "apipkg 1.5" = [
@@ -981,9 +981,9 @@ content_hash = "sha256:ef1810dc6aa55d1080c66929b119e303156dfa40818c2174443864343
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
-"tomli 1.0.4" = [
-    {file = "tomli-1.0.4-py3-none-any.whl", hash = "sha256:0713b16ff91df8638a6a694e295c8159ab35ba93e3424a626dd5226d386057be"},
-    {file = "tomli-1.0.4.tar.gz", hash = "sha256:be670d0d8d7570fd0ea0113bd7bb1ba3ac6706b4de062cc4c952769355c9c268"},
+"tomli 1.2.0" = [
+    {file = "tomli-1.2.0-py3-none-any.whl", hash = "sha256:056f0376bf5a6b182c513f9582c1e5b0487265eb6c48842b69aa9ca1cd5f640a"},
+    {file = "tomli-1.2.0.tar.gz", hash = "sha256:d60e681734099207a6add7a10326bc2ddd1fdc36c1b0f547d00ef73ac63739c2"},
 ]
 "tornado 6.1" = [
     {file = "tornado-6.1-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:d371e811d6b156d82aa5f9a4e08b58debf97c302a35714f6f45e35139c332e32"},

--- a/pdm/builders/base.py
+++ b/pdm/builders/base.py
@@ -157,7 +157,7 @@ class EnvBuilder:
         self.src_dir = src_dir
         logger.debug("Preparing isolated env for PEP 517 build...")
         try:
-            with open(os.path.join(src_dir, "pyproject.toml"), encoding="utf8") as f:
+            with open(os.path.join(src_dir, "pyproject.toml"), "rb") as f:
                 spec = tomli.load(f)
         except FileNotFoundError:
             spec = {}

--- a/pdm/cli/completions/pdm.ps1
+++ b/pdm/cli/completions/pdm.ps1
@@ -130,7 +130,7 @@ PACKAGE_REGEX = re.compile(r'^[A-Za-z][A-Za-z0-9._-]*')
 def get_packages(lines):
     return [PACKAGE_REGEX.match(line).group() for line in lines]
 
-with open('pyproject.toml', encoding='utf8') as f:
+with open('pyproject.toml', 'rb') as f:
     data = tomli.load(f)
 packages = get_packages(data.get('project', {}).get('dependencies', []))
 for reqs in data.get('project', {}).get('optional-dependencies', {}).values():

--- a/pdm/cli/completions/pdm.zsh
+++ b/pdm/cli/completions/pdm.zsh
@@ -338,7 +338,7 @@ PACKAGE_REGEX = re.compile(r'^[A-Za-z][A-Za-z0-9._-]*')
 def get_packages(lines):
     return [PACKAGE_REGEX.match(line).group() for line in lines]
 
-with open('pyproject.toml', encoding='utf8') as f:
+with open('pyproject.toml', 'rb') as f:
     data = tomli.load(f)
 packages = get_packages(data.get('project', {}).get('dependencies', []))
 for reqs in data.get('project', {}).get('optional-dependencies', {}).values():

--- a/pdm/cli/utils.py
+++ b/pdm/cli/utils.py
@@ -430,7 +430,7 @@ def format_resolution_impossible(err: ResolutionImpossible) -> str:
     result.append(
         "Please make sure the package names are correct. If so, you can either "
         "loosen the version constraints of these dependencies, or "
-        "set a narrower `requires-python` range in the pyproject.tomli."
+        "set a narrower `requires-python` range in the pyproject.toml."
     )
     return "\n".join(result)
 

--- a/pdm/formats/flit.py
+++ b/pdm/formats/flit.py
@@ -20,7 +20,7 @@ from pdm.utils import cd
 
 
 def check_fingerprint(project: Optional[Project], filename: PathLike) -> bool:
-    with open(filename, encoding="utf-8") as fp:
+    with open(filename, "rb") as fp:
         try:
             data = tomli.load(fp)
         except tomli.TOMLDecodeError:
@@ -143,7 +143,7 @@ class FlitMetaConverter(MetaConverter):
 def convert(
     project: Optional[Project], filename: PathLike, options: Optional[Namespace]
 ) -> Tuple[Mapping, Mapping]:
-    with open(filename, encoding="utf-8") as fp, cd(
+    with open(filename, "rb") as fp, cd(
         os.path.dirname(os.path.abspath(filename))
     ):
         converter = FlitMetaConverter(

--- a/pdm/formats/flit.py
+++ b/pdm/formats/flit.py
@@ -143,9 +143,7 @@ class FlitMetaConverter(MetaConverter):
 def convert(
     project: Optional[Project], filename: PathLike, options: Optional[Namespace]
 ) -> Tuple[Mapping, Mapping]:
-    with open(filename, "rb") as fp, cd(
-        os.path.dirname(os.path.abspath(filename))
-    ):
+    with open(filename, "rb") as fp, cd(os.path.dirname(os.path.abspath(filename))):
         converter = FlitMetaConverter(
             tomli.load(fp)["tool"]["flit"], project.core.ui if project else None
         )

--- a/pdm/formats/legacy.py
+++ b/pdm/formats/legacy.py
@@ -20,7 +20,7 @@ from pdm.project.core import Project
 
 
 def check_fingerprint(project: Project, filename: PathLike) -> bool:
-    with open(filename, encoding="utf-8") as fp:
+    with open(filename, "rb") as fp:
         try:
             data = tomli.load(fp)
         except tomli.TOMLDecodeError:
@@ -169,7 +169,7 @@ class LegacyMetaConverter(MetaConverter):
 def convert(
     project: Project, filename: Path, options: Optional[Namespace]
 ) -> Tuple[Mapping[str, Any], Mapping[str, Any]]:
-    with open(filename, encoding="utf-8") as fp:
+    with open(filename, "rb") as fp:
         converter = LegacyMetaConverter(tomli.load(fp)["tool"]["pdm"], project.core.ui)
         return converter.convert()
 

--- a/pdm/formats/pipfile.py
+++ b/pdm/formats/pipfile.py
@@ -44,7 +44,7 @@ def check_fingerprint(project: Project, filename: PathLike) -> bool:
 def convert(
     project: Project, filename: PathLike, options: Namespace | None
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    with open(filename, encoding="utf-8") as fp:
+    with open(filename, "rb") as fp:
         data = tomli.load(fp)
     result = {}
     settings = {}

--- a/pdm/formats/poetry.py
+++ b/pdm/formats/poetry.py
@@ -30,7 +30,7 @@ from pdm.utils import cd
 
 
 def check_fingerprint(project: Project | None, filename: Path | str) -> bool:
-    with open(filename, encoding="utf-8") as fp:
+    with open(filename, "rb") as fp:
         try:
             data = tomli.load(fp)
         except tomli.TOMLDecodeError:
@@ -198,7 +198,7 @@ def convert(
     filename: str | Path,
     options: Namespace | None,
 ) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
-    with open(filename, encoding="utf-8") as fp, cd(
+    with open(filename, "rb") as fp, cd(
         os.path.dirname(os.path.abspath(filename))
     ):
         converter = PoetryMetaConverter(

--- a/pdm/formats/poetry.py
+++ b/pdm/formats/poetry.py
@@ -198,9 +198,7 @@ def convert(
     filename: str | Path,
     options: Namespace | None,
 ) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
-    with open(filename, "rb") as fp, cd(
-        os.path.dirname(os.path.abspath(filename))
-    ):
+    with open(filename, "rb") as fp, cd(os.path.dirname(os.path.abspath(filename))):
         converter = PoetryMetaConverter(
             tomli.load(fp)["tool"]["poetry"], project.core.ui if project else None
         )

--- a/pdm/formats/requirements.py
+++ b/pdm/formats/requirements.py
@@ -80,7 +80,7 @@ def parse_requirement_file(
 def check_fingerprint(project: Project, filename: PathLike) -> bool:
     import tomli
 
-    with open(filename, encoding="utf-8") as fp:
+    with open(filename, "rb") as fp:
         try:
             tomli.load(fp)
         except ValueError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "resolvelib>=0.7.0,<0.8.0",
     "shellingham<2.0.0,>=1.3.2",
     "wheel<1.0.0,>=0.36.2",
-    "tomli~=1.0",
+    "tomli>=1.1.0,<2.0.0",
     "installer~=0.2",
 ]
 name = "pdm"


### PR DESCRIPTION
Text file objects are deprecated in Tomli. This PR moves to using binary file objects to avoid deprecation warning