### PR TITLE
rename project from Python Development Master to Python Development Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# PDM - Python Development Master
+# PDM - Python Development Manager
 
 A modern Python package manager with [PEP 582] support. [中文版本说明](README_zh.md)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# PDM - Python Development Master
+# PDM - Python Development Manager
 
 一个现代的 Python 包管理器，支持 [PEP 582]。[English version README](README.md)
 

--- a/docs/docs/dev/benchmark.md
+++ b/docs/docs/dev/benchmark.md
@@ -100,7 +100,7 @@ Running benchmark: Poetry version 1.1.12
               Install dependencies: 17.82s
        Add dependencies with cache: 43.90s
     Add dependencies without cache: 37.24s
-Running benchmark: Python Development Master (PDM), version 1.11.2
+Running benchmark: Python Development Manager (PDM), version 1.11.2
    Lock dependencies without cache: 27.56s
       Lock dependencies with cache: 21.91s
               Install dependencies: 12.16s

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: PDM - Python Development Master
+site_name: PDM - Python Development Manager
 
 repo_url: https://github.com/pdm-project/pdm
 edit_uri: edit/main/docs/docs

--- a/news/rename_project.md
+++ b/news/rename_project.md
@@ -1,0 +1,1 @@
+Rename project from Python Development Master to Python Development Manager.

--- a/pdm/core.py
+++ b/pdm/core.py
@@ -58,7 +58,7 @@ class Core:
     def init_parser(self) -> None:
         self.parser = argparse.ArgumentParser(
             prog="pdm",
-            description="PDM - Python Development Master",
+            description="PDM - Python Development Manager",
             formatter_class=PdmFormatter,
         )
         self.parser.is_root = True  # type: ignore
@@ -67,7 +67,7 @@ class Core:
             "--version",
             action="version",
             version="{}, version {}".format(
-                click.style("Python Development Master (PDM)", bold=True), self.version
+                click.style("Python Development Manager (PDM)", bold=True), self.version
             ),
             help="show the version and exit",
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "wheel>=0.36.2",
 ]
 name = "pdm"
-description = "Python Development Master"
+description = "Python Development Manager"
 readme = "README.md"
 keywords = ["packaging", "dependency", "workflow"]
 classifiers = [

--- a/tests/cli/test_others.py
+++ b/tests/cli/test_others.py
@@ -38,7 +38,7 @@ def test_init_validate_python_requires(project_no_init):
 
 def test_help_option(invoke):
     result = invoke(["--help"])
-    assert "PDM - Python Development Master" in result.output
+    assert "PDM - Python Development Manager" in result.output
 
 
 def test_info_command(project, invoke):


### PR DESCRIPTION
I was researching tools in this area today, like pipenv, poetry, and pdm. I was excited about pdm potentially being faster for my use case (I've seen the benchmarks). I was a little surprised by the name. It seems like folks are trying to avoid the word "master" these days (see https://www.vice.com/en/article/8x7akv/masterslave-terminology-was-removed-from-python-programming-language and similar articles). It seemed like it might be easy to change, and the word "Manager" might better explain what the tool does anyway. Thanks for your great open source project!