### PR TITLE
Fix crash if dependencies have prerelease requires-python versions

### DIFF
--- a/news/1111.bugfix.md
+++ b/news/1111.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug where dependencies with `requires-python` pre-release versions caused `pdm update` to fail with `InvalidPyVersion`.

--- a/pdm/models/specifiers.py
+++ b/pdm/models/specifiers.py
@@ -69,8 +69,6 @@ class PySpecSet(SpecifierSet):
             self._analyze_specifiers()
 
     def _analyze_specifiers(self) -> None:
-        # XXX: Prerelease or postrelease specifiers will fail here, but I guess we can
-        # just ignore them for now.
         lower_bound, upper_bound = Version.MIN, Version.MAX
         excludes: Set[Version] = set()
         for spec in self:
@@ -238,9 +236,9 @@ class PySpecSet(SpecifierSet):
             return ""
         lower = self._lower_bound
         upper = self._upper_bound
-        if lower[-1] == 0:
+        if lower[-1] == 0 and not lower.is_prerelease:
             lower = lower[:-1]
-        if upper[-1] == 0:
+        if upper[-1] == 0 and not upper.is_prerelease:
             upper = upper[:-1]
         lower_str = "" if lower == Version.MIN else f">={lower}"
         upper_str = "" if upper == Version.MAX else f"<{upper}"

--- a/pdm/models/specifiers.py
+++ b/pdm/models/specifiers.py
@@ -6,7 +6,6 @@ from operator import attrgetter
 from pathlib import Path
 from typing import Any, Iterable, List, Set, Tuple, Union, cast
 
-from packaging.version import Version as PackageVersion
 from pip._vendor.packaging.specifiers import SpecifierSet
 
 from pdm.exceptions import InvalidPyVersion
@@ -98,19 +97,6 @@ class PySpecSet(SpecifierSet):
             else:
                 raise InvalidPyVersion(f"Unsupported version specifier: {op}{version}")
         self._rearrange(lower_bound, upper_bound, excludes)
-
-    @classmethod
-    def equal_to(cls, version: PackageVersion) -> "PySpecSet":
-        """Create a specifierset that is equal to the given version."""
-        if not version.is_prerelease:
-            return cls(f"=={version}")
-        spec = cls(f"=={version}", analyze=False)
-        spec._upper_bound = Version((version.major, version.minor, 0))
-        lower_bound = Version((version.major, version.minor - 1))
-        spec._lower_bound = lower_bound.complete(
-            cls.PY_MAX_MINOR_VERSION[lower_bound] + 1
-        )
-        return spec
 
     @classmethod
     def _merge_bounds_and_excludes(

--- a/pdm/project/core.py
+++ b/pdm/project/core.py
@@ -241,7 +241,7 @@ class Project:
             env = GlobalEnvironment(self)
             # Rewrite global project's python requires to be
             # compatible with the exact version
-            env.python_requires = PySpecSet.equal_to(self.python.version)
+            env.python_requires = PySpecSet(f"=={self.python.version}")
             return env
         if self.config["python.use_venv"] and get_venv_like_prefix(
             self.python.executable

--- a/tests/models/test_specifiers.py
+++ b/tests/models/test_specifiers.py
@@ -23,6 +23,8 @@ from pdm.models.specifiers import PySpecSet
         (">3.4.*", ">=3.5"),
         ("<=3.4.*", "<3.4"),
         ("<3.4.*", "<3.4"),
+        ("<3.10.0a6", "<3.10.0a6"),
+        ("<3.10.2a3", "<3.10.2a3"),
     ],
 )
 def test_normalize_pyspec(original, normalized):
@@ -38,6 +40,8 @@ def test_normalize_pyspec(original, normalized):
         ("", ">=3.6", ">=3.6"),
         (">=3.6", "<3.2", "impossible"),
         (">=2.7,!=3.0.*", "!=3.1.*", ">=2.7,!=3.0.*,!=3.1.*"),
