### PR TITLE
Use test.pypi.org instead of testpypi.org

### DIFF
--- a/docs/docs/usage/dependency.md
+++ b/docs/docs/usage/dependency.md
@@ -212,7 +212,7 @@ bump2version 1.0.0
 You can specify a PyPI mirror URL by following commands:
 
 ```console
-$ pdm config pypi.url https://testpypi.org/simple
+$ pdm config pypi.url https://test.pypi.org/simple
 ```
 
 By default, PDM will read the pip's configuration files to decide the PyPI URL, and fallback

--- a/docs/docs/usage/project.md
+++ b/docs/docs/usage/project.md
@@ -83,13 +83,13 @@ $ pdm config pypi.url
 Change a configuration value and store in home configuration:
 
 ```console
-$ pdm config pypi.url "https://testpypi.org/simple"
+$ pdm config pypi.url "https://test.pypi.org/simple"
 ```
 
 By default, the configuration are changed globally, if you want to make the config seen by this project only, add a `--local` flag:
 
 ```console
-$ pdm config --local pypi.url "https://testpypi.org/simple"
+$ pdm config --local pypi.url "https://test.pypi.org/simple"
 ```
 
 Any local configurations will be stored in `.pdm.toml` under the project root directory.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -257,7 +257,7 @@ def test_config_env_var_shadowing(project, invoke):
         assert result.output.strip() == "https://example.org/simple"
 
         result = invoke(
-            ["config", "pypi.url", "https://testpypi.org/pypi"], obj=project
+            ["config", "pypi.url", "https://test.pypi.org/pypi"], obj=project
         )
         assert "config is shadowed by env var 'PDM_PYPI_URL'" in result.output
         result = invoke(["config", "pypi.url"], obj=project)
@@ -265,7 +265,7 @@ def test_config_env_var_shadowing(project, invoke):
 
         del os.environ["PDM_PYPI_URL"]
         result = invoke(["config", "pypi.url"], obj=project)
-        assert result.output.strip() == "https://testpypi.org/pypi"
+        assert result.output.strip() == "https://test.pypi.org/pypi"
 
 
 def test_config_project_global_precedence(project, invoke):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -51,8 +51,8 @@ def test_project_config_set_invalid_key(project):
 
 
 def test_project_sources_overriding(project):
-    project.project_config["pypi.url"] = "https://testpypi.org/simple"
-    assert project.sources[0]["url"] == "https://testpypi.org/simple"
+    project.project_config["pypi.url"] = "https://test.pypi.org/simple"
+    assert project.sources[0]["url"] == "https://test.pypi.org/simple"
 
     project.tool_settings["source"] = [
         {"url": "https://example.org/simple", "name": "pypi", "verify_ssl": True}
@@ -65,13 +65,13 @@ def test_project_sources_env_var_expansion(project):
     os.environ["PYPI_PASS"] = "password"
     project.project_config[
         "pypi.url"
-    ] = "https://${PYPI_USER}:${PYPI_PASS}@testpypi.org/simple"
+    ] = "https://${PYPI_USER}:${PYPI_PASS}@test.pypi.org/simple"
     # expanded in sources
-    assert project.sources[0]["url"] == "https://user:password@testpypi.org/simple"
+    assert project.sources[0]["url"] == "https://user:password@test.pypi.org/simple"
     # not expanded in project config
     assert (
         project.project_config["pypi.url"]
-        == "https://${PYPI_USER}:${PYPI_PASS}@testpypi.org/simple"
+        == "https://${PYPI_USER}:${PYPI_PASS}@test.pypi.org/simple"
     )
 
     project.tool_settings["source"] = [


### PR DESCRIPTION
## Pull Request Check List

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

`testpypi.org` URL seems wrong; `test.pypi.org` should be used instead.