### PR TITLE
Refactor: split Environment into `PEP582Environment` and `GlobalEnvironment`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+layout_anaconda pdm

--- a/pdm/cli/actions.py
+++ b/pdm/cli/actions.py
@@ -31,14 +31,13 @@ from pdm.exceptions import NoPythonVersion, PdmUsageError, ProjectError
 from pdm.formats import FORMATS
 from pdm.formats.base import array_of_inline_tables, make_array, make_inline_table
 from pdm.models.candidates import Candidate
+from pdm.models.environment import PEP582_PATH
 from pdm.models.python import PythonInfo
 from pdm.models.requirements import Requirement, parse_requirement, strip_extras
 from pdm.models.specifiers import get_specifier
 from pdm.project import Project
 from pdm.resolver import resolve
 from pdm.utils import normalize_name
-
-PEP582_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "pep582")
 
 
 def do_lock(
@@ -527,10 +526,10 @@ def do_use(project: Project, python: str = "", first: bool = False) -> None:
     if (
         old_python
         and Path(old_python.path) != Path(selected_python.path)
-        and not project.environment.is_global
+        and hasattr(project.environment, "update_shebangs")
     ):
         project.core.ui.echo(termui.cyan("Updating executable scripts..."))
-        project.environment.update_shebangs(selected_python.executable)
+        project.environment.update_shebangs(selected_python.executable)  # type: ignore
 
 
 def do_import(

--- a/pdm/cli/commands/info.py
+++ b/pdm/cli/commands/info.py
@@ -38,7 +38,9 @@ class Command(BaseCommand):
         elif options.where:
             project.core.ui.echo(project.root.as_posix())
         elif options.packages:
-            project.core.ui.echo(str(project.environment.packages_path))
+            project.core.ui.echo(
+                str(getattr(project.environment, "packages_path", None))
+            )
         elif options.env:
             project.core.ui.echo(
                 json.dumps(project.environment.marker_environment, indent=2)
@@ -54,7 +56,7 @@ class Command(BaseCommand):
                 (termui.cyan("Project Root:", bold=True), project.root.as_posix()),
                 (
                     termui.cyan("Project Packages:", bold=True),
-                    str(project.environment.packages_path),
+                    str(getattr(project.environment, "packages_path", None)),
                 ),
             ]
             project.core.ui.display_columns(rows)

--- a/pdm/cli/utils.py
+++ b/pdm/cli/utils.py
@@ -288,7 +288,7 @@ def format_reverse_package(
 
 def package_is_project(package: Package, project: Project) -> bool:
     return (
-        not project.environment.is_global
+        not project.is_global
         and bool(project.meta.name)
         and package.name == project.meta.project_name.lower()
     )

--- a/pdm/models/candidates.py
+++ b/pdm/models/candidates.py
@@ -407,12 +407,7 @@ class Candidate:
         if self.link.is_existing_dir():
             ireq.source_dir = self.link.file_path
         elif self.req.editable:
-            if self.environment.packages_path:
-                src_dir = self.environment.packages_path / "src"
-            elif os.getenv("VIRTUAL_ENV"):
-                src_dir = Path(os.environ["VIRTUAL_ENV"]) / "src"
-            else:
-                src_dir = Path("src")
+            src_dir = self.environment.editable_dir
             if not src_dir.is_dir():
                 src_dir.mkdir()
             ireq.ensure_has_source_dir(str(src_dir))

--- a/pdm/models/environment.py
+++ b/pdm/models/environment.py
@@ -80,7 +80,7 @@ class Environment:
 
     def get_paths(self) -> dict[str, str]:
         """Get paths like ``sysconfig.get_paths()`` for installation."""
-        return pdm_scheme(str(self.packages_path))
+        raise NotImplementedError
 
     @cached_property
     def packages_path(self) -> Path:
@@ -209,6 +209,15 @@ class Environment:
         if not pip_wheel.is_file():
             self._download_pip_wheel(pip_wheel)
         return [executable, str(pip_wheel / "pip")]
+
+
+class PEP582Environment(Environment):
+
+    is_global = False
+
+    def get_paths(self) -> dict[str, str]:
+        """Get paths like ``sysconfig.get_paths()`` for installation."""
+        return pdm_scheme(str(self.packages_path))
 
 
 class GlobalEnvironment(Environment):

--- a/pdm/models/environment.py
+++ b/pdm/models/environment.py
@@ -64,19 +64,21 @@ def _replace_shebang(contents: bytes, new_executable: bytes) -> bytes:
 class Environment:
     """Environment dependent stuff related to the selected Python interpreter."""
 
-    is_global = False
-
-    def __init__(self, project: Project) -> None:
+    def __init__(self, project: Project, interpreter: PythonInfo) -> None:
         """
         :param project: the project instance
         """
         self.python_requires = project.python_requires
         self.project = project
-        self.interpreter: PythonInfo = project.python
+        self._interpreter: PythonInfo = interpreter
         self._essential_installed = False
         self.auth = make_basic_auth(
             self.project.sources, self.project.core.ui.verbosity >= termui.DETAIL
         )
+
+    @property
+    def interpreter(self) -> PythonInfo:
+        return self._interpreter
 
     def get_paths(self) -> dict[str, str]:
         """Get paths like ``sysconfig.get_paths()`` for installation."""

--- a/pdm/project/core.py
+++ b/pdm/project/core.py
@@ -156,6 +156,8 @@ class Project:
         self._python = value
         self.project_config["python.path"] = value.path
 
+        self._environment = self.get_environment(value)
+
     @property
     def python_executable(self) -> str:
         """For backward compatibility"""
@@ -195,23 +197,23 @@ class Project:
             )
         )
 
-    def get_environment(self) -> Environment:
+    def get_environment(self, interpreter) -> Environment:
         """Get the environment selected by this project"""
         if self.is_global:
-            env = GlobalEnvironment(self)
+            env = GlobalEnvironment(self, interpreter)
             # Rewrite global project's python requires to be
             # compatible with the exact version
             env.python_requires = PySpecSet(f"=={self.python.version}")
             return env
         if self.config["use_venv"] and is_venv_python(self.python.executable):
             # Only recognize venv created by python -m venv and virtualenv>20
-            return GlobalEnvironment(self)
-        return PEP582Environment(self)
+            return GlobalEnvironment(self, interpreter)
+        return PEP582Environment(self, interpreter)
 
     @property
     def environment(self) -> Environment:
         if not self._environment:
-            self._environment = self.get_environment()
+            self._environment = self.get_environment(self._python)
         return self._environment
 
     @property

--- a/pdm/project/core.py
+++ b/pdm/project/core.py
@@ -20,7 +20,7 @@ from pdm.exceptions import NoPythonVersion, PdmUsageError, ProjectError
 from pdm.models import pip_shims
 from pdm.models.caches import CandidateInfoCache, HashCache
 from pdm.models.candidates import Candidate
-from pdm.models.environment import Environment, GlobalEnvironment
+from pdm.models.environment import Environment, GlobalEnvironment, PEP582Environment
 from pdm.models.python import PythonInfo
 from pdm.models.repositories import BaseRepository, LockedRepository, PyPIRepository
 from pdm.models.requirements import Requirement, parse_requirement
@@ -206,7 +206,7 @@ class Project:
         if self.config["use_venv"] and is_venv_python(self.python.executable):
             # Only recognize venv created by python -m venv and virtualenv>20
             return GlobalEnvironment(self)
-        return Environment(self)
+        return PEP582Environment(self)
 
     @property
     def environment(self) -> Environment:

--- a/pdm/project/core.py
+++ b/pdm/project/core.py
@@ -197,7 +197,7 @@ class Project:
             )
         )
 
-    def get_environment(self, interpreter) -> Environment:
+    def get_environment(self, interpreter: PythonInfo) -> Environment:
         """Get the environment selected by this project"""
         if self.is_global:
             env = GlobalEnvironment(self, interpreter)
@@ -213,7 +213,7 @@ class Project:
     @property
     def environment(self) -> Environment:
         if not self._environment:
-            self._environment = self.get_environment(self._python)
+            self._environment = self.get_environment(self.python)
         return self._environment
 
     @property

--- a/pdm/project/core.py
+++ b/pdm/project/core.py
@@ -214,10 +214,6 @@ class Project:
             self._environment = self.get_environment()
         return self._environment
 
-    @environment.setter
-    def environment(self, value: Environment) -> None:
-        self._environment = value
-
     @property
     def python_requires(self) -> PySpecSet:
         return PySpecSet(self.meta.requires_python)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from pdm.models.environment import GlobalEnvironment
 from pdm.utils import cd, temp_environ
 
 
@@ -109,7 +110,7 @@ def test_project_sources_env_var_expansion(project):
 
 def test_global_project(tmp_path, core):
     project = core.create_project(tmp_path, True)
-    assert project.environment.is_global
+    assert isinstance(project.environment, GlobalEnvironment)
 
 
 def test_auto_global_project(tmp_path, core):
@@ -158,7 +159,7 @@ def test_project_auto_detect_venv(project):
         project.root / "test_venv" / scripts / f"python{suffix}"
     ).as_posix()
 
-    assert project.environment.is_global
+    assert isinstance(project.environment, GlobalEnvironment)
 
 
 def test_ignore_saved_python(project):


### PR DESCRIPTION
## Pull Request Check List

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
This PR tries to separate PEP-582 logic from the non-582 logic in the existing `Environment` base class. I've tried to use duck-typing rather than `isinstance`, but mypy doesn't seem to know how to narrow after a `hasattr` guard, so in some places `isinstance` or `type: ignore` is used.

When modifying the environment, it became apparent that the `Project` and `Environment` classes are quite inter-dependent. For now, I've just made the interpreter aspect more evident by passing it in as an argument. This provides a motivation in the source code for re-creating the environment if the interpreter is changed.

The `Environment` classes only depend on a few project attributes:
- `interpreter` (passed in as arg now)
- `cache_dir`
- `sources`
- `root`

I think we can eliminate some of these by moving the `get_finder` functionality into a new/different class. This would mean changing `Environment` to be responsible for the Python (virtual) environment abstraction only.

Meanwhile, the `Project` class only depends upon environment in order to pass it to other classes, which refer back to the project indirectly via `environment.project`. I think we can decouple these by moving `get_finder` elsewhere as discussed above.