### PR TITLE
fix: Strip the local part when building a specifier for comparison

### DIFF
--- a/news/1562.bugfix.md
+++ b/news/1562.bugfix.md
@@ -1,0 +1,1 @@
+Strip the local part when building a specifier for comparison with the package version. This is not permitted by PEP 508 as implemented by `packaging 22.0`.

--- a/src/pdm/models/requirements.py
+++ b/src/pdm/models/requirements.py
@@ -17,7 +17,6 @@ from packaging.requirements import InvalidRequirement
 from packaging.requirements import Requirement as PackageRequirement
 from packaging.specifiers import SpecifierSet
 from packaging.utils import parse_sdist_filename, parse_wheel_filename
-from packaging.version import parse as parse_version
 from unearth import Link
 
 from pdm.compat import Distribution
@@ -28,6 +27,7 @@ from pdm.models.setup import Setup
 from pdm.models.specifiers import PySpecSet, get_specifier
 from pdm.utils import (
     add_ssh_scheme_to_git_uri,
+    comparable_version,
     normalize_name,
     path_to_url,
     path_without_fragments,
@@ -110,11 +110,7 @@ class Requirement:
         """Return a new requirement with the given pinned version."""
         if self.is_pinned or not other_version:
             return self
-        version = parse_version(other_version)
-        normalized = str(version)
-        if version.local:
-            # Remove the local part to accept wider range of prereleases.
-            normalized = normalized.rsplit("+", 1)[0]
+        normalized = comparable_version(other_version)
         return dataclasses.replace(self, specifier=get_specifier(f"=={normalized}"))
 
     def _hash_key(self) -> tuple:

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -334,6 +334,15 @@ def normalize_name(name: str, lowercase: bool = True) -> str:
     return name.lower() if lowercase else name
 
 
+def comparable_version(version: str) -> Version:
+    """Normalize a version to make it valid in a specifier."""
+    parsed = Version(version)
+    if parsed.local is not None:
+        # strip the local part
+        parsed._version = parsed._version._replace(local=None)
+    return parsed
+
+
 def is_egg_link(dist: Distribution) -> bool:
     """Check if the distribution is an egg-link install"""
     return getattr(dist, "link_file", None) is not None

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -314,3 +314,11 @@ def test_add_editable_package_with_extras(project, working_set):
     assert "demo" in working_set
     assert "requests" in working_set
     assert "urllib3" in working_set
+
+
+def test_add_package_with_local_version(project, repository, working_set):
+    repository.add_candidate("foo", "1.0-alpha.0+local")
+    actions.do_add(project, packages=["foo"], save="minimum")
+    assert working_set["foo"].version == "1.0-alpha.0+local"
+    dependencies, _ = project.get_pyproject_dependencies("default")
+    assert dependencies[0] == "foo>=1.0a0"

--- a/tests/resolver/test_resolve.py
+++ b/tests/resolver/test_resolve.py
@@ -67,20 +67,20 @@ def test_resolve_requires_python(resolve):
 
 def test_resolve_allow_prereleases(resolve, repository):
     repository.add_candidate("foo", "1.0.0")
-    repository.add_candidate("foo", "1.1.0a0")
-    repository.add_candidate("bar", "1.0.0b0")
+    repository.add_candidate("foo", "1.1.0-alpha")
+    repository.add_candidate("bar", "1.0.0-beta")
 
     result = resolve(["foo"])
     assert result["foo"].version == "1.0.0"
 
     result = resolve(["foo"], allow_prereleases=True)
-    assert result["foo"].version == "1.1.0a0"
+    assert result["foo"].version == "1.1.0-alpha"
 
     result = resolve(["foo==1.1.0a0"])
-    assert result["foo"].version == "1.1.0a0"
+    assert result["foo"].version == "1.1.0-alpha"
 
     result = resolve(["bar"])
-    assert result["bar"].version == "1.0.0b0"
+    assert result["bar"].version == "1.0.0-beta"
 
     with pytest.raises(Exception):
         resolve(["bar"], allow_prereleases=False)


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.
Close #1562