### PR TITLE
Add doctype

### DIFF
--- a/tests/fixtures/index/demo.html
+++ b/tests/fixtures/index/demo.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <body>
     <h1>Demo</h1>

--- a/tests/fixtures/index/future-fstrings.html
+++ b/tests/fixtures/index/future-fstrings.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <body>
     <h1>future-fstrings</h1>

--- a/tests/fixtures/index/pep345-legacy.html
+++ b/tests/fixtures/index/pep345-legacy.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <body>
     <h1>pep345-legacy</h1>


### PR DESCRIPTION
## Pull Request Check List
Its a temporary solution, should migrate to `html.parser` as `html5lib` will be [deprecated](https://github.com/pypa/pip/pull/10291). New parser requires doctypes.
Or add html5lib/another parser as a dependency.
- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
