### PR TITLE
[RFC/WIP] Fix find_candidates with no requires_python

### DIFF
--- a/pdm/models/repositories.py
+++ b/pdm/models/repositories.py
@@ -120,8 +120,13 @@ class BaseRepository:
             if requirement.specifier.contains(  # type: ignore
                 c.version, allow_prereleases  # type: ignore
             )
-            and requires_python.is_subset(c.requires_python)
         ]
+        if requires_python:
+            applicable_cans = [
+                c
+                for c in applicable_cans
+                if requires_python.is_subset(c.requires_python)
+            ]
 
         if not applicable_cans:
             termui.logger.debug("\tCould not find any matching candidates.")


### PR DESCRIPTION
This fixes installation/resolving of "coveralls", which would pick
version 1.11.1 without a required Python version (`requires-python` in
`pyproject.toml`'s `[project]` section'), since this is the last
version not requiring a specific Python version.

Note that pdm 1.9 changed the code in this area, but with the default of
`allow_all=False` would apply the same behavior there.
Ref: https://github.com/pdm-project/pdm/pull/658 (6be985aa5ca)

## Pull Request Check List

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.