### PR TITLE
fix: suppress errors when cache dir isn't accessible

### DIFF
--- a/news/1226.bugfix.md
+++ b/news/1226.bugfix.md
@@ -1,0 +1,1 @@
+Suppress errors when cache dir isn't accessible.

--- a/pdm/project/core.py
+++ b/pdm/project/core.py
@@ -644,7 +644,11 @@ dependencies = ["pip", "setuptools", "wheel"]
 
     def cache(self, name: str) -> Path:
         path = self.cache_dir / name
-        path.mkdir(parents=True, exist_ok=True)
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            # The path could be not accessible
+            pass
         return path
 
     def make_wheel_cache(self) -> WheelCache:


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
Fix #1226