### PR TITLE
fix: set minimum version for `packaging` dependency

### DIFF
--- a/news/1293.bugfix.md
+++ b/news/1293.bugfix.md
@@ -1,0 +1,1 @@
+Set a minimum version for the `packaging` dependency to ensure that `packaging.utils.parse_wheel_filename` is available.

--- a/pdm.lock
+++ b/pdm.lock
@@ -669,7 +669,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "4.0"
-content_hash = "sha256:3599f06dba4e270c8ae0f9f46e7735fcc1814b14ed8f64c361381283b9b20c85"
+content_hash = "sha256:a9dc66cb6756fcca7ca2659c9d80e1b367f29d4591185bc4f575e4c430db6a8d"
 
 [metadata.files]
 "arpeggio 1.10.2" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.7"
 license = {text = "MIT"}
 dependencies = [
     "blinker",
-    "packaging",
+    "packaging>=20.9",
     "platformdirs",
     "rich>=12.3.0",
     "virtualenv>=20",


### PR DESCRIPTION
Fixes #1293.

## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

I've set the minimum version of `packaging` to 20.9 in `pyproject.toml`, which I think should resolve the issue.