### PR TITLE
env_file variables do not override existing

### DIFF
--- a/news/1235.feature
+++ b/news/1235.feature
@@ -1,0 +1,1 @@
+env_file variables no longer override existing environment variables.

--- a/pdm/cli/commands/run.py
+++ b/pdm/cli/commands/run.py
@@ -123,7 +123,7 @@ class TaskRunner:
     ) -> int:
         """Run command in a subprocess and return the exit code."""
         project = self.project
-        process_env = os.environ.copy()
+        process_env = {}
         if env_file:
             import dotenv
 
@@ -132,9 +132,10 @@ class TaskRunner:
                 err=True,
                 verbosity=termui.Verbosity.DETAIL,
             )
-            process_env.update(
-                dotenv.dotenv_values(project.root / env_file, encoding="utf-8")
+            process_env = dotenv.dotenv_values(
+                project.root / env_file, encoding="utf-8"
             )
+        process_env.update(os.environ)
         pythonpath = process_env.get("PYTHONPATH", "").split(os.pathsep)
         pythonpath = [PEP582_PATH] + [
             p for p in pythonpath if "pdm/pep582" not in p.replace("\\", "/")


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

This changes the logic when using an env_file such that any
environment variables defined within it do not override existing set
environment variables. This matches the default logic of dotenv and
should match user expectations.