### PR TITLE
Fixed zsh completion for pep582 flag

### DIFF
--- a/news/correct-zsh-completion.md
+++ b/news/correct-zsh-completion.md
@@ -1,1 +1,1 @@
-Fixed a bug with `zsh` completion regarding --pep582 flag.
+Fixed a bug with `zsh` completion regarding `--pep582` flag.

--- a/news/correct-zsh-completion.md
+++ b/news/correct-zsh-completion.md
@@ -1,0 +1,1 @@
+Fixed a bug with `zsh` completion regarding --pep582 flag.

--- a/pdm/cli/completions/pdm.zsh
+++ b/pdm/cli/completions/pdm.zsh
@@ -43,7 +43,7 @@ _pdm() {
     {-c,--config}'[Specify another config file path(env var: PDM_CONFIG_FILE)]' \
     {-V,--version}'[Show the version and exit]' \
     {-I,--ignore-python}'[Ignore the Python path saved in the .pdm.toml config]' \
-    '--pep582=[Print the command line to be eval by the shell]:shell:(zsh bash fish tcsh csh)' \
+    '--pep582:Print the command line to be eval by the shell:shell:(zsh bash fish tcsh csh)' \
     '*:: :->_subcmds' \
     && return 0
 


### PR DESCRIPTION
## Pull Request Check List
- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

Fixed the `invalid option definition` in the pdm zsh completion for the --pep582 flag.

The exact error was `_arguments:comparguments:327: invalid option definition: --pep582=[Print the command line to be eval by the shell]:shell:(zsh bash fish tcsh csh)`.

Images:

The problem:
![faulty](https://user-images.githubusercontent.com/109092228/178343460-928a9941-0ac9-43bd-a6f1-8ecb5a6737dd.png)

The fix:
![corrected](https://user-images.githubusercontent.com/109092228/178343494-9dd3bfc0-50c5-4969-b466-3006ec1cf38a.png)