### PR TITLE
Feature: Option to skip hooks

### DIFF
--- a/docs/docs/usage/scripts.md
+++ b/docs/docs/usage/scripts.md
@@ -219,3 +219,22 @@ Under certain situations PDM will look for some special hook scripts for executi
 !!! note
     Composite tasks can also have pre and post scripts.
     Called tasks will run their own pre and post scripts.
+
+
+## Skipping scripts
+
+Because, sometimes it is desirable to run a script but without its hooks,
+there is a `--skip=:all` which will disable all hooks, pre and post.
+There is also `--skip=:pre` and `--skip=:post` allowing to respectively
+skip all `pre_*` hooks and all `post_*` hooks.
+
+It is also possible to need a pre scripts but not the post one,
+or to need all tasks from a composite tasks except one.
+For those use cases, there is a finer grained `--skip` parameter
+accepting a list of tasks or hooks name to exclude.
+
+```console
+pdm run --skip pre_task1,task2 my-composite
+```
+
+This command will run the `my-composite` task and skip the `pre_task1` hook as well as the `task2` and its hooks.

--- a/docs/docs/usage/scripts.md
+++ b/docs/docs/usage/scripts.md
@@ -220,7 +220,6 @@ Under certain situations PDM will look for some special hook scripts for executi
     Composite tasks can also have pre and post scripts.
     Called tasks will run their own pre and post scripts.
 
-
 ## Skipping scripts
 
 Because, sometimes it is desirable to run a script but without its hooks,
@@ -228,7 +227,7 @@ there is a `--skip=:all` which will disable all hooks, pre and post.
 There is also `--skip=:pre` and `--skip=:post` allowing to respectively
 skip all `pre_*` hooks and all `post_*` hooks.
 
-It is also possible to need a pre scripts but not the post one,
+It is also possible to need a pre script but not the post one,
 or to need all tasks from a composite tasks except one.
 For those use cases, there is a finer grained `--skip` parameter
 accepting a list of tasks or hooks name to exclude.
