### PR TITLE
Output additional info about errors to stderr

### DIFF
--- a/pdm/core.py
+++ b/pdm/core.py
@@ -156,7 +156,9 @@ class Core:
                     err=True,
                 )
                 if should_show_tb:
-                    self.ui.echo("Add '-v' to see the detailed traceback", fg="yellow")
+                    self.ui.echo(
+                        "Add '-v' to see the detailed traceback", fg="yellow", err=True
+                    )
                 sys.exit(1)
             else:
                 if options.project.config["check_update"]:

--- a/pdm/termui.py
+++ b/pdm/termui.py
@@ -193,7 +193,7 @@ class UI:
         except Exception:
             if self.verbosity < DETAIL:
                 logger.exception("Error occurs")
-                self.echo(yellow(f"See {file_name} for detailed debug log."))
+                self.echo(yellow(f"See {file_name} for detailed debug log."), err=True)
             raise
         else:
             atexit.register(cleanup)


### PR DESCRIPTION
When using `pdm export -f requirements > requirements.txt` it looked like
this in case of failure before this patch:

```
The exported requirements file is no longer cross-platform. Using it on other platforms may cause unexpected result.
[ParseError]: Empty key found at line 1 col 0
```

With the requirements.txt file containing this then:
```
See /tmp/pdm-install-resolve-skag1q8x.log for detailed debug log.
Add '-v' to see the detailed traceback
```

It should not write the additional information about (debugging) the
error to stdout, but stderr also.

Using `-v` displays the traceback on stderr already as expected.

## Pull Request Check List

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
