### PR TITLE
Add option to skip _add_to_path in installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ Or you can install it under a user site:
 pip install --user pdm
 ```
 
+With [asdf-vm](https://asdf-vm.com/)
+```bash
+asdf plugin add github.com/1oglop1/asdf-pdm.git
+asdf install pdm latest
+```
+
 ## Quickstart
 
 **Initialize a new PDM project**

--- a/install-pdm.py
+++ b/install-pdm.py
@@ -354,8 +354,8 @@ class Installer:
     def install(self) -> None:
         venv = self._make_env()
         self._install(venv)
-        bin = self._make_bin(venv)
-        self._post_install(venv, bin)
+        bin_dir = self._make_bin(venv)
+        self._post_install(venv, bin_dir)
 
     def uninstall(self) -> None:
         _echo(

--- a/install-pdm.py
+++ b/install-pdm.py
@@ -195,6 +195,7 @@ class Installer:
     version: str | None = None
     prerelease: bool = False
     additional_deps: Sequence[str] = ()
+    skip_add_to_path: bool = False
 
     def __post_init__(self):
         self._path = self._decide_path()
@@ -349,7 +350,8 @@ class Installer:
                 colored("cyan", str(script)),
             )
         )
-        _add_to_path(bin_path)
+        if not self.skip_add_to_path:
+            _add_to_path(bin_path)
 
     def install(self) -> None:
         venv = self._make_env()
@@ -419,10 +421,20 @@ def main():
         default=os.getenv("PDM_DEPS", "").split(","),
         help="Specify additional dependencies, can be given multiple times",
     )
+    parser.add_argument(
+        "--skip-add-to-path",
+        action="store_true",
+        help="Do not add binary to the PATH.",
+        default=os.getenv("PDM_SKIP_ADD_TO_PATH"),
+    )
 
     options = parser.parse_args()
     installer = Installer(
-        options.path, options.version, options.prerelease, options.dep
+        location=options.path,
+        version=options.version,
+        prerelease=options.prerelease,
+        additional_deps=options.dep,
+        skip_add_to_path=options.skip_add_to_path,
     )
     if options.remove:
         installer.uninstall()

--- a/news/1145.misc.md
+++ b/news/1145.misc.md
@@ -1,0 +1,3 @@
+Add additional installation option via [asdf-pdm](https://github.com/1oglop1/asdf-pdm).
+Add `skpip-add-to-path` option to installer in order to prevent changing `PATH`.
+Replace `bin` variable name with `bin_dir`.


### PR DESCRIPTION
## Pull Request Check List

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
I created a [asdf-vm](https://asdf-vm.com/) plugin for PDM https://github.com/1oglop1/asdf-pdm. 
And created an issue to add it to the community plugins #asdf-community/.github/issues/33. 
Also a minor change to a variable name `bin` which was shadowing builtin function `bin`.