### PR TITLE
Replace deprecated `set-output` command with `GITHUB_OUTPUT` file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,8 @@ jobs:
       - name: Set Variables
         id: set_variables
         run: |
-          echo "::set-output name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-          echo "::set-output name=PIP_CACHE::$(pip cache dir)"
+          echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_OUTPUT
+          echo "PIP_CACHE=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: Cache PIP
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
           architecture: ${{ matrix.arch }}
       - name: Set Variables
         id: set_variables
+        shell: bash
         run: |
           echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_OUTPUT
           echo "PIP_CACHE=$(pip cache dir)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
GitHub deprecated set-output command, recommend using GITHUB_OUTPUT environment file instead:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Current warnings in [CI](https://github.com/pdm-project/pdm/actions/runs/3241934222/jobs/5314532917):
![image](https://user-images.githubusercontent.com/10510431/195601386-dca5ff33-5f67-4bfa-a11e-c3c90e593b49.png)

