### PR TITLE
Pyre: name has type `str` but is used as type `None`

### DIFF
--- a/src/pdm/cli/options.py
+++ b/src/pdm/cli/options.py
@@ -59,7 +59,7 @@ class ArgumentGroup(Option):
 
     def __init__(
         self,
-        name: str = None,
+        name: str,
         is_mutually_exclusive: bool = False,
         required: bool = None,
     ) -> None:


### PR DESCRIPTION
"filename": "pdm/cli/options.py"
"warning_type": "Incompatible variable type [9]",
"warning_message": " name is declared to have type `str` but is used as type `None`.",
"warning_line": 62
"fix": remove none