### PR TITLE
style(cli): vertically align config output

### DIFF
--- a/news/1447.feature.md
+++ b/news/1447.feature.md
@@ -1,0 +1,1 @@
+Vertically align `pdm config` output

--- a/src/pdm/cli/commands/config.py
+++ b/src/pdm/cli/commands/config.py
@@ -65,6 +65,10 @@ class Command(BaseCommand):
         self, config: Mapping[str, Any], supersedes: Mapping[str, Any]
     ) -> None:
         assert Config.site is not None
+        key_length_max = 0
+        for key in sorted(config):
+            key_len = len(key)
+            key_length_max = key_len if key_len > key_length_max else key_length_max
         for key in sorted(config):
             deprecated = ""
             canonical_key = key
@@ -84,7 +88,7 @@ class Command(BaseCommand):
                 verbosity=termui.Verbosity.DETAIL,
             )
             self.ui.echo(
-                f"[cyan]{canonical_key}[/]{deprecated} = {config[key]}",
+                f"[cyan]{canonical_key:<{key_length_max}}[/]{deprecated} = {config[key]}",
                 style=extra_style or None,
             )
 

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -7,7 +7,7 @@ from pdm.utils import cd
 def test_config_command(project, invoke):
     result = invoke(["config"], obj=project)
     assert result.exit_code == 0
-    assert "python.use_pyenv = True" in result.output
+    assert "python.use_pyenv                = True" in result.output
 
     result = invoke(["config", "-v"], obj=project)
     assert result.exit_code == 0


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.
Vertically aligned `pdm config` output for better visibility, for example (the full example is in the linked issue below)
```
key = 1
keylong = 2  becomes
key     = 1 (padded to align by =)
keylong = 2
```

closes https://github.com/pdm-project/pdm/issues/1447