@@ -238,3 +237,6 @@ pdm run --skip pre_task1,task2 my-composite
 ```
 
 This command will run the `my-composite` task and skip the `pre_task1` hook as well as the `task2` and its hooks.
+
+You can also provide you skip list in `PDM_SKIP_HOOKS` environment variable
+but it will be overridden as soon as the `--skip` parameter is provided.

--- a/news/1127.feature.md
+++ b/news/1127.feature.md
@@ -1,0 +1,1 @@
+Add a new execution option `--skip` to opt-out some scripts and hooks from any execution (both scripts and PDM commands).

--- a/pdm/cli/commands/add.py
+++ b/pdm/cli/commands/add.py
@@ -2,6 +2,7 @@ import argparse
 
 from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
+from pdm.cli.hooks import HookManager
 from pdm.cli.options import (
     dry_run_option,
     install_group,
@@ -9,6 +10,7 @@ from pdm.cli.options import (
     packages_group,
     prerelease_option,
     save_strategy_group,
+    skip_option,
     unconstrained_option,
     update_strategy_group,
 )
@@ -28,6 +30,7 @@ class Command(BaseCommand):
         packages_group,
         install_group,
         dry_run_option,
+        skip_option,
     ]
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
@@ -66,4 +69,5 @@ class Command(BaseCommand):
             no_self=options.no_self,
             dry_run=options.dry_run,
             prerelease=options.prerelease,
+            hooks=HookManager(project, options.skip),
         )

--- a/pdm/cli/commands/build.py
+++ b/pdm/cli/commands/build.py
@@ -4,14 +4,20 @@ from pdm import signals
 from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.commands.run import run_script_if_present
-from pdm.cli.options import no_isolation_option, project_option, verbose_option
+from pdm.cli.hooks import HookManager
+from pdm.cli.options import (
+    no_isolation_option,
+    project_option,
+    skip_option,
+    verbose_option,
+)
 from pdm.project import Project
 
 
 class Command(BaseCommand):
     """Build artifacts for distribution"""
 
-    arguments = [verbose_option, project_option, no_isolation_option]
+    arguments = [verbose_option, project_option, no_isolation_option, skip_option]
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
@@ -66,6 +72,7 @@ class Command(BaseCommand):
             dest=options.dest,
             clean=options.clean,
             config_settings=config_settings,
+            hooks=HookManager(project, options.skip),
         )
 
 

--- a/pdm/cli/commands/init.py
+++ b/pdm/cli/commands/init.py
@@ -4,6 +4,8 @@ from pdm import signals, termui
 from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.commands.run import run_script_if_present
+from pdm.cli.hooks import HookManager
+from pdm.cli.options import skip_option
 from pdm.project import Project
 from pdm.utils import get_user_email_from_git
 
@@ -24,6 +26,7 @@ class Command(BaseCommand):
         return termui.ask(question, default=default)
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        skip_option.add_to_parser(parser)
         parser.add_argument(
             "-n",
             "--non-interactive",
@@ -77,6 +80,7 @@ class Command(BaseCommand):
             author=author,
             email=email,
             python_requires=python_requires,
+            hooks=HookManager(project, options.skip),
         )
         if self.interactive:
             actions.ask_for_import(project)

--- a/pdm/cli/commands/lock.py
+++ b/pdm/cli/commands/lock.py
@@ -4,14 +4,19 @@ from pdm import signals
 from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.commands.run import run_script_if_present
-from pdm.cli.options import lockfile_option, no_isolation_option
+from pdm.cli.hooks import HookManager
+from pdm.cli.options import lockfile_option, no_isolation_option, skip_option
 from pdm.project import Project
 
 
 class Command(BaseCommand):
     """Resolve and lock dependencies"""
 
-    arguments = BaseCommand.arguments + [lockfile_option, no_isolation_option]
+    arguments = BaseCommand.arguments + [
+        lockfile_option,
+        no_isolation_option,
+        skip_option,
+    ]
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
@@ -21,7 +26,11 @@ class Command(BaseCommand):
         )
 
     def handle(self, project: Project, options: argparse.Namespace) -> None:
-        actions.do_lock(project, refresh=options.refresh)
+        actions.do_lock(
+            project,
+            refresh=options.refresh,
+            hooks=HookManager(project, options.skip),
+        )
 
 
 signals.pre_lock.connect(run_script_if_present("pre_lock"), weak=False)

--- a/pdm/cli/commands/publish/__init__.py
+++ b/pdm/cli/commands/publish/__init__.py
@@ -15,7 +15,8 @@ from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.commands.publish.package import PackageFile
 from pdm.cli.commands.publish.repository import Repository
-from pdm.cli.options import project_option, verbose_option
+from pdm.cli.hooks import HookManager
+from pdm.cli.options import project_option, skip_option, verbose_option
 from pdm.exceptions import PdmUsageError, PublishError
 from pdm.project import Project
 from pdm.termui import logger
@@ -24,7 +25,7 @@ from pdm.termui import logger
 class Command(BaseCommand):
     """Build and publish the project to PyPI"""
 
-    arguments = [verbose_option, project_option]
+    arguments = [verbose_option, project_option, skip_option]
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
@@ -118,7 +119,7 @@ class Command(BaseCommand):
 
     def handle(self, project: Project, options: argparse.Namespace) -> None:
         if options.build:
-            actions.do_build(project)
+            actions.do_build(project, hooks=HookManager(project, options.skip))
 
         package_files = [
             str(p)

--- a/pdm/cli/commands/remove.py
+++ b/pdm/cli/commands/remove.py
@@ -2,7 +2,8 @@ import argparse
 
 from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
-from pdm.cli.options import dry_run_option, install_group, lockfile_option
+from pdm.cli.hooks import HookManager
+from pdm.cli.options import dry_run_option, install_group, lockfile_option, skip_option
 from pdm.project import Project
 
 
@@ -13,6 +14,7 @@ class Command(BaseCommand):
         install_group.add_to_parser(parser)
         dry_run_option.add_to_parser(parser)
         lockfile_option.add_to_parser(parser)
+        skip_option.add_to_parser(parser)
         parser.add_argument(
             "-d",
             "--dev",
@@ -44,4 +46,5 @@ class Command(BaseCommand):
             no_editable=options.no_editable,
             no_self=options.no_self,
             dry_run=options.dry_run,
+            hooks=HookManager(project, options.skip),
         )

--- a/pdm/cli/commands/sync.py
+++ b/pdm/cli/commands/sync.py
@@ -2,12 +2,14 @@ import argparse
 
 from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
+from pdm.cli.hooks import HookManager
 from pdm.cli.options import (
     clean_group,
     dry_run_option,
     groups_group,
     install_group,
     lockfile_option,
+    skip_option,
 )
 from pdm.project import Project
 
@@ -25,6 +27,7 @@ class Command(BaseCommand):
             action="store_true",
             help="Force reinstall existing dependencies",
         )
+        skip_option.add_to_parser(parser)
         clean_group.add_to_parser(parser)
         install_group.add_to_parser(parser)
 
@@ -40,4 +43,5 @@ class Command(BaseCommand):
             no_editable=options.no_editable,
             no_self=options.no_self,
             reinstall=options.reinstall,
+            hooks=HookManager(project, options.skip),
         )

--- a/pdm/cli/commands/update.py
+++ b/pdm/cli/commands/update.py
@@ -2,12 +2,14 @@ import argparse
 
 from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
+from pdm.cli.hooks import HookManager
 from pdm.cli.options import (
     groups_group,
     install_group,
     lockfile_option,
     prerelease_option,
     save_strategy_group,
+    skip_option,
     unconstrained_option,
     update_strategy_group,
 )
@@ -25,6 +27,7 @@ class Command(BaseCommand):
         update_strategy_group,
         prerelease_option,
         unconstrained_option,
+        skip_option,
     ]
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
@@ -69,4 +72,5 @@ class Command(BaseCommand):
             no_editable=options.no_editable,
             no_self=options.no_self,
             prerelease=options.prerelease,
+            hooks=HookManager(project, options.skip),
         )

--- a/pdm/cli/hooks.py
+++ b/pdm/cli/hooks.py
@@ -39,7 +39,7 @@ class HookManager:
 
     def should_run(self, name: str) -> bool:
         """
-        Tells wether a task given its name should be run or not
+        Tells wether a task given its name should run or not
         according to the current skipping rules.
         """
         return (

--- a/pdm/cli/hooks.py
+++ b/pdm/cli/hooks.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pdm import signals
+from pdm.project.core import Project
+from pdm.utils import cached_property
+
+KNOWN_HOOKS = (
+    "post_init",
+    "pre_build",
+    "post_build",
+    "pre_install",
+    "post_install",
+    "pre_lock",
+    "post_lock",
+)
+
+
+class HookManager:
+    projet: Project
+    skip: list[str]
+
+    def __init__(self, project: Project, skip: list[str] | None = None):
+        self.project = project
+        self.skip = skip or []
+
+    @cached_property
+    def skip_all(self) -> bool:
+        return ":all" in self.skip
+
+    @cached_property
+    def skip_pre(self) -> bool:
+        return ":pre" in self.skip
+
+    @cached_property
+    def skip_post(self) -> bool:
+        return ":post" in self.skip
+
+    def should_run(self, name: str) -> bool:
+        """
+        Tells wether a task given its name should be run or not
+        according to the current skipping rules.
+        """
+        return (
+            not self.skip_all
+            and name not in self.skip
+            and not (self.skip_pre and name.startswith("pre_"))
+            and not (self.skip_post and name.startswith("post_"))
+        )
+
+    def try_emit(self, name: str, **kwargs: Any) -> None:
+        """
+        Emit a hook signal if rules allow it.
+        """
+        if self.should_run(name):
+            getattr(signals, name).send(self.project, hooks=self, **kwargs)

--- a/pdm/cli/options.py
+++ b/pdm/cli/options.py
@@ -97,6 +97,26 @@ def deprecated(message: str, type_: type = str) -> Callable[[Any], Any]:
     return wrapped_type
 
 
+def split_lists(separator: str) -> type[argparse.Action]:
+    class SplitList(argparse.Action):
+        def __call__(
+            self,
+            parser: argparse.ArgumentParser,
+            args: argparse.Namespace,
+            values: Any,
+            option_string: str | None = None,
+        ) -> None:
+            if not isinstance(values, str):
+                return
+            splitted = getattr(args, self.dest) or []
+            splitted.extend(
+                value.strip() for value in values.split(separator) if value.strip()
+            )
+            setattr(args, self.dest, splitted)
+
+    return SplitList
+
+
 verbose_option = Option(
     "-v",
     "--verbose",
@@ -228,6 +248,14 @@ save_strategy_group.add_argument(
     dest="save_strategy",
     const="minimum",
     help="Save minimum version specifiers",
+)
+
+skip_option = Option(
+    "-k",
+    "--skip",
+    dest="skip",
+    action=split_lists(","),
+    help="Skip some tasks and/or hooks",
 )
 
 update_strategy_group = ArgumentGroup("update_strategy", is_mutually_exclusive=True)

--- a/pdm/cli/options.py
+++ b/pdm/cli/options.py
@@ -98,6 +98,11 @@ def deprecated(message: str, type_: type = str) -> Callable[[Any], Any]:
 
 
 def split_lists(separator: str) -> type[argparse.Action]:
+    """
+    Works the same as `append` except each argument
+    is considered a `separator`-separated list.
+    """
+
     class SplitList(argparse.Action):
         def __call__(
             self,
@@ -115,6 +120,16 @@ def split_lists(separator: str) -> type[argparse.Action]:
             setattr(args, self.dest, splitted)
 
     return SplitList
+
+
+def from_splitted_env(name: str, separator: str) -> list[str] | None:
+    """
+    Parse a `separator`-separated list from a `name` environment variable if present.
+    """
+    value = os.getenv(name)
+    if not value:
+        return None
+    return [v.strip() for v in value.split(separator) if v.strip()] or None
 
 
 verbose_option = Option(
@@ -255,7 +270,11 @@ skip_option = Option(
     "--skip",
     dest="skip",
     action=split_lists(","),
-    help="Skip some tasks and/or hooks",
+    help="Skip some tasks and/or hooks by their comma-separated names."
+    " Can be supplied multiple times."
+    ' Use ":all" to skip all hooks.'
+    ' Use ":pre" and ":post" to skip all pre or post hooks.',
+    default=from_splitted_env("PDM_SKIP_HOOKS", ","),
 )
 
 update_strategy_group = ArgumentGroup("update_strategy", is_mutually_exclusive=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ version = {use_scm = true}
 [tool.pdm.scripts]
 pre_release = "python tasks/max_versions.py"
 release = "python tasks/release.py"
-test = "pytest tests/"
+test = "pytest"
 doc = {shell = "cd docs && mkdocs serve", help = "Start the dev server for doc preview"}
 lint = "pre-commit run --all-files"
 complete = {call = "tasks.complete:main", help = "Create autocomplete files for bash and fish"}
@@ -184,3 +184,7 @@ markers = [
     "deprecated: Tests about deprecated features",
 ]
 addopts = "-ra"
+testpaths = [
+    "tests/",
+]
+

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+from pytest_mock import MockerFixture
+
+from pdm.cli.commands.publish.package import PackageFile
+from pdm.cli.commands.publish.repository import Repository
+from tests import FIXTURES
+
+
+@pytest.fixture
+def mock_run_gpg(mocker: MockerFixture):
+    def mock_run_gpg(args):
+        signature_file = args[-1] + ".asc"
+        with open(signature_file, "wb") as f:
+            f.write(b"fake signature")
+
+    mocker.patch.object(PackageFile, "_run_gpg", side_effect=mock_run_gpg)
+
+
+@pytest.fixture
+def prepare_packages(tmp_path: Path):
+    dist_path = tmp_path / "dist"
+    dist_path.mkdir()
+    for filename in [
+        "demo-0.0.1-py2.py3-none-any.whl",
+        "demo-0.0.1.tar.gz",
+        "demo-0.0.1.zip",
+    ]:
+        shutil.copy2(FIXTURES / "artifacts" / filename, dist_path)
+
+
+@pytest.fixture
+def mock_pypi(mocker: MockerFixture):
+    def post(url, *, data, **kwargs):
+        # consume the data body to make the progress complete
+        data.read()
+        resp = requests.Response()
+        resp.status_code = 200
+        resp.reason = "OK"
+        resp.url = url
+        return resp
+
+    return mocker.patch("pdm.models.session.PDMSession.post", side_effect=post)
+
+
+@pytest.fixture
+def uploaded(mocker: MockerFixture):
+    packages = []
+
+    def fake_upload(package, progress):
+        packages.append(package)
+        resp = requests.Response()
+        resp.status_code = 200
+        resp.reason = "OK"
+        resp.url = "https://upload.pypi.org/legacy/"
+        return resp
+
+    mocker.patch.object(Repository, "upload", side_effect=fake_upload)
+    return packages
+
+
+@dataclass
+class PublishMock:
+    mock_pypi: MagicMock
+    uploaded: list[Any]
+
+
+@pytest.fixture
+# @pytest.mark.usefixtures("mock_run_gpg", "prepare_packages")
+def mock_publish(mock_pypi, uploaded) -> PublishMock:
+    return PublishMock(
+        mock_pypi=mock_pypi,
+        uploaded=uploaded,
+    )

--- a/tests/cli/test_hooks.py
+++ b/tests/cli/test_hooks.py
@@ -5,6 +5,7 @@ import pytest
 
 from pdm.cli import actions
 from pdm.cli.hooks import KNOWN_HOOKS
+from pdm.cli.options import from_splitted_env
 from pdm.models.requirements import parse_requirement
 
 
@@ -128,6 +129,26 @@ def test_skip_option(project, invoke, capfd, args):
     assert "Second CALLED" not in out
     assert "Post-Second CALLED" not in out
     assert "Post-Test CALLED" in out
+
+
+@pytest.mark.parametrize(
+    "env, expected",
+    [
+        ("pre_test", ["pre_test"]),
+        ("pre_test,post_test", ["pre_test", "post_test"]),
+        ("pre_test , post_test", ["pre_test", "post_test"]),
+        (None, None),
+        (" ", None),
+        (" , ", None),
+    ],
+)
+def test_skip_option_default_from_env(env, expected, monkeypatch):
+    if env is not None:
+        monkeypatch.setenv("PDM_SKIP_HOOKS", env)
+
+    # Default value is set once and not easily testable
+    # so we test the function generating this default value
+    assert from_splitted_env("PDM_SKIP_HOOKS", ",") == expected
 
 
 HookSpecs = namedtuple("HookSpecs", ["command", "hooks", "fixtures"])

--- a/tests/cli/test_hooks.py
+++ b/tests/cli/test_hooks.py
@@ -1,0 +1,241 @@
+import shlex
+from collections import namedtuple
+
+import pytest
+
+from pdm.cli import actions
+from pdm.cli.hooks import KNOWN_HOOKS
+from pdm.models.requirements import parse_requirement
+
+
+def test_pre_script_fail_fast(project, invoke, capfd, mocker):
+    project.tool_settings["scripts"] = {
+        "pre_install": "python -c \"print('PRE INSTALL CALLED'); exit(1)\"",
+        "post_install": "python -c \"print('POST INSTALL CALLED')\"",
+    }
+    project.write_pyproject()
+    synchronize = mocker.patch("pdm.installers.synchronizers.Synchronizer.synchronize")
+    result = invoke(["install"], obj=project)
+    assert result.exit_code == 1
+    out, _ = capfd.readouterr()
+    assert "PRE INSTALL CALLED" in out
+    assert "POST INSTALL CALLED" not in out
+    synchronize.assert_not_called()
+
+
+def test_pre_and_post_scripts(project, invoke, capfd):
+    project.tool_settings["scripts"] = {
+        "pre_test": "python -c \"print('PRE test CALLED')\"",
+        "test": "python -c \"print('IN test CALLED')\"",
+        "post_test": "python -c \"print('POST test CALLED')\"",
+    }
+    project.write_pyproject()
+    capfd.readouterr()
+    invoke(["run", "test"], strict=True, obj=project)
+    out, _ = capfd.readouterr()
+    assert "PRE test CALLED" in out
+    assert "IN test CALLED" in out
+    assert "POST test CALLED" in out
+
+
+def test_composite_runs_all_hooks(project, invoke, capfd):
+    project.tool_settings["scripts"] = {
+        "test": {"composite": ["first", "second"]},
+        "pre_test": "echo 'Pre-Test CALLED'",
+        "post_test": "echo 'Post-Test CALLED'",
+        "first": "echo 'First CALLED'",
+        "pre_first": "echo 'Pre-First CALLED'",
+        "second": "echo 'Second CALLED'",
+        "post_second": "echo 'Post-Second CALLED'",
+    }
+    project.write_pyproject()
+    capfd.readouterr()
+    invoke(["run", "test"], strict=True, obj=project)
+    out, _ = capfd.readouterr()
+    assert "Pre-Test CALLED" in out
+    assert "Pre-First CALLED" in out
+    assert "First CALLED" in out
+    assert "Second CALLED" in out
+    assert "Post-Second CALLED" in out
+    assert "Post-Test CALLED" in out
+
+
+@pytest.mark.parametrize("option", [":all", ":pre,:post"])
+def test_skip_all_hooks_option(project, invoke, capfd, option: str):
+    project.tool_settings["scripts"] = {
+        "test": {"composite": ["first", "second"]},
+        "pre_test": "echo 'Pre-Test CALLED'",
+        "post_test": "echo 'Post-Test CALLED'",
+        "first": "echo 'First CALLED'",
+        "pre_first": "echo 'Pre-First CALLED'",
+        "post_first": "echo 'Post-First CALLED'",
+        "second": "echo 'Second CALLED'",
+        "pre_second": "echo 'Pre-Second CALLED'",
+        "post_second": "echo 'Post-Second CALLED'",
+    }
+    project.write_pyproject()
+    capfd.readouterr()
+    invoke(["run", f"--skip={option}", "first"], strict=True, obj=project)
+    out, _ = capfd.readouterr()
+    assert "Pre-First CALLED" not in out
+    assert "First CALLED" in out
+    assert "Post-First CALLED" not in out
+    capfd.readouterr()
+    invoke(["run", f"--skip={option}", "test"], strict=True, obj=project)
+    out, _ = capfd.readouterr()
+    assert "Pre-Test CALLED" not in out
+    assert "Pre-First CALLED" not in out
+    assert "First CALLED" in out
+    assert "Post-First CALLED" not in out
+    assert "Pre-Second CALLED" not in out
+    assert "Second CALLED" in out
+    assert "Post-Second CALLED" not in out
+    assert "Post-Test CALLED" not in out
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        "--skip pre_test,post_first,second",
+        "-k pre_test,post_first,second",
+        "--skip pre_test --skip post_first --skip second",
+        "-k pre_test -k post_first -k second",
+        "--skip pre_test --skip post_first,second",
+        "-k pre_test -k post_first,second",
+    ],
+)
+def test_skip_option(project, invoke, capfd, args):
+    project.tool_settings["scripts"] = {
+        "test": {"composite": ["first", "second"]},
+        "pre_test": "echo 'Pre-Test CALLED'",
+        "post_test": "echo 'Post-Test CALLED'",
+        "first": "echo 'First CALLED'",
+        "pre_first": "echo 'Pre-First CALLED'",
+        "post_first": "echo 'Post-First CALLED'",
+        "second": "echo 'Second CALLED'",
+        "pre_second": "echo 'Pre-Second CALLED'",
+        "post_second": "echo 'Post-Second CALLED'",
+    }
+    project.write_pyproject()
+    capfd.readouterr()
+    invoke(["run", *shlex.split(args), "test"], strict=True, obj=project)
+    out, _ = capfd.readouterr()
+    assert "Pre-Test CALLED" not in out
+    assert "Pre-First CALLED" in out
+    assert "First CALLED" in out
+    assert "Post-First CALLED" not in out
+    assert "Pre-Second CALLED" not in out
+    assert "Second CALLED" not in out
+    assert "Post-Second CALLED" not in out
+    assert "Post-Test CALLED" in out
+
+
+HookSpecs = namedtuple("HookSpecs", ["command", "hooks", "fixtures"])
+
+KNOWN_COMMAND_HOOKS = (
+    ("add", "add requests", ("pre_lock", "post_lock"), ["working_set"]),
+    ("build", "build", ("pre_build", "post_build"), []),
+    ("init", "init --non-interactive", ("post_init",), []),
+    (
+        "install",
+        "install",
+        ("pre_install", "post_install", "pre_lock", "post_lock"),
+        ["repository"],
+    ),
+    ("lock", "lock", ("pre_lock", "post_lock"), []),
+    ("publish", "publish", ("pre_build", "post_build"), ["mock_publish"]),
+    ("remove", "remove requests", ("pre_lock", "post_lock"), ["lock"]),
+    ("sync", "sync", ("pre_install", "post_install"), ["lock"]),
+    ("update", "update", ("pre_install", "post_install", "pre_lock", "post_lock"), []),
+)
+
+parametrize_with_commands = pytest.mark.parametrize(
+    "specs",
+    [
+        pytest.param(HookSpecs(command, hooks, fixtures), id=id)
+        for id, command, hooks, fixtures in KNOWN_COMMAND_HOOKS
+    ],
+)
+
+parametrize_with_hooks = pytest.mark.parametrize(
+    "specs,hook",
+    [
+        pytest.param(HookSpecs(command, hooks, fixtures), hook, id=f"{id}-{hook}")
+        for id, command, hooks, fixtures in KNOWN_COMMAND_HOOKS
+        for hook in hooks
+    ],
+)
+
+
+@pytest.fixture
+def hooked_project(project, capfd, specs, request):
+    project.tool_settings["scripts"] = {
+        hook: f"python -c \"print('{hook} CALLED')\"" for hook in KNOWN_HOOKS
+    }
+    project.write_pyproject()
+    for fixture in specs.fixtures:
+        request.getfixturevalue(fixture)
+    capfd.readouterr()
+    return project
+
+
+@pytest.fixture
+def lock(project, capfd):
+    project.add_dependencies({"requests": parse_requirement("requests")})
+    actions.do_lock(project)
+    capfd.readouterr()
+
+
+@parametrize_with_commands
+def test_hooks(hooked_project, invoke, capfd, specs: HookSpecs):
+    invoke(shlex.split(specs.command), strict=True, obj=hooked_project)
+    out, _ = capfd.readouterr()
+    for hook in specs.hooks:
+        assert f"{hook} CALLED" in out
+
+
+@parametrize_with_hooks  # Iterate over hooks as we need a clean slate for each run
+def test_skip_option_from_signal(
+    hooked_project, invoke, capfd, specs: HookSpecs, hook: str
+):
+    invoke(
+        [*shlex.split(specs.command), f"--skip={hook}"], strict=True, obj=hooked_project
+    )
+    out, _ = capfd.readouterr()
+    assert f"{hook} CALLED" not in out
+    for known_hook in specs.hooks:
+        if known_hook != hook:
+            assert f"{known_hook} CALLED" in out
+
+
+@parametrize_with_commands
+@pytest.mark.parametrize("option", [":all", ":pre,:post"])
+def test_skip_all_option_from_signal(
+    hooked_project, invoke, capfd, specs: HookSpecs, option: str
+):
+    invoke(
+        [*shlex.split(specs.command), f"--skip={option}"],
+        strict=True,
+        obj=hooked_project,
+    )
+    out, _ = capfd.readouterr()
+    for hook in KNOWN_HOOKS:
+        assert f"{hook} CALLED" not in out
+
+
+@parametrize_with_commands
+@pytest.mark.parametrize("prefix", ["pre", "post"])
+def test_skip_pre_post_option_from_signal(
+    hooked_project, invoke, capfd, specs: HookSpecs, prefix: str
+):
+    invoke(
+        [*shlex.split(specs.command), f"--skip=:{prefix}"],
+        strict=True,
+        obj=hooked_project,
+    )
+    out, _ = capfd.readouterr()
+    for hook in specs.hooks:
+        if hook.startswith(prefix):
+            assert f"{hook} CALLED" not in out
+        else:
+            assert f"{hook} CALLED" in out

--- a/tests/cli/test_lock.py
+++ b/tests/cli/test_lock.py
@@ -1,3 +1,5 @@
+from unittest.mock import ANY
+
 import pytest
 
 from pdm.cli import actions
@@ -7,7 +9,7 @@ from pdm.models.requirements import parse_requirement
 def test_lock_command(project, invoke, mocker):
     m = mocker.patch.object(actions, "do_lock")
     invoke(["lock"], obj=project)
-    m.assert_called_with(project, refresh=False)
+    m.assert_called_with(project, refresh=False, hooks=ANY)
 
 
 @pytest.mark.usefixtures("repository")

--- a/tests/cli/test_others.py
+++ b/tests/cli/test_others.py
@@ -1,3 +1,5 @@
+from unittest.mock import ANY
+
 import pytest
 
 from pdm.cli import actions
@@ -93,6 +95,7 @@ def test_init_command(project_no_init, invoke, mocker):
         author="Testing",
         email="me@example.org",
         python_requires=f">={python_version}",
+        hooks=ANY,
     )
 
 
@@ -118,6 +121,7 @@ def test_init_command_library(project_no_init, invoke, mocker):
         author="Testing",
         email="me@example.org",
         python_requires=f">={python_version}",
+        hooks=ANY,
     )
 
 
@@ -139,6 +143,7 @@ def test_init_non_interactive(project_no_init, invoke, mocker):
         author="Testing",
         email="me@example.org",
         python_requires=f">={python_version}",
+        hooks=ANY,
     )
 
 

--- a/tests/cli/test_publish.py
+++ b/tests/cli/test_publish.py
@@ -1,66 +1,14 @@
 import os
-import shutil
 from argparse import Namespace
 
 import pytest
-import requests
 
 from pdm.cli.commands.publish import Command as PublishCommand
 from pdm.cli.commands.publish.package import PackageFile
 from pdm.cli.commands.publish.repository import Repository
 from tests import FIXTURES
 
-
-@pytest.fixture(autouse=True)
-def mock_run_gpg(mocker):
-    def mock_run_gpg(args):
-        signature_file = args[-1] + ".asc"
-        with open(signature_file, "wb") as f:
-            f.write(b"fake signature")
-
-    mocker.patch.object(PackageFile, "_run_gpg", side_effect=mock_run_gpg)
-
-
-@pytest.fixture()
-def prepare_packages(tmp_path):
-    dist_path = tmp_path / "dist"
-    dist_path.mkdir()
-    for filename in [
-        "demo-0.0.1-py2.py3-none-any.whl",
-        "demo-0.0.1.tar.gz",
-        "demo-0.0.1.zip",
-    ]:
-        shutil.copy2(FIXTURES / "artifacts" / filename, dist_path)
-
-
-@pytest.fixture()
-def mock_pypi(mocker):
-    def post(url, *, data, **kwargs):
-        # consume the data body to make the progress complete
-        data.read()
-        resp = requests.Response()
-        resp.status_code = 200
-        resp.reason = "OK"
-        resp.url = url
-        return resp
-
-    return mocker.patch("pdm.models.session.PDMSession.post", side_effect=post)
-
-
-@pytest.fixture()
-def uploaded(mocker):
-    packages = []
-
-    def fake_upload(package, progress):
-        packages.append(package)
-        resp = requests.Response()
-        resp.status_code = 200
-        resp.reason = "OK"
-        resp.url = "https://upload.pypi.org/legacy/"
-        return resp
-
-    mocker.patch.object(Repository, "upload", side_effect=fake_upload)
-    return packages
+pytestmark = pytest.mark.usefixtures("mock_run_gpg")
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -348,48 +348,6 @@ print(json.dumps(sysconfig.get_paths()))
     assert "__pypackages__" in out["purelib"]
 
 
-def test_pre_and_post_hooks(project, invoke, capfd):
-    project.tool_settings["scripts"] = {
-        "pre_install": "python -c \"print('PRE INSTALL CALLED')\"",
-        "post_install": "python -c \"print('POST INSTALL CALLED')\"",
-    }
-    project.write_pyproject()
-    invoke(["install"], strict=True, obj=project)
-    out, _ = capfd.readouterr()
-    assert "PRE INSTALL CALLED" in out
-    assert "POST INSTALL CALLED" in out
-
-
-def test_pre_script_fail_fast(project, invoke, capfd, mocker):
-    project.tool_settings["scripts"] = {
-        "pre_install": "python -c \"print('PRE INSTALL CALLED'); exit(1)\"",
-        "post_install": "python -c \"print('POST INSTALL CALLED')\"",
-    }
-    project.write_pyproject()
-    synchronize = mocker.patch("pdm.installers.synchronizers.Synchronizer.synchronize")
-    result = invoke(["install"], obj=project)
-    assert result.exit_code == 1
-    out, _ = capfd.readouterr()
-    assert "PRE INSTALL CALLED" in out
-    assert "POST INSTALL CALLED" not in out
-    synchronize.assert_not_called()
-
-
-def test_pre_and_post_scripts(project, invoke, capfd):
-    project.tool_settings["scripts"] = {
-        "pre_test": "python -c \"print('PRE test CALLED')\"",
-        "test": "python -c \"print('IN test CALLED')\"",
-        "post_test": "python -c \"print('POST test CALLED')\"",
-    }
-    project.write_pyproject()
-    capfd.readouterr()
-    invoke(["run", "test"], strict=True, obj=project)
-    out, _ = capfd.readouterr()
-    assert "PRE test CALLED" in out
-    assert "IN test CALLED" in out
-    assert "POST test CALLED" in out
-
-
 def test_run_composite(project, invoke, capfd):
     project.tool_settings["scripts"] = {
         "first": "echo 'First CALLED'",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import functools
 import json
@@ -18,6 +20,7 @@ from unearth.vcs import Git, vcs_support
 
 from pdm._types import CandidateInfo
 from pdm.cli.actions import do_init, do_use
+from pdm.cli.hooks import HookManager
 from pdm.core import Core
 from pdm.exceptions import CandidateInfoNotFound
 from pdm.models.candidates import Candidate
@@ -324,7 +327,8 @@ def local_finder(project_no_init, mocker):
 
 @pytest.fixture()
 def project(project_no_init):
-    do_init(project_no_init, "test_project", "0.0.0")
+    hooks = HookManager(project_no_init, ["post_init"])
+    do_init(project_no_init, "test_project", "0.0.0", hooks=hooks)
     # Clean the cached property
     project_no_init._environment = None
     return project_no_init

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -9,7 +9,7 @@ def test_post_init_signal(project_no_init, invoke):
     with signals.post_init.connected_to(mock_handler):
         result = invoke(["init"], input="\n\n\n\n\n\n", obj=project_no_init)
         assert result.exit_code == 0
-    mock_handler.assert_called_once_with(project_no_init)
+    mock_handler.assert_called_once_with(project_no_init, hooks=mock.ANY)
 
 
 def test_post_lock_and_install_signals(project, working_set, repository):


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

This PR is a proposal at implementing #948.
If provides 2 parameters:
- `--skip-hooks` that will skip any hook (or pre/post script) involved in the execution
- `--skip` which can take any arbitrary task or hook name(s) and skip it/them

Those 2 parameters have been added to the following commands
- `run`
- `install`
- `lock`
- `build`
- `init`

The `--skip` can be used many times. The following commands are all equivalents
- `--skip=pre_task1,task2`
- `--skip pre_task1,task2`
- `--skip=pre_task1 --skip=task2`
- `--skip pre_task1 --skip task2`

The both options can be used together:
```console
pdm run --skip-hooks --skip=taskn my-composite-task
```
