### PR TITLE
Fix locking sort bug

### DIFF
--- a/news/1256.bugfix.md
+++ b/news/1256.bugfix.md
@@ -1,0 +1,1 @@
+Stabilize sorting of URLs in `metadata.files` in `pdm.lock`.

--- a/pdm/cli/utils.py
+++ b/pdm/cli/utils.py
@@ -465,7 +465,7 @@ def format_lockfile(
                 continue
             array = tomlkit.array().multiline(True)
             for link, hash_value in sorted(
-                v.hashes.items(), key=lambda l: l[0].filename
+                v.hashes.items(), key=lambda l_h: (l_h[0].url_without_fragment, l_h[1])
             ):
                 inline = make_inline_table(
                     {"url": link.url_without_fragment, "hash": hash_value}

--- a/pdm/resolver/core.py
+++ b/pdm/resolver/core.py
@@ -20,11 +20,10 @@ def resolve(
     max_rounds: int = 10000,
 ) -> tuple[dict[str, Candidate], dict[str, list[Requirement]]]:
     """Core function to perform the actual resolve process.
-    Return a tuple containing 3 items:
+    Return a tuple containing 2 items:
 
         1. A map of pinned candidates
         2. A map of resolved dependencies for each dependency group
-        3. A map of package descriptions fetched from PyPI source
     """
     requirements.append(PythonRequirement.from_pyspec_set(requires_python))
     provider = cast(BaseProvider, resolver.provider)

--- a/tests/cli/test_lock.py
+++ b/tests/cli/test_lock.py
@@ -30,24 +30,23 @@ def test_lock_refresh(invoke, project, repository):
     assert project.is_lockfile_hash_match()
     assert not project.lockfile["metadata"]["files"].get("requests 2.19.1")
     project.add_dependencies({"requests": parse_requirement("requests>=2.0")})
-    repository.get_hashes = (
-        lambda c: {
-            Link(
-                "http://example.com/requests-2.19.1-py3-none-any.whl"
-            ): "sha256:abcdef123456"
-        }
+    url_hashes = {
+        "http://example.com/requests-2.19.1-py3-none-any.whl": "sha256:abcdef123456",
+        "http://example2.com/requests-2.19.1-py3-none-AMD64.whl": "sha256:abcdef123456",
+        "http://example1.com/requests-2.19.1-py3-none-any.whl": "sha256:abcdef123456",
+    }
+    repository.get_hashes = lambda c: (
+        {Link(url): hash for url, hash in url_hashes.items()}
         if c.identify() == "requests"
         else {}
     )
-    print(project.lockfile)
     assert not project.is_lockfile_hash_match()
     result = invoke(["lock", "--refresh", "-v"], obj=project)
     assert result.exit_code == 0
     assert project.is_lockfile_hash_match()
-    assert project.lockfile["metadata"]["files"]["requests 2.19.1"][0] == {
-        "url": "http://example.com/requests-2.19.1-py3-none-any.whl",
-        "hash": "sha256:abcdef123456",
-    }
+    assert project.lockfile["metadata"]["files"]["requests 2.19.1"] == [
+        {"url": url, "hash": hash} for url, hash in sorted(url_hashes.items())
+    ]
 
 
 def test_lock_refresh_keep_consistent(invoke, project, repository):


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.


    Make pdm.lock metadata.files sorting idempotent

    In #1203 pdm.lock was changed to store a list of URLs rather than wheel
    names. That change caused a regression because we were sorting the
    output based on filename only, not the full URL.

    This caused unnecessary lockfile changes in our CI environment.


Fixes #1256