### PR TITLE
Improve the cli parser to fix the duplicate usage on error

### DIFF
--- a/pdm/cli/utils.py
+++ b/pdm/cli/utils.py
@@ -27,7 +27,7 @@ from resolvelib.structs import DirectedGraph
 from rich.tree import Tree
 
 from pdm import termui
-from pdm.exceptions import PdmUsageError, ProjectError
+from pdm.exceptions import PdmArgumentError, PdmUsageError, ProjectError
 from pdm.formats import FORMATS
 from pdm.formats.base import make_array, make_inline_table
 from pdm.models.repositories import BaseRepository
@@ -47,6 +47,23 @@ if TYPE_CHECKING:
 
     from pdm.compat import Distribution
     from pdm.models.candidates import Candidate
+
+
+class ErrorArgumentParser(argparse.ArgumentParser):
+    """A subclass of argparse.ArgumentParser that raises
+    parsing error rather than exiting.
+
+    This does the same as passing exit_on_error=False on Python 3.9+
+    """
+
+    def _parse_known_args(
+        self, arg_strings: list[str], namespace: argparse.Namespace
+    ) -> tuple[argparse.Namespace, list[str]]:
+        try:
+            return super()._parse_known_args(arg_strings, namespace)
+        except argparse.ArgumentError as e:
+            # We raise a dedicated error to avoid being caught by the caller
+            raise PdmArgumentError(e) from e
 
 
 class PdmFormatter(argparse.RawDescriptionHelpFormatter):

--- a/pdm/exceptions.py
+++ b/pdm/exceptions.py
@@ -10,6 +10,10 @@ class PdmException(Exception):
     pass
 
 
+class PdmArgumentError(PdmException):
+    pass
+
+
 class PdmUsageError(PdmException):
     pass
 


### PR DESCRIPTION
## Pull Request Check List

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
Before this change, when running script shortcuts with `pdm <script>`, the error message will show before the script is run. This is because when `SystemExit` is caught, the error message has been shown already.

I fixed this by raising a custom error instead, making it not caught by the default handler, and handle the error ourselves.