### PR TITLE
Fix finding interpreters if file matches spec

### DIFF
--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -632,10 +632,9 @@ class Project:
                     python = find_python_in_path(python_spec)
                     if python:
                         yield PythonInfo.from_path(python)
-                else:
-                    python = shutil.which(python_spec)
-                    if python:
-                        yield PythonInfo.from_path(python)
+                python = shutil.which(python_spec)
+                if python:
+                    yield PythonInfo.from_path(python)
                 return
             args = [int(v) for v in python_spec.split(".") if v != ""]
         finder = self._get_python_finder()


### PR DESCRIPTION
Before this fix, when running `pdm use python` if there was a file or folder named `python` then the code would not look for other installed interpreters.

fixes #1523

## Pull Request Check List

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
