### PR TITLE
Replace remaining deprecated usages of `-s` in doc

### DIFF
--- a/docs/docs/pyproject/pep621.md
+++ b/docs/docs/pyproject/pep621.md
@@ -101,7 +101,7 @@ To install a group of optional dependencies:
 $ pdm install -G socks
 ```
 
-`-s` option can be given multiple times to include more than one group.
+`-G` option can be given multiple times to include more than one group.
 
 ## Console scripts
 

--- a/docs/docs/usage/advanced.md
+++ b/docs/docs/usage/advanced.md
@@ -79,12 +79,12 @@ os.environ.update({"PDM_IGNORE_SAVED_PYTHON": "1"})
 
 @nox.session
 def tests(session):
-    session.run('pdm', 'install', '-s', 'test', external=True)
+    session.run('pdm', 'install', '-G', 'test', external=True)
     session.run('pytest')
 
 @nox.session
 def lint(session):
-    session.run('pdm', 'install', '-s', 'lint', external=True)
+    session.run('pdm', 'install', '-G', 'lint', external=True)
     session.run('flake8', '--import-order-style', 'google')
 ```
 
@@ -127,7 +127,7 @@ Testing:
 
     - name: Install dependencies
       run: |
-        pdm sync -d -s testing
+        pdm sync -d -G testing
     - name: Run Tests
       run: |
         pdm run -v pytest tests

--- a/pdm/cli/commands/add.py
+++ b/pdm/cli/commands/add.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
             dest="group",
             help="(DEPRECATED) Alias of `-G/--group`",
             type=deprecated(
-                "`-s/--section` is deprecated in favor of `-G/--groups` "
+                "`-s/--section` is deprecated in favor of `-G/--group` "
                 "and will be removed in the next minor release."
             ),
         )

--- a/pdm/cli/commands/import_cmd.py
+++ b/pdm/cli/commands/import_cmd.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
             dest="group",
             help="(DEPRECATED) Alias of `-G/--group`",
             type=deprecated(
-                "`-s/--section` is deprecated in favor of `-G/--groups` "
+                "`-s/--section` is deprecated in favor of `-G/--group` "
                 "and will be removed in the next minor release."
             ),
         )

--- a/pdm/cli/commands/remove.py
+++ b/pdm/cli/commands/remove.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
             dest="group",
             help="(DEPRECATED) Alias of `-G/--group`",
             type=deprecated(
-                "`-s/--section` is deprecated in favor of `-G/--groups` "
+                "`-s/--section` is deprecated in favor of `-G/--group` "
                 "and will be removed in the next minor release."
             ),
         )

--- a/pdm/cli/options.py
+++ b/pdm/cli/options.py
@@ -165,7 +165,7 @@ groups_group.add_argument(
     help="(DEPRECATED) alias of `--group`",
     default=[],
     type=deprecated(
-        "`-s/--section` is deprecated in favor of `-G/--groups` "
+        "`-s/--section` is deprecated in favor of `-G/--group` "
         "and will be removed in the next minor release."
     ),
 )


### PR DESCRIPTION
## Pull Request Check List

- ~[ ] A news fragment is added in `news/` describing what is new.~ Not applicable
- ~[ ] Test cases added for changed code.~ Not applicable

## Describe what you have changed in this PR.
Looks like some occurrences of `-s` option were not replaced in https://github.com/pdm-project/pdm/pull/591
Also fixing a typo where `--groups` is used instead of `--group` in CLI deprecation descriptions.