### PR TITLE
chore: remove remaining artifacts from #1127

### DIFF
--- a/pdm/cli/commands/run.py
+++ b/pdm/cli/commands/run.py
@@ -26,8 +26,6 @@ class TaskOptions(TypedDict, total=False):
     env_file: str | None
     help: str
     site_packages: bool
-    skip_hooks: bool
-    skip: list[str]
 
 
 def exec_opts(*options: TaskOptions | None) -> dict[str, Any]:


### PR DESCRIPTION
Just clean up a remaining artifact from #1127 (not used anymore in the final version)