### PR TITLE
Clean up documentation related to new setup-script

### DIFF
--- a/news/1327.doc.md
+++ b/news/1327.doc.md
@@ -1,0 +1,1 @@
+Clarify documentation explaining `setup-script`, `run-setuptools`, and `is-purelib`.


### PR DESCRIPTION
Since the behavior changes with run-setuptools, and since is-purelib
also changes, it was a little confusing how everything was intended to
work. After reading the code I updated the documentation to be more
clear.

See also a similar pull request in pdm-pep517: https://github.com/pdm-project/pdm-pep517/pull/116

#1327