### PR TITLE
feat(hooks): added a post_use hook

### DIFF
--- a/docs/docs/usage/hooks.md
+++ b/docs/docs/usage/hooks.md
@@ -28,7 +28,7 @@ They trigger the following hooks:
 
 - [`post_init`][pdm.signals.post_init]
 
-``` mermaid
+```mermaid
 flowchart LR
   subgraph pdm-init [pdm init]
     direction LR
@@ -62,8 +62,7 @@ They trigger the following hooks:
 - [`pre_lock`][pdm.signals.pre_lock]
 - [`post_lock`][pdm.signals.post_lock]
 
-
-``` mermaid
+```mermaid
 flowchart LR
   subgraph pdm-install [pdm install]
     direction LR
@@ -86,6 +85,21 @@ flowchart LR
   end
 ```
 
+### Switching Python version
+
+This is a special case in dependency management:
+you can switch the current Python version using [`pdm use`](cli_reference.md#exec-0--use) 
+and it will emit the [`post_use`][pdm.signals.post_use] signal with the new Python interpreter.
+
+```mermaid
+flowchart LR
+  subgraph pdm-use [pdm use]
+    direction LR
+    post-use{{Emit post_use}}
+    use --> post-use
+  end 
+```
+
 ## Publication
 
 As soon as you are ready to publish you package/app/libray, you will require the publication tasks:
@@ -106,7 +120,7 @@ They trigger the following hooks:
 - [`post_build`][pdm.signals.post_build]
 
 
-``` mermaid
+```mermaid
 flowchart LR
   subgraph pdm-publish [pdm publish]
     direction LR
@@ -155,7 +169,7 @@ composite = {composite: ["test"]}
 
 a `pdm run test` will have the following lifecycle:
 
-``` mermaid
+```mermaid
 flowchart LR
   subgraph pdm-run-test [pdm run test]
     direction LR
@@ -178,7 +192,7 @@ flowchart LR
 
 while `pdm run composite` will have the following:
 
-``` mermaid
+```mermaid
 flowchart LR
   subgraph pdm-run-composite [pdm run composite]
     direction LR
@@ -222,7 +236,7 @@ but it will be overridden as soon as the `--skip` parameter is provided.
 
 Given the previous script block, running `pdm run --skip=:pre,post_test composite` will result in the following reduced lifecycle:
 
-``` mermaid
+```mermaid
 flowchart LR
   subgraph pdm-run-composite [pdm run composite]
     direction LR

--- a/news/1163.feature.md
+++ b/news/1163.feature.md
@@ -1,0 +1,1 @@
+Add a `post_use` hook triggered after succesfully switching Python version.

--- a/pdm/cli/actions.py
+++ b/pdm/cli/actions.py
@@ -588,10 +588,13 @@ def do_use(
     python: str = "",
     first: bool = False,
     ignore_remembered: bool = False,
+    hooks: HookManager | None = None,
 ) -> None:
     """Use the specified python version and save in project config.
     The python can be a version string or interpreter path.
     """
+    hooks = hooks or HookManager(project)
+
     if python:
         python = python.strip()
 
@@ -673,6 +676,7 @@ def do_use(
     ):
         project.core.ui.echo("Updating executable scripts...", style="cyan")
         project.environment.update_shebangs(selected_python.executable.as_posix())
+    hooks.try_emit("post_use", python=selected_python)
 
 
 def do_import(

--- a/pdm/cli/commands/init.py
+++ b/pdm/cli/commands/init.py
@@ -35,6 +35,7 @@ class Command(BaseCommand):
         parser.set_defaults(search_parent=False)
 
     def handle(self, project: Project, options: argparse.Namespace) -> None:
+        hooks = HookManager(project, options.skip)
         if project.pyproject_file.exists():
             project.core.ui.echo(
                 "pyproject.toml already exists, update it now.", style="cyan"
@@ -44,9 +45,9 @@ class Command(BaseCommand):
         self.set_interactive(not options.non_interactive)
 
         if self.interactive:
-            actions.do_use(project)
+            actions.do_use(project, hooks=hooks)
         else:
-            actions.do_use(project, "3", True)
+            actions.do_use(project, "3", True, hooks=hooks)
         is_library = (
             termui.confirm(
                 "Is the project a library that will be uploaded to PyPI", default=False
@@ -79,7 +80,7 @@ class Command(BaseCommand):
             author=author,
             email=email,
             python_requires=python_requires,
-            hooks=HookManager(project, options.skip),
+            hooks=hooks,
         )
         if self.interactive:
             actions.ask_for_import(project)

--- a/pdm/cli/commands/use.py
+++ b/pdm/cli/commands/use.py
@@ -2,6 +2,8 @@ import argparse
 
 from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
+from pdm.cli.hooks import HookManager
+from pdm.cli.options import skip_option
 from pdm.project import Project
 
 
@@ -9,6 +11,7 @@ class Command(BaseCommand):
     """Use the given python version or path as base interpreter"""
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        skip_option.add_to_parser(parser)
         parser.add_argument(
             "-f",
             "--first",
@@ -27,5 +30,9 @@ class Command(BaseCommand):
 
     def handle(self, project: Project, options: argparse.Namespace) -> None:
         actions.do_use(
-            project, options.python, options.first, options.ignore_remembered
+            project,
+            python=options.python,
+            first=options.first,
+            ignore_remembered=options.ignore_remembered,
+            hooks=HookManager(project, options.skip),
         )

--- a/pdm/signals.py
+++ b/pdm/signals.py
@@ -115,3 +115,10 @@ Args:
     script (str): the script name
     args (Sequence[str]): the command line provided arguments
 """
+post_use: NamedSignal = pdm_signals.signal("post_use")
+"""Called after use switched to a new Python version.
+
+Args:
+    project (Project): The project object
+    python (PythonInfo): Informations about the new Python interpreter
+"""

--- a/tests/cli/test_hooks.py
+++ b/tests/cli/test_hooks.py
@@ -214,6 +214,7 @@ KNOWN_COMMAND_HOOKS = (
     ("remove", "remove requests", ("pre_lock", "post_lock"), ["lock"]),
     ("sync", "sync", ("pre_install", "post_install"), ["lock"]),
     ("update", "update", ("pre_install", "post_install", "pre_lock", "post_lock"), []),
+    ("use", "use -f 3.7", ("post_use",), []),
 )
 
 parametrize_with_commands = pytest.mark.parametrize(

--- a/tests/cli/test_others.py
+++ b/tests/cli/test_others.py
@@ -131,9 +131,16 @@ def test_init_non_interactive(project_no_init, invoke, mocker):
         return_value=("Testing", "me@example.org"),
     )
     do_init = mocker.patch.object(actions, "do_init")
+    do_use = mocker.patch.object(actions, "do_use")
     result = invoke(["init", "-n"], obj=project_no_init)
     assert result.exit_code == 0
     python_version = f"{project_no_init.python.major}.{project_no_init.python.minor}"
+    do_use.assert_called_once_with(
+        project_no_init,
+        ANY,
+        True,
+        hooks=ANY,
+    )
     do_init.assert_called_with(
         project_no_init,
         name="",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,7 +297,11 @@ def project_no_init(tmp_path, mocker, core, index):
     )
     tmp_path.joinpath("caches").mkdir(parents=True)
     p.global_config["cache_dir"] = tmp_path.joinpath("caches").as_posix()
-    do_use(p, getattr(sys, "_base_executable", sys.executable))
+    do_use(
+        p,
+        getattr(sys, "_base_executable", sys.executable),
+        HookManager(p, ["post_use"]),
+    )
     with temp_environ():
         os.environ.pop("VIRTUAL_ENV", None)
         os.environ.pop("CONDA_PREFIX", None)


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

This PR adds a `post_use` hook which was missing while being very useful.
In my use case, a `pdm-vscode`extensions (WIP) it allows the extension to automatically update `VSCode` settings when you switch Python version.

As there are already many hooks, I didn't add the `pre_use` but I can.