### PR TITLE
fix: egg segment for local dependency

### DIFF
--- a/news/1552.bugfix.md
+++ b/news/1552.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug with egg segment for local dependency

--- a/src/pdm/models/requirements.py
+++ b/src/pdm/models/requirements.py
@@ -30,6 +30,7 @@ from pdm.utils import (
     add_ssh_scheme_to_git_uri,
     normalize_name,
     path_to_url,
+    path_without_fragments,
     url_to_path,
     url_without_fragments,
 )
@@ -292,11 +293,11 @@ class FileRequirement(Requirement):
             path = get_relative_path(self.url)
             if path is None:
                 try:
-                    self.path = Path(url_to_path(self.url))
+                    self.path = path_without_fragments(url_to_path(self.url))
                 except AssertionError:
                     pass
             else:
-                self.path = Path(path)
+                self.path = path_without_fragments(path)
         if self.url:
             self._parse_name_from_url()
 
@@ -305,7 +306,7 @@ class FileRequirement(Requirement):
         if self.path is None or self.path.is_absolute():
             return
         # self.path is relative
-        self.path = Path(os.path.relpath(self.path, backend.root))
+        self.path = path_without_fragments(os.path.relpath(self.path, backend.root))
         self.url = backend.relative_path_to_url(self.path.as_posix())
 
     @property

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -410,3 +410,8 @@ def is_pip_compatible_with_python(python_version: Version | str) -> bool:
     pip = importlib_metadata.distribution("pip")
     requires_python = get_specifier(pip.metadata["Requires-Python"])
     return requires_python.contains(python_version, True)
+
+
+def path_without_fragments(path: str) -> Path:
+    """Remove egg fragment from path"""
+    return Path(path.split("#")[0])

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -25,6 +25,8 @@ from packaging.version import Version
 from pdm._types import Source
 from pdm.compat import Distribution
 
+_egg_fragment_re = re.compile(r"(.*)[#&]egg=[^&]*")
+
 
 def create_tracked_tempdir(
     suffix: str | None = None, prefix: str | None = None, dir: str | None = None
@@ -414,4 +416,7 @@ def is_pip_compatible_with_python(python_version: Version | str) -> bool:
 
 def path_without_fragments(path: str) -> Path:
     """Remove egg fragment from path"""
-    return Path(path.split("#")[0])
+    match = _egg_fragment_re.search(path)
+    if not match:
+        return Path(path)
+    return Path(match.group(1))

--- a/tests/fixtures/projects/demo-#-with-hash/demo.py
+++ b/tests/fixtures/projects/demo-#-with-hash/demo.py
@@ -1,0 +1,5 @@
+import os
+
+import chardet
+
+print(os.name)

--- a/tests/fixtures/projects/demo-#-with-hash/setup.py
+++ b/tests/fixtures/projects/demo-#-with-hash/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+
+setup(
+    name="demo",
+    version="0.0.1",
+    description="test demo",
+    py_modules=["demo"],
+    python_requires=">=3.3",
+    install_requires=["idna", "chardet; os_name=='nt'"],
+    extras_require={
+        "tests": ["pytest"],
+        "security": ['requests; python_version>="3.6"'],
+    },
+)

--- a/tests/models/test_candidates.py
+++ b/tests/models/test_candidates.py
@@ -125,6 +125,7 @@ def test_parse_abnormal_specifiers(project):
         "demo @ file:///${PROJECT_ROOT}/tests/fixtures/artifacts/demo-0.0.1.tar.gz",
         "demo @ file:///${PROJECT_ROOT}/tests/fixtures/projects/demo",
         "-e ./tests/fixtures/projects/demo",
+        "-e file:///${PROJECT_ROOT}/tests/fixtures/projects/demo#egg=demo",
     ],
 )
 def test_expand_project_root_in_url(req_str, core):

--- a/tests/models/test_candidates.py
+++ b/tests/models/test_candidates.py
@@ -126,6 +126,7 @@ def test_parse_abnormal_specifiers(project):
         "demo @ file:///${PROJECT_ROOT}/tests/fixtures/projects/demo",
         "-e ./tests/fixtures/projects/demo",
         "-e file:///${PROJECT_ROOT}/tests/fixtures/projects/demo#egg=demo",
+        "-e file:///${PROJECT_ROOT}/tests/fixtures/projects/demo-#-with-hash#egg=demo",
     ],
 )
 def test_expand_project_root_in_url(req_str, core):


### PR DESCRIPTION
## Pull Request Check List

- [X] A news fragment is added in `news/` describing what is new.
- [X] Test cases added for changed code.

## Describe what you have changed in this PR.

The command `pdm add -e ./demo --dev` result on a line added to pyproject.toml

```
dev = [
    "-e file:///${PROJECT_ROOT}/demo#egg=demo",
]
```

Any following `pdm add` will result on an error

```
Adding packages to dev dev-dependencies: -e file:///${PROJECT_ROOT}/demo#egg=demo
[RequirementError]: Editable requirement is only supported for VCS link or local directory.
```