### PR TITLE
chore: change the project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 <div align="center">
 
-# PDM - Python Development Master
+# PDM
 
-A modern Python package manager with [PEP 582] support. [中文版本说明](README_zh.md)
+A modern Python package and dependency manager supporting the latest PEP standards.
+[中文版本说明](README_zh.md)
 
 ![PDM logo](https://raw.githubusercontent.com/pdm-project/pdm/main/docs/docs/assets/logo_big.png)
 
@@ -46,11 +47,12 @@ Read more about the specification [here](https://www.python.org/dev/peps/pep-058
 ## Highlights of features
 
 - [PEP 582] local package installer and runner, no virtualenv involved at all.
-- Simple and relatively fast dependency resolver, mainly for large binary distributions.
+- Simple and fast dependency resolver, mainly for large binary distributions.
 - A [PEP 517] build backend.
-- A flexible yet powerful plug-in system.
-- [PEP 621] project metadata format.
-- Opted-in centralized installation cache like [pnpm].
+- [PEP 621] project metadata.
+- Flexible and powerful plug-in system.
+- Versatile user scripts.
+- Opt-in centralized installation cache like [pnpm](https://pnpm.io/motivation#saving-disk-space-and-boosting-installation-speed).
 
 [pep 517]: https://www.python.org/dev/peps/pep-0517
 [pep 582]: https://www.python.org/dev/peps/pep-0582

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-# PDM - Python Development Master
+# PDM
 
-一个现代的 Python 包管理器，支持 [PEP 582]。[English version README](README.md)
+一个现代的 Python 包管理器，支持 PEP 最新标准。[English version README](README.md)
 
 ![PDM logo](https://raw.githubusercontents.com/pdm-project/pdm/main/docs/docs/assets/logo_big.png)
 
@@ -47,6 +47,7 @@ foo
 - 兼容 [PEP 517] 的构建后端，用于构建发布包(源码格式与 wheel 格式)
 - 灵活且强大的插件系统
 - [PEP 621] 元数据格式
+- 功能强大的用户脚本
 - 像 [pnpm] 一样的中心化安装缓存，节省磁盘空间
 
 [pep 517]: https://www.python.org/dev/peps/pep-0517

--- a/docs/docs/dev/benchmark.md
+++ b/docs/docs/dev/benchmark.md
@@ -100,7 +100,7 @@ Running benchmark: Poetry version 1.1.12
               Install dependencies: 17.82s
        Add dependencies with cache: 43.90s
     Add dependencies without cache: 37.24s
-Running benchmark: Python Development Master (PDM), version 1.11.2
+Running benchmark: PDM, version 1.11.2
    Lock dependencies without cache: 27.56s
       Lock dependencies with cache: 21.91s
               Install dependencies: 12.16s

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,21 +4,25 @@
 
 # Introduction
 
-PDM is a modern Python package manager with [PEP 582] support. It installs and manages packages
+PDM, as described, is a modern Python package and dependency manager supporting the latest PEP standards. But it is more than a package manager. It boosts your development workflow in various aspects. The most significant benefit is it installs and manages packages
 in a similar way to `npm` that doesn't need to create a virtualenv at all!
 
 <script id="asciicast-jnifN30pjfXbO9We2KqOdXEhB" src="https://asciinema.org/a/jnifN30pjfXbO9We2KqOdXEhB.js" async></script>
 
-[pep 582]: https://www.python.org/dev/peps/pep-0582/
-
 ## Feature highlights
 
-- PEP 582 local package installer and runner, no virtualenv involved at all.
-- Simple and relatively fast dependency resolver, mainly for large binary distributions.
-- A PEP 517 build backend.
-- PEP 621 project metadata.
-- Flexible yet powerful plug-in system.
-- Opted-in centralized installation cache like [pnpm](https://pnpm.io/motivation#saving-disk-space-and-boosting-installation-speed).
+- [PEP 582] local package installer and runner, no virtualenv involved at all.
+- Simple and fast dependency resolver, mainly for large binary distributions.
+- A [PEP 517] build backend.
+- [PEP 621] project metadata.
+- Flexible and powerful plug-in system.
+- Versatile user scripts.
+- Opt-in centralized installation cache like [pnpm](https://pnpm.io/motivation#saving-disk-space-and-boosting-installation-speed).
+
+[pep 517]: https://www.python.org/dev/peps/pep-0517
+[pep 582]: https://www.python.org/dev/peps/pep-0582
+[pep 621]: https://www.python.org/dev/peps/pep-0621
+[pnpm]: https://pnpm.io/motivation#saving-disk-space-and-boosting-installation-speed
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "requests-toolbelt",
 ]
 name = "pdm"
-description = "Python Development Master"
+description = "A modern Python package and dependency manager supporting the latest PEP standards"
 readme = "README.md"
 keywords = ["packaging", "dependency", "workflow"]
 classifiers = [


### PR DESCRIPTION
## Pull Request Check List

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

- Change the project description to not highlighting PEP 582
- Remove the Python Development Master from the tagline. We don't explicitly declare the full expanded name of PDM, while users can derive it from the description: `a modern Python package and dependency manager supporting the latest PEP standards`
- Supersedes #1064