### PR TITLE
doc: fix URL requirement example with "Dependency specification"

### DIFF
--- a/docs/docs/pyproject/pep621.md
+++ b/docs/docs/pyproject/pep621.md
@@ -67,7 +67,7 @@ dependencies = [
     # Requirement with environment marker
     "pywin32; sys_platform == 'win32'",
     # URL requirement
-    "pip @ https://github.com/pypa/pip.git@20.3.1"
+    "pip @ git+https://github.com/pypa/pip.git@20.3.1"
 ]
 ```
 


### PR DESCRIPTION
This is in line with
https://peps.python.org/pep-0440/#direct-references.

PEP 508 only has an example with a zip file
(https://peps.python.org/pep-0508/#examples).


The original example fails like this:

> % pdm add "pip @ https://github.com/pypa/pip.git@20.3.1"
Adding packages to default dependencies: pip @ https://github.com/pypa/pip.git@20.3.1
⠸ Resolving dependencies
See /tmp/pdm-lock-nnaadyua.log for detailed debug log.
[NetworkConnectionError]: 404 Client Error: Not Found for url: https://github.com/pypa/pip.git@20.3.1
Add '-v' to see the detailed traceback