### PR TITLE
Remove ellipsis from config sample for copy

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -215,11 +215,10 @@ run/debug configuration.
 
 ### VSCode
 
-Add the following to `.vscode/settings.json`:
+Add the following two entries to the top-level dict in `.vscode/settings.json`:
 
 ```json
 {
-  ...
   "python.autoComplete.extraPaths": ["__pypackages__/<major.minor>/lib"],
   "python.analysis.extraPaths": ["__pypackages__/<major.minor>/lib"]
 }


### PR DESCRIPTION
Small documentation improvement suggestion: I copied the code for `.vscode/settings.json`, the file didn't exist in my project. The copied code included the ellipsis for other settings.
I think it's better to not include the ellipsis in the code and rephrase, so it's clear it should be added to existing configuration.
Fixes #736