### PR TITLE
Add pdm export to available pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: pdm-export
+  name: pdm-export-lock
+  description: export locked packages to requirements.txt or setup.py
+  entry: pdm export
+  language: python
+  language_version: python3
+  pass_filenames: false
+  files: ^pdm.lock$  

--- a/docs/docs/usage/advanced.md
+++ b/docs/docs/usage/advanced.md
@@ -221,3 +221,21 @@ Below is a sample code snippet showing how to make PDM work with [lsp-python-ms]
                (require 'lsp-python-ms)
                (lsp))))  ; or lsp-deferred
 ```
+## Hooks for `pre-commit`
+
+[`pre-commit`](https://pre-commit.com/) is a powerful framework for managing git hooks in a centralized fashion. PDM already uses `pre-commit` [hooks](https://github.com/pdm-project/pdm/blob/main/.pre-commit-config.yaml) for its internal QA checks. PDM exposes also several hooks that can be run locally or in CI pipelines.
+
+### Export `requirements.txt` or `setup.py`
+
+This hook wraps the command `pdm export` along with any valid argument. It can be used as a hook (e.g., for CI) to ensure that you are going to check in the codebase a `requirements.txt` or a `setup.py` file, which reflects the actual content of [`pdm lock`](cli_reference.md#exec-0--lock).
+
+```yaml
+# export python requirements
+- repo: https://github.com/pdm-project/pdm
+  rev: 2.x.y # a PDM release exposing the hook
+  hooks:
+    - id: pdm-export
+      # command arguments, e.g.:
+      args: ["-o", "requirements.txt", "--without-hashes"]
+      files: ^pdm.lock$
+```

--- a/docs/docs/usage/project.md
+++ b/docs/docs/usage/project.md
@@ -244,6 +244,9 @@ pdm export -o requirements.txt
 pdm export -f setuppy -o setup.py
 ```
 
+!!! NOTE
+    You can also run `pdm export` with a [`.pre-commit` hook](advanced.md#hooks-for-pre-commit).
+
 ## Hide the credentials from pyproject.toml
 
 There are many times when we need to use sensitive information, such as login credentials for the PyPI server

--- a/news/1279.feature.md
+++ b/news/1279.feature.md
@@ -1,0 +1,1 @@
+Add `pdm export` to available pre-commit hooks.


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code. (not available)
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Added `pdm export` to available pre-commit hooks. This can be used for CI pipelines. The file `pre-commit-hooks.yaml` can be expanded in the future with other hooks to expose.

Updated the doc accordingly.
