### PR TITLE
docs: clarify the behavior of includes

### DIFF
--- a/docs/docs/pyproject/build.md
+++ b/docs/docs/pyproject/build.md
@@ -95,6 +95,10 @@ excludes = [
 ]
 ```
 
+!!! note
+
+	When using `includes` the default includes will be overriden. You have to add the package paths manually.
+
 In case you may want some files to be included in source distributions only, use the `source-includes` field:
 
 ```toml


### PR DESCRIPTION
The behavior of `includes` seems to imply that any files listed will be *added* to the package itself. However the latter has to be also explicitly included. This can cause confusion when adding `includes` for the first time in an already existing package, whereby the package itself will suddenly disappear from the build. Clarify this in the documentaion.

Fixes https://github.com/pdm-project/pdm/issues/1531

## Pull Request Check List

- [ ] A news fragment is added in `news/` describing what is new. N/A
- [ ] Test cases added for changed code. N/A

## Describe what you have changed in this PR.
