### PR TITLE
add `--check` flag to `pdm lock`

### DIFF
--- a/news/1459.feature.md
+++ b/news/1459.feature.md
@@ -1,0 +1,1 @@
+A new `pdm lock --check` flag to validate whether the lock is up to date.

--- a/src/pdm/cli/commands/lock.py
+++ b/src/pdm/cli/commands/lock.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
                 sys.exit(1)
             else:
                 project.core.ui.echo(
-                    "Lockfile is [success]up to date[/].",
+                    f"{termui.Emoji.SUCC} Lockfile is [success]up to date[/].",
                     err=True,
                     verbosity=Verbosity.DETAIL,
                 )

--- a/src/pdm/cli/commands/lock.py
+++ b/src/pdm/cli/commands/lock.py
@@ -1,12 +1,12 @@
 import argparse
 import sys
 
+from pdm import termui
 from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.hooks import HookManager
 from pdm.cli.options import lockfile_option, no_isolation_option, skip_option
 from pdm.project import Project
-from pdm.termui import Verbosity
 
 
 class Command(BaseCommand):
@@ -38,14 +38,14 @@ class Command(BaseCommand):
                 project.core.ui.echo(
                     f"{termui.Emoji.FAIL} Lockfile is [error]out of date[/].",
                     err=True,
-                    verbosity=Verbosity.DETAIL,
+                    verbosity=termui.Verbosity.DETAIL,
                 )
                 sys.exit(1)
             else:
                 project.core.ui.echo(
                     f"{termui.Emoji.SUCC} Lockfile is [success]up to date[/].",
                     err=True,
-                    verbosity=Verbosity.DETAIL,
+                    verbosity=termui.Verbosity.DETAIL,
                 )
                 sys.exit(0)
 

--- a/src/pdm/cli/commands/lock.py
+++ b/src/pdm/cli/commands/lock.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             strategy = actions.check_lockfile(project, False)
             if strategy:
                 project.core.ui.echo(
-                    "Lockfile is [error]out of date[/].",
+                    f"{termui.Emoji.FAIL} Lockfile is [error]out of date[/].",
                     err=True,
                     verbosity=Verbosity.DETAIL,
                 )

--- a/tests/cli/test_lock.py
+++ b/tests/cli/test_lock.py
@@ -60,6 +60,27 @@ def test_lock_refresh_keep_consistent(invoke, project, repository):
     assert project.lockfile_file.read_text() == previous
 
 
+def test_lock_check_no_change_success(invoke, project, repository):
+    project.add_dependencies({"requests": parse_requirement("requests")})
+    result = invoke(["lock"], obj=project)
+    assert result.exit_code == 0
+    assert project.is_lockfile_hash_match()
+
+    result = invoke(["lock", "--check"], obj=project)
+    assert result.exit_code == 0
+
+
+def test_lock_check_change_fails(invoke, project, repository):
+    project.add_dependencies({"requests": parse_requirement("requests")})
+    result = invoke(["lock"], obj=project)
+    assert result.exit_code == 0
+    assert project.is_lockfile_hash_match()
+
+    project.add_dependencies({"pyyaml": parse_requirement("pyyaml")})
+    result = invoke(["lock", "--check"], obj=project)
+    assert result.exit_code == 1
+
+
 @pytest.mark.usefixtures("repository")
 def test_innovations_with_specified_lockfile(invoke, project, working_set):
     project.add_dependencies({"requests": parse_requirement("requests")})


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Added a `--check` flag to `pdm lock` as discussed in #1459.  I followed the pattern from install, which I wasn't aware of. I do think `lock --check` is a more logical check and easier to discover.

<img width="391" alt="image" src="https://user-images.githubusercontent.com/8234817/197726649-2eb60805-8aed-40c4-9cf2-557c5be9285e.png">