### PR TITLE
Fix use_cache.json with corrupted python causes `pdm use` error

### DIFF
--- a/news/1039.bugfix.md
+++ b/news/1039.bugfix.md
@@ -1,0 +1,1 @@
+Fix use_cache.json with corrupted python causes `pdm use` error.

--- a/pdm/cli/actions.py
+++ b/pdm/cli/actions.py
@@ -29,7 +29,12 @@ from pdm.cli.utils import (
     set_env_in_reg,
     translate_groups,
 )
-from pdm.exceptions import NoPythonVersion, PdmUsageError, ProjectError
+from pdm.exceptions import (
+    InvalidPyVersion,
+    NoPythonVersion,
+    PdmUsageError,
+    ProjectError,
+)
 from pdm.formats import FORMATS
 from pdm.formats.base import array_of_inline_tables, make_array, make_inline_table
 from pdm.models.caches import JSONFileCache
@@ -568,14 +573,23 @@ def do_use(
     selected_python: PythonInfo | None = None
     if python and not ignore_remembered:
         if use_cache.has_key(python):
-            cached_python = PythonInfo.from_path(use_cache.get(python))
-            if version_matcher(cached_python):
+            path = use_cache.get(python)
+            try:
+                cached_python = PythonInfo.from_path(path)
+                if version_matcher(cached_python):
+                    project.core.ui.echo(
+                        "Using the last selection, add '-i' to ignore it.",
+                        fg="yellow",
+                        err=True,
+                    )
+                    selected_python = cached_python
+            except InvalidPyVersion:
                 project.core.ui.echo(
-                    "Using the last selection, add '-i' to ignore it.",
-                    fg="yellow",
+                    f"The last selection is corrupted. {path!r}",
+                    fg="red",
                     err=True,
                 )
-                selected_python = cached_python
+
     if selected_python is None:
         found_interpreters = list(dict.fromkeys(project.find_interpreters(python)))
         matching_interperters = list(filter(version_matcher, found_interpreters))

--- a/pdm/project/core.py
+++ b/pdm/project/core.py
@@ -594,7 +594,7 @@ dependencies = ["pip", "setuptools", "wheel"]
             yield PythonInfo.from_path(path)
         except InvalidPyVersion:
             self.core.ui.echo(
-                f"This interpreter {path!r} is corrupted, skip.",
+                f"This interpreter {str(path)!r} is corrupted, skip.",
                 fg="yellow",
                 err=True,
             )

--- a/tests/cli/test_use.py
+++ b/tests/cli/test_use.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from pdm.cli import actions
-from pdm.exceptions import InvalidPyVersion
+from pdm.exceptions import NoPythonVersion
 from pdm.models.caches import JSONFileCache
 
 
@@ -56,7 +56,7 @@ echo hello
     shim_path = project.root.joinpath("python_shim.sh")
     shim_path.write_text(wrapper_script)
     shim_path.chmod(0o755)
-    with pytest.raises(InvalidPyVersion):
+    with pytest.raises(NoPythonVersion):
         actions.do_use(project, shim_path.as_posix())
 
 


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Before

```plain
[⚡ PIPE] ❯ pdm use -f 3.10 -v
Traceback (most recent call last):
  File "/Users/linw1995/.local/bin/pdm", line 8, in <module>
    sys.exit(main())
  File "/Users/linw1995/Documents/opensources/pdm/pdm/core.py", line 233, in main
    return Core().main(args)
  File "/Users/linw1995/Documents/opensources/pdm/pdm/core.py", line 168, in main
    raise cast(Exception, err).with_traceback(traceback)
  File "/Users/linw1995/Documents/opensources/pdm/pdm/core.py", line 163, in main
    f(options.project, options)
  File "/Users/linw1995/Documents/opensources/pdm/pdm/cli/commands/use.py", line 29, in handle
    actions.do_use(
  File "/Users/linw1995/Documents/opensources/pdm/pdm/cli/actions.py", line 571, in do_use
    cached_python = PythonInfo.from_path(use_cache.get(python))
  File "/Users/linw1995/Documents/opensources/pdm/pdm/models/python.py", line 27, in from_path
    raise InvalidPyVersion(f"Invalid Python interpreter: {path}")
pdm.exceptions.InvalidPyVersion: Invalid Python interpreter: /Users/linw1995/.pyenv/versions/3.10.0/bin/python3.10
```

After

![image](https://user-images.githubusercontent.com/13523027/163325370-0083f1ba-fe5a-4bfa-895e-45b5e66875da.png)
