### PR TITLE
ci: configure codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+codecov:
+  notify:
+    after_n_builds: 12
+    wait_for_ci: false


### PR DESCRIPTION
## Pull Request Check List

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

This configures codecov, so that it only reports coverage after all jobs have finished.

I prefer in general to not have comments being posted, but have left this out for now.

Reference: https://docs.codecov.com/docs/coverage-configuration