+        (">=3.11.0a2", "<3.11.0b", ">=3.11.0a2,<3.11.0b0"),
+        ("<3.11.0a2", ">3.11.0b", "impossible"),
     ],
 )
 def test_pyspec_and_op(left, right, result):
@@ -55,6 +59,7 @@ def test_pyspec_and_op(left, right, result):
         (">=3.6,<3.8", ">=3.4,<3.7", ">=3.4,<3.8"),
         ("~=2.7", ">=3.6", ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"),
         ("<2.7.15", ">=3.0", "!=2.7.15,!=2.7.16,!=2.7.17,!=2.7.18"),
+        (">3.11.0a2", ">3.11.0b", ">=3.11.0a3"),
     ],
 )
 def test_pyspec_or_op(left, right, result):
@@ -86,6 +91,7 @@ def test_impossible_pyspec():
             ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*",
             ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
         ),
+        (">=3.11*", ">=3.11.0rc"),  # 11* normalizes to 11.0
     ],
 )
 def test_pyspec_is_subset_superset(left, right):
@@ -102,6 +108,7 @@ def test_pyspec_is_subset_superset(left, right):
         (">=3.7", ">=3.6,<3.9"),
         (">=3.7,<3.6", "==2.7"),
         (">=3.0,!=3.4.*", ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"),
+        (">=3.11.0", "<3.11.0a"),
     ],
 )
 def test_pyspec_isnot_subset_superset(left, right):

--- a/tests/models/test_versions.py
+++ b/tests/models/test_versions.py
@@ -3,9 +3,19 @@ import pytest
 from pdm.models.versions import InvalidPyVersion, Version
 
 
-def test_unsupported_prerelease_version():
+def test_unsupported_post_version() -> None:
     with pytest.raises(InvalidPyVersion):
-        Version("3.9.0a4")
+        Version("3.10.0post1")
+
+
+def test_support_prerelease_version() -> None:
+    assert not Version("3.9.0").is_prerelease
+    v = Version("3.9.0a4")
+    assert v.is_prerelease
+    assert str(v) == "3.9.0a4"
+    assert v.complete() == v
+    assert v.bump() == Version("3.9.0a5")
+    assert v.bump(2) == Version("3.9.1")
 
 
 def test_normalize_non_standard_version():
@@ -18,6 +28,12 @@ def test_version_comparison():
     assert Version("3.4") < Version("3.9.1")
     assert Version("3.7.*") < Version("3.7.5")
     assert Version("3.7") == Version((3, 7))
+
+    assert Version("3.9.0a") != Version("3.9.0")
+    assert Version("3.9.0a") == Version("3.9.0a0")
+    assert Version("3.10.0a9") < Version("3.10.0a12")
+    assert Version("3.10.0a12") < Version("3.10.0b1")
+    assert Version("3.7.*") < Version("3.7.1b")
 
 
 def test_version_is_wildcard():


### PR DESCRIPTION
Recently, coverage 6.4.1 listed its requirements with an alpha version of
python and this broke PDM's version parsing:

    extras_require={
        'toml': ['tomli; python_full_version<="3.11.0a6"'],
    },

Prerelease `requires-python` versions *are* valid, per these specifications:

* https://peps.python.org/pep-0440/
* https://peps.python.org/pep-0621/#requires-python
* https://packaging.python.org/en/latest/specifications/core-metadata/#requires-python

Therefore this commit adds missing parsing support for `{a|b|rc}[N]`
pre-release specifiers which are used by python language releases:

* https://docs.python.org/3/faq/general.html#how-does-the-python-version-numbering-scheme-work

This bug meant that projects that directly or indirectly depended on coverage
were unable to update pdm.lock using commands like `update` `add` `lock` and
`install` because `pdm.models.versions.Version` would raise:

    pdm.exceptions.InvalidPyVersion: 3.11.0a6: Prereleases or postreleases are not supported for python version specifers.

Until this is fixed, projects can workaround this by depending on:

    "coverage<6.4",
    "coverage[toml]<6.4",

Fixes pdm-project/pdm#1111
