### PR TITLE
feat: Add venv.prompt config to allow customizing prompt when venv is…

### DIFF
--- a/docs/docs/usage/configuration.md
+++ b/docs/docs/usage/configuration.md
@@ -29,6 +29,7 @@ The following configuration items can be retrieved and modified by [`pdm config`
 | `strategy.resolve_max_rounds`     | Specify the max rounds of resolution process                              | 1000                                                                      | Yes                  | `PDM_RESOLVE_MAX_ROUNDS` |
 | `venv.location`                   | Parent directory for virtualenvs                                          | `<default data location on OS>/venvs`                                     | No                   |                          |
 | `venv.backend`                    | Default backend to create virtualenv                                      | `virtualenv`                                                              | Yes                  | `PDM_VENV_BACKEND`       |
+| `venv.prompt`                     | Formatted string to be displayed in the prompt when virtualenv is active  | `{project_name}-{python_version}`                                         | Yes                  | `PDM_VENV_PROMPT`        |
 | `venv.in-project`                 | Create virtualenv in `.venv` under project root                           | `False`                                                                   | Yes                  | `PDM_VENV_IN_PROJECT`    |
 
 _If the corresponding env var is set, the value will take precedence over what is saved in the config file._

--- a/docs/docs/usage/venv.md
+++ b/docs/docs/usage/venv.md
@@ -71,7 +71,7 @@ Instead of spawning a subshell like what `pipenv` and `poetry` do, `pdm-venv` do
 
     ```bash
     $ eval $(pdm venv activate for-test)
-    (test-project-8Sgn_62n-for-test) $  # Virtualenv entered
+    (test-project-for-test) $  # Virtualenv entered
     Fish
 
     $ eval (pdm venv activate for-test)
@@ -99,6 +99,30 @@ Instead of spawning a subshell like what `pipenv` and `poetry` do, `pdm-venv` do
     `venv activate` **does not** switch the Python interpreter used by the project. It only changes the shell by injecting the virtualenv paths to environment variables. For the forementioned purpose, use the `pdm use` command.
 
 For more CLI usage, see the [`pdm venv`](cli_reference.md#exec-0--venv) documentation.
+
+## Prompt customization
+
+By default when you activate a virtualenv, the prompt will show: `{project_name}-{python_version}`.
+
+For example if your project is named `test-project`:
+
+
+```bash
+$ eval $(pdm venv activate for-test)
+(test-project-3.10) $  # {project_name} == test-project and {python_version} == 3.10
+```
+
+The format can be customized before virtualenv creation with the [`venv.prompt`](configuration.md) configuration or `PDM_VENV_PROMPT` environment variable (before a `pdm init` or `pdm venv create`).
+Available variables are:
+
+ - `project_name`: name of your project
+ - `python_version`: version of Python (used by the virtualenv)
+
+```bash
+$ PDM_VENV_PROMPT='{project_name}-py{python_version}' pdm venv create --name test-prompt
+$ eval $(pdm venv activate test-prompt)
+(test-project-py3.10) $
+```
 
 ## Disable virtualenv mode
 

--- a/news/1332.feature.md
+++ b/news/1332.feature.md
@@ -1,0 +1,1 @@
+Add `venv.prompt` configuration to allow customizing prompt when a virtualenv is activated

--- a/src/pdm/cli/commands/venv/backends.py
+++ b/src/pdm/cli/commands/venv/backends.py
@@ -5,11 +5,11 @@ import sys
 from pathlib import Path
 from typing import Any, List, Mapping, Optional, Tuple, Type
 
-from pdm.project import Project
 from pdm import termui
 from pdm.cli.commands.venv.utils import get_venv_prefix
 from pdm.exceptions import PdmUsageError, ProjectError
 from pdm.models.python import PythonInfo
+from pdm.project import Project
 from pdm.utils import cached_property
 
 
@@ -88,11 +88,18 @@ class Backend(abc.ABC):
         args: Tuple[str, ...] = (),
         force: bool = False,
         in_project: bool = False,
+        prompt: Optional[str] = None,
     ) -> Path:
         if in_project:
             location = self.project.root / ".venv"
         else:
             location = self.get_location(name)
+        if prompt is not None:
+            prompt_string = prompt.format(
+                project_name=self.project.root.name.lower() or "virtualenv",
+                python_version=self.ident,
+            )
+            args = (*args, f"--prompt={prompt_string}")
         self._ensure_clean(location, force)
         self.perform_create(location, args)
         return location

--- a/src/pdm/cli/commands/venv/create.py
+++ b/src/pdm/cli/commands/venv/create.py
@@ -1,9 +1,9 @@
 import argparse
 
 from pdm.cli.commands.base import BaseCommand
-from pdm.project import Project
 from pdm.cli.commands.venv.backends import BACKENDS
 from pdm.cli.options import verbose_option
+from pdm.project import Project
 
 
 class CreateCommand(BaseCommand):
@@ -47,12 +47,13 @@ class CreateCommand(BaseCommand):
             and not options.name
             and not project.root.joinpath(".venv").exists()
         )
+        prompt = project.config["venv.prompt"]
         backend: str = options.backend or project.config["venv.backend"]
         venv_backend = BACKENDS[backend](project, options.python)
         with project.core.ui.open_spinner(
             f"Creating virtualenv using [green]{backend}[/]..."
         ):
             path = venv_backend.create(
-                options.name, options.venv_args, options.force, in_project
+                options.name, options.venv_args, options.force, in_project, prompt
             )
         project.core.ui.echo(f"Virtualenv [green]{path}[/] is created successfully")

--- a/src/pdm/project/config.py
+++ b/src/pdm/project/config.py
@@ -234,6 +234,13 @@ class Config(MutableMapping[str, str]):
             env_var="PDM_VENV_IN_PROJECT",
             coerce=ensure_boolean,
         ),
+        "venv.prompt": ConfigItem(
+            "Define a custom template to be displayed in the prompt when virtualenv is"
+            "active. Variables `project_name` and `python_version` are available for"
+            "formatting",
+            default="{project_name}-{python_version}",
+            env_var="PDM_VENV_PROMPT",
+        ),
     }
 
     site: Config | None = None

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -282,7 +282,9 @@ class Project:
         backend: str = self.config["venv.backend"]
         venv_backend = BACKENDS[backend](self, None)
         path = venv_backend.create(
-            force=True, in_project=self.config["venv.in_project"]
+            force=True,
+            in_project=self.config["venv.in_project"],
+            prompt=self.config["venv.prompt"],
         )
         self.core.ui.echo(
             f"Virtualenv is created successfully at [green]{path}[/]", err=True

--- a/tests/cli/test_venv.py
+++ b/tests/cli/test_venv.py
@@ -111,6 +111,17 @@ def test_venv_activate(invoke, mocker, project):
         assert result.output.startswith("source")
 
 
+@pytest.mark.usefixtures("venv_backends")
+def test_venv_activate_custom_prompt(invoke, mocker, project):
+    project.project_config["venv.in_project"] = False
+    creator = mocker.patch("pdm.cli.commands.venv.backends.Backend.create")
+    result = invoke(["venv", "create"], obj=project)
+    assert result.exit_code == 0, result.stderr
+    creator.assert_called_once_with(
+        None, [], False, False, project.project_config["venv.prompt"]
+    )
+
+
 def test_venv_activate_project_without_python(invoke, project):
     project.project_config.pop("python.path", None)
     result = invoke(["venv", "activate"], obj=project)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -443,5 +443,6 @@ BACKENDS = ["virtualenv", "venv"]
 @pytest.fixture(params=BACKENDS)
 def venv_backends(project, request):
     project.project_config["venv.backend"] = request.param
+    project.project_config["venv.prompt"] = "{project_name}-{python_version}"
     project.project_config["python.use_venv"] = True
     shutil.rmtree(project.root / "__pypackages__", ignore_errors=True)


### PR DESCRIPTION
… activated

## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

This MR adds a new config `venv.prompt` that is used during venv creation (`init` and `venv create`). This variable contains a string format that will be printed when activating a virtualenv.
Two variables can be used `project_name` and `python_version`.  The default format is: `{project_name}-{python_version}`


Related to #1332 
