### PR TITLE
fix: write lockfile before post_lock hook

### DIFF
--- a/news/1224.bugfix.md
+++ b/news/1224.bugfix.md
@@ -1,0 +1,1 @@
+Write lockfile before calling 'post_lock' hook

--- a/pdm/cli/actions.py
+++ b/pdm/cli/actions.py
@@ -120,9 +120,8 @@ def do_lock(
         else:
             data = format_lockfile(project, mapping, dependencies)
             ui.echo(f"{termui.Emoji.LOCK} Lock successful")
+            project.write_lockfile(data, write=not dry_run)
             hooks.try_emit("post_lock", resolution=mapping, dry_run=dry_run)
-
-    project.write_lockfile(data, write=not dry_run)
 
     return mapping
 


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
Now lockfile is written before `post_lock` hook. Fixes #1224 