### PR TITLE
fix: pass `pypi.[ca,client]_cert[s]` to install step of builders

### DIFF
--- a/news/1396.bugfix.md
+++ b/news/1396.bugfix.md
@@ -1,0 +1,1 @@
+Ensure `pypi.[ca,client]_cert[s]` config items are passed to distribution builder install steps to allow for custom PyPI index sources with self signed certificates.

--- a/src/pdm/builders/base.py
+++ b/src/pdm/builders/base.py
@@ -289,6 +289,12 @@ class EnvBuilder:
                 "--prefix",
                 path,
             ]
+            ca_certs = self._env.project.config.get("pypi.ca_certs")
+            if ca_certs is not None:
+                cmd.extend(["--cert", ca_certs])
+            client_cert = self._env.project.config.get("pypi.client_cert")
+            if client_cert is not None:
+                cmd.extend(["--client-cert", client_cert])
             cmd.extend(prepare_pip_source_args(self._env.project.sources))
             cmd.extend(["-r", req_file.name])
             self.subprocess_runner(cmd, isolated=False)


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

I looked if it would be feasible to add a unit test by monkey patching subprocess and then checking the arguments to the `pip` command for `pdm.builders.base.EnvBuilder.install`, but I was unsure how to do so without further code re-factoring.

## Describe what you have changed in this PR.

Fix #1396.