### PR TITLE
Add an override option to the env_file script option

### DIFF
--- a/docs/docs/usage/scripts.md
+++ b/docs/docs/usage/scripts.md
@@ -146,6 +146,15 @@ start.cmd = "flask run -p 54321"
 start.env_file = ".env"
 ```
 
+The variables within the dotenv file will *not* override any existing environment variables.
+If you want the dotenv file to override existing environment variables use the following:
+
+```toml
+[tool.pdm.scripts]
+start.cmd = "flask run -p 54321"
+start.env_file.override = ".env"
+```
+
 !!! note
     A dotenv file specified on a composite task level will override those defined by called tasks.
 

--- a/news/1299.feature
+++ b/news/1299.feature
@@ -1,0 +1,4 @@
+Add a env_file.override option that allows the user to specify that
+the env_file should override any existing environment variables. This
+is not the default as the environment the code runs it should take
+precedence.


### PR DESCRIPTION
This allows the user to specify that the env_file should override any
existing environment variables. This is not the default as the
environment the code runs it should take precedence.

## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.
