### PR TITLE
feat(CLI): Yarn-like root scripts fallback

### DIFF
--- a/docs/docs/usage/scripts.md
+++ b/docs/docs/usage/scripts.md
@@ -10,6 +10,13 @@ pdm run flask run -p 54321
 
 It will run `flask run -p 54321` in the environment that is aware of packages in `__pypackages__/` folder.
 
+!!! note
+    There is a builtin shortcut making all scripts available as root commands
+    as long as the script does not conflict with any builtin or plugin-contributed command.
+    Said otherwise, if you have a `test` script, you can run both `pdm run test` and `pdm test`.
+    But if you have an `install` script, only `pdm run install` will run it,
+    `pdm install` will still run the builtin `install` command.
+
 ## User Scripts
 
 PDM also supports custom script shortcuts in the optional `[tool.pdm.scripts]` section of `pyproject.toml`.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -58,10 +58,8 @@ nav:
       - dev/benchmark.md
 
 markdown_extensions:
-  - admonition
   - pymdownx.highlight:
       linenums: true
-  - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.details

--- a/news/1159.feature.md
+++ b/news/1159.feature.md
@@ -1,0 +1,1 @@
+Scripts are now available as root command if they don't conflict with any builtin or plugin-contributed command.


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

This PR allow to execute PDM scripts without the `run` command prefix as long as it doesn't conflict with any builtin command or any plugin-provided command.
In case of error, it produces the exact same output, especially in case of shell command not found (ie. instead of having the command not found error from your shell as `run` does, you still have the PDM usage and error).

In the process I made the "no parameters provided" behavior the same as any others parsing error: usage (help in in this case) is printed on `stderr` instead of `stdout` [here](https://github.com/pdm-project/pdm/pull/1159/files#diff-3a198f24ba7555b1c4cf4d06730a48e6d7494772cda928b78676a76f0f1a0cd9L158-R184).

**Note:** the `click.testing.CliRunner` have some known issues with `stderr` (`stderr` is unbuffered but `CliRunner` mock it as a buffered one making error message lost in the process) and to be able to test error messages, I had to switch on a simpler home made runner only based on Pytest fixture. Same signature, less `click` specific in the process but we gain proper `stderr` handling (as well as the possibility to have the execution output for debug with the `RunResult.print()` method. I kept the dependency in  `pyproject.toml` to avoid locking in this PR and I wasn't sure about side-effects as some tests install `click` and having it as a dependency make sure that it is present in the cache.

**Note:** there has been 3 versions before compatibility with Python 3.7 and Python 3.8 was reached:
- first one was using `argparse`'s `exit_on_error` but this was added in Python 3.9
- second one was trying to backport `argparse`'s `exit_on_error`, was working but MyPy disagreed
- this one which now rely on catching `SystemExit` instead of `argparse.ArgumentError`: less fine but tests ensure that we don't silently catch other errors