### PR TITLE
Adapt edit URI on docs pages

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: PDM - Python Development Master
 
 repo_url: https://github.com/pdm-project/pdm
+edit_uri: edit/main/docs/docs
 
 theme:
   name: material


### PR DESCRIPTION
https://www.mkdocs.org/user-guide/configuration/#edit_uri

## Pull Request Check List

- [ ] ~~A news fragment is added in `news/` describing what is new.~~
- [ ] ~~Test cases added for changed code.~~

## Describe what you have changed in this PR.
Currently, the edit links on pages points to, for example, https://github.com/pdm-project/pdm/edit/master/docs/pyproject/pep621.md.
With the `edit_uri` option, we can fix it to point to the right location: https://github.com/pdm-project/pdm/edit/main/docs/docs/pyproject/pep621.md