### PR TITLE
fixed the issue where license-expression is read as None

### DIFF
--- a/news/1012.bugfix.md
+++ b/news/1012.bugfix.md
@@ -1,0 +1,1 @@
+Fixed the bug where license is `None` even if `license-expression` is defined.

--- a/pdm/models/project_info.py
+++ b/pdm/models/project_info.py
@@ -51,7 +51,9 @@ class ProjectInfo:
             "summary": str(metadata.description),
             "author": str(metadata.author),
             "email": str(metadata.author_email),
-            "license": str(metadata.get("license-expression", metadata.get("license"))),
+            "license": str(
+                metadata.get("license-expression", getattr(metadata, "license", ""))
+            ),
             "requires-python": str(metadata.requires_python),
             "platform": "",
             "keywords": ", ".join(metadata.keywords or []),

--- a/pdm/models/project_info.py
+++ b/pdm/models/project_info.py
@@ -45,16 +45,13 @@ class ProjectInfo:
         }
 
     def _parse_self(self, metadata: Metadata) -> dict[str, Any]:
-        license_expression = getattr(metadata, "license_expression", None)
-        if license_expression is None:
-            license_expression = getattr(metadata, "license", "")
         return {
             "name": str(metadata.name),
             "version": str(metadata.version),
             "summary": str(metadata.description),
             "author": str(metadata.author),
             "email": str(metadata.author_email),
-            "license": str(license_expression),
+            "license": str(metadata.get("license-expression", metadata.get("license"))),
             "requires-python": str(metadata.requires_python),
             "platform": "",
             "keywords": ", ".join(metadata.keywords or []),


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## The Issue

In the latest version of PDM (1.13.6), `license` shows up as `None` even if `license-expression` is defined in `pyproject.toml`. I came across this issue while running `pdm show` in my own repo:

![image](https://user-images.githubusercontent.com/21986859/161368276-f389c89a-aa85-4b6c-862b-f349dde58799.png)

## The Fix

The key for `license-expression` is uses a hyphen `-` instead of an underscore `_`. The changes in this PR produces the following effects:

- If both `license-expression` and `license` are defined, prioritize `license-expression`
- If only `license` is present, use `license`
- If neiter are present, use `None`

When both are defined, `license-expression` is prioritized:

![image](https://user-images.githubusercontent.com/21986859/161368429-4fe1b07f-972c-49c5-b664-a136b274aef3.png)

If only `license` exists, use the value of `license`:

![image](https://user-images.githubusercontent.com/21986859/161368566-1c4ad1e9-a8ee-4ca4-8d35-610189bdc1f1.png)

If neither are present, license is `None`:

![image](https://user-images.githubusercontent.com/21986859/161368575-ff1f88a6-c027-4d14-b831-ba2841ef57fc.png)
