### PR TITLE
Proposal: Fix for multilines and composite scripts listing

### DIFF
--- a/news/1151.feature.md
+++ b/news/1151.feature.md
@@ -1,0 +1,1 @@
+Shorter scripts listing, especially for multilines and composite scripts.

--- a/pdm/termui.py
+++ b/pdm/termui.py
@@ -101,11 +101,15 @@ class Emoji:
         LOCK = " "
         CONGRAT = " "
         POPPER = " "
+        ELLIPSIS = "..."
+        ARROW_SEPARATOR = ">"
     else:
         SUCC = ":heavy_check_mark:"
         FAIL = ":heavy_multiplication_x:"
         LOCK = ":lock:"
         POPPER = ":party_popper:"
+        ELLIPSIS = "…"
+        ARROW_SEPARATOR = "➤"
 
 
 if is_legacy_windows():


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

While the current script listing is working fine when your command are short one-liners, it was broken for multilines scripts on `main` (where this PR was initially implemented).
Now that `dev` switched on a `rich` table display, I'm not sure whether it is improvement or not so I submit it anyway,

This PR improvement proposal was to merge the `Script` and `Description` column into a single `Description` column displaying the `help` if available and if not:
- display the sequence of calls for `composite`
- display the first line of script with a `⮨` ellipsis if it has been truncated

Also, the list is now sorted.

## Example

Here the same output for `main`, `dev` and this PR for this given `tool.pdm.scripts`:

```toml
[tool.pdm.scripts]
all = {composite = ["format", "lint", "cover"]}
test = "pytest better/ tests/"
format = { shell = """\
isort better/
black better/
""" }
doc = "sphinx-build docs docs/_build/html"
"doc:watch" = "sphinx-autobuild docs docs/_build/html"

[tool.pdm.scripts.lint]
shell = """\
  echo "Flakes"
  flake8 better
  echo "isort"
  isort --check better
  echo "black"
  black --check better
  echo "MyPy"
  mypy better
"""

[tool.pdm.scripts.cover]
help = "Run tests with coverage"
cmd = """
pytest
  --cov-report=term
  --cov=better
  --cov-report=html:reports/coverage
  --cov-report=xml:reports/coverage.xml
  --junitxml=reports/tests.xml
"""
```

### Main
![Capture d’écran du 2022-06-22 13-21-27](https://user-images.githubusercontent.com/15725/175018127-a3d8660e-cbe3-48ad-9ea1-bc7d8cf8f052.png)

Note: the `composite` task has been removed to be able to run the command

### Dev
![Capture d’écran du 2022-06-22 13-22-03](https://user-images.githubusercontent.com/15725/175018169-ec7e78b7-b46b-4b3f-8590-c98fccb60c27.png)

### Proposal
![Capture d’écran du 2022-06-22 13-22-53](https://user-images.githubusercontent.com/15725/175018214-8ceb80d0-eaec-4a8e-a3fc-6c7be3d6432d.png)
