### PR TITLE
Strip trailing whitespace with pdm-show

### DIFF
--- a/news/680.bugfix.md
+++ b/news/680.bugfix.md
@@ -1,0 +1,1 @@
+Remove trailing whitespace with terminal output of tables (via `project.core.ui.display_columns`), fixing unnecessary wrapping due to / with empty lines full of spaces in case of long URLs in the last column.

--- a/pdm/termui.py
+++ b/pdm/termui.py
@@ -146,7 +146,7 @@ class UI:
                 " ".join(
                     aligner(head, size)
                     for aligner, head, size in zip(aligners, header, sizes)
-                )
+                ).rstrip()
             )
             # Print a separator
             self.echo(" ".join("-" * size for size in sizes))
@@ -155,7 +155,7 @@ class UI:
                 " ".join(
                     aligner(item, size)
                     for aligner, item, size in zip(aligners, row, sizes)
-                )
+                ).rstrip()
             )
 
     @contextlib.contextmanager


### PR DESCRIPTION

## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

pdm-show uses `project.core.ui.display`, which adds trailing spaces to all the
lines (based on the longest one), which results in them being displayed/wrapped
when the terminal is not wide enough for the longest line:

```
% pdm show coverage|cat -A
Name:                  coverage                                       …$
Latest version:        6.0.2                                          …$
…
Project URLs:          Documentation: https://coverage.readthedocs.io …$
                       Funding: https://example.com/?utm_source=foobar…$
…
```

This patch just adds `rstrip()`, which gets rid of it, while still
keeping the maybe too long underline for the header (not used with
pdm-show).

Maybe this could use $COLUMNS / the terminal width to limit the length
of the header underline, but that is not really needed / not trivial.