### PR TITLE
Split arguments to interpreter executable.

### DIFF
--- a/news/628.bugfix.md
+++ b/news/628.bugfix.md
@@ -1,0 +1,1 @@
+Fix crash when Jython 2.7 is found.


### PR DESCRIPTION
Jython 2.7 doesn't handle the concatenated form.

## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

This fixes the issue. But my clean checkout of pdm fails 3 tests:
- [ ] test_integration.py test_basic_integration[3.6] 
      ModuleNotFoundError: No module named 'pdm'
- [ ] test_integration.py test_basic_integration[3.7]
      ModuleNotFoundError: No module named 'pdm'
- [ ] cli/test_cli.py test_show_self_package (but only when all tests are run [!?]; when run in isolation, it passes)

      E       AssertionError: assert 'test_project\n0.0.0\n' == '    test_pro...\n    0.0.0\n'
      E         -     test_project
      E         ? ----
      E         + test_project
      E         -     0.0.0
      E         ? ----
      E         + 0.0.0

Looks like the first two tests find python interpreters that I have installed on my machine, but that don't have pdm installed. I might have to run pdm install with both of them. Why the third test fails when I run the whole suite, but not when I run the single test, I don't know.
