### PR TITLE
fix: Crashes when executing pdm show for an sdist

### DIFF
--- a/news/1276.bugfix.md
+++ b/news/1276.bugfix.md
@@ -1,0 +1,1 @@
+Do not crash when calling `pdm show` for a package that is only available as source distribution.

--- a/pdm/models/project_info.py
+++ b/pdm/models/project_info.py
@@ -23,10 +23,17 @@ class ProjectInfo:
         metadata = cast(Message, data.metadata)
         keywords = metadata.get("Keywords", "").replace(",", ", ")
         platform = metadata.get("Platform", "").replace(",", ", ")
-        project_urls = {
-            k.strip(): v.strip()
-            for k, v in (row.split(",") for row in metadata.get_all("Project-URL", []))
-        }
+
+        if "Project-URL" in metadata:
+            project_urls = {
+                k.strip(): v.strip()
+                for k, v in (
+                    row.split(",") for row in metadata.get_all("Project-URL", [])
+                )
+            }
+        else:
+            project_urls = {}
+
         return {
             "name": metadata["Name"],
             "version": metadata["Version"],

--- a/tests/cli/test_others.py
+++ b/tests/cli/test_others.py
@@ -121,6 +121,10 @@ def test_show_package_on_pypi(invoke):
     assert result.exit_code == 0
     assert "requests" in result.output.splitlines()[0]
 
+    result = invoke(["show", "--name", "sphinx-data-viewer"])
+    assert result.exit_code == 0
+    assert "sphinx-data-viewer" in result.output.splitlines()[0]
+
 
 def test_show_self_package(project, invoke):
     result = invoke(["show"], obj=project)


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

This fixes #1276.
