### PR TITLE
Small documentation improvements

### DIFF
--- a/docs/docs/pyproject/pep621.md
+++ b/docs/docs/pyproject/pep621.md
@@ -43,7 +43,7 @@ PDM can also read version from SCM tags. If you are using git or hg as the versi
 version = {use_scm = true}
 ```
 
-In either case, you MUST delete the `version` field from the `[project]` table, and include `version` 
+In either case, you MUST delete the `version` field from the `[project]` table, and include `version`
 in the `dynamic` field, or the backend will raise an error:
 
 ```toml

--- a/docs/docs/usage/advanced.md
+++ b/docs/docs/usage/advanced.md
@@ -115,7 +115,7 @@ Testing:
   runs-on: ${{ matrix.os }}
   strategy:
     matrix:
-      python-version: [3.6, 3.7, 3.8, 3.9]
+      python-version: [3.7, 3.8, 3.9, 3.10]
       os: [ubuntu-latest, macOS-latest, windows-latest]
 
   steps:

--- a/docs/docs/usage/dependency.md
+++ b/docs/docs/usage/dependency.md
@@ -75,7 +75,7 @@ This will result in a pyproject.toml as following:
 test = ["pytest"]
 ```
 
-For backward-compatibility, if `-G/--group` is not given, dependencies will go to `dev` group under `[tool.pdm.dev-dependencies]` by default.
+For backward-compatibility, if only `-d` or `--dev` is specified, dependencies will go to `dev` group under `[tool.pdm.dev-dependencies]` by default.
 
 !!! NOTE
     The same group name MUST NOT appear in both `[tool.pdm.dev-dependencies]` and `[project.optional-dependencies]` .
@@ -86,7 +86,8 @@ If the package is given without a version specifier like `pdm add requests`. PDM
 specifier is saved for the dependency, which is given by `--save-<strategy>`(Assume `2.21.0` is the latest version that can be found
 for the dependency):
 
-- `compatible`: Save the compatible version specifier: `>=2.21.0,<3.0.0`(default).
+- `minimum`: Save the minimum version specifier: `>=2.21.0` (default).
+- `compatible`: Save the compatible version specifier: `>=2.21.0,<3.0.0`.
 - `exact`: Save the exact version specifier: `==2.21.0`.
 - `wildcard`: Don't constrain version and leave the specifier to be wildcard: `*`.
 
@@ -136,7 +137,7 @@ pdm update -dG test pytest
 Similarly, PDM also provides 2 different behaviors of updating dependencies and sub-dependencies，
 which is given by `--update-<strategy>` option:
 
-- `reuse`: Keep all locked dependencies except for those given in the command line.
+- `reuse`: Keep all locked dependencies except for those given in the command line (default).
 - `eager`: Try to lock a newer version of the packages in command line and their recursive sub-dependencies
   and keep other dependencies as they are.
 
@@ -259,7 +260,7 @@ To fix this, you could loosen the dependency version constraints in pyproject.to
 ```
 
 You can either change to a lower version of `django` or remove the upper bound of `asgiref`. But if it is not eligible for your project,
-you can tell PDM to forcely resolve `asgiref` to a specific version by adding the following lines to `pyproject.toml`:
+you can tell PDM to forcedly resolve `asgiref` to a specific version by adding the following lines to `pyproject.toml`:
 
 _New in version 1.12.0_
 
@@ -286,15 +287,3 @@ For convenience, PDM supports environment variables expansion in the dependency 
   `file:///${PROJECT_ROOT}/artifacts/Flask-1.1.2.tar.gz`.
 
 Don't worry about credential leakage, the environment variables will be expanded when needed and kept untouched in the lock file.
-
-## Save disk space by enabling the install cache
-
-When using virtualenv to isolate project dependencies, if you have 100 projects depending on the same package, you will end up with 100 copies of that dependency. With PDM, you can opt in the installation caching so that the dependency will be installed into a centrialized store and be used by multiple projects. To enable it, simply do:
-
-```
-pdm config feature.install_cache on
-```
-
-Add `--local` option to enable for the current project only.
-
-This feature will only cache the normal wheel installations, i.e. installing from source won't be cached.

--- a/docs/docs/usage/project.md
+++ b/docs/docs/usage/project.md
@@ -37,7 +37,8 @@ $ pdm build
 - Built pdm_test-0.0.0-py3-none-any.whl
 ```
 
-The artifacts can then be uploaded to PyPI by [twine](https://pypi.org/project/twine). Available options can be found by
+The artifacts can then be uploaded to PyPI by [twine](https://pypi.org/project/twine) or using the
+[pdm-publish](https://github.com/branchvincent/pdm-publish) plugin. Available options can be found by
 typing `pdm build --help`.
 
 ## Show the current Python environment
@@ -142,7 +143,7 @@ project path via `-p/--project <path>` option.
 ## Working with a virtualenv
 
 Although PDM enforces PEP 582 by default, it also allows users to install packages into the virtualenv. It is controlled
-by the configuration item `use_venv`. When it is set to `True` PDM will use the virtualenv if:
+by the configuration item `use_venv`. When it is set to `True`, PDM will use the virtualenv if:
 
 - a virtualenv is already activated.
 - any of `venv`, `.venv`, `env` is a valid virtualenv folder.
@@ -314,7 +315,7 @@ Besides, PDM also injects the root path of the project via `PDM_PROJECT_ROOT` en
 
 ### Load site-packages in the running environment
 
-To make sure the running environment is properly isolated from the outer Python interperter,
+To make sure the running environment is properly isolated from the outer Python interpreter,
 site-packages from the selected interpreter WON'T be loaded into `sys.path`, unless any of the following conditions holds:
 
 1. The executable is from `PATH` but not inside the `__pypackages__` folder.


### PR DESCRIPTION
docs: clarify the use of `-d` without `-G`
It's clearer that you can use `pdm add --dev pytest`, because when you
arrive this point in the documentation, you don't know that `-d` means
`--dev`.

docs: add the `minimum` save strategy

It's the default and it was not mentioned! :P

docs: mark the `reuse` update strategy as the default

docs: fix typos

docs: add the `pdm-publish` as an option to upload packages

docs: remove duplicated install cache version

It's already documented [here](project.md#cache-the-installation-of-wheels).

docs: Update the Python versions of the github action snippet

## Pull Request Check List

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Just documentation, so no need to add anything under `news` or `tests`