### PR TITLE
feat: remove usages of __file__ to support pdm in a zipapp

### DIFF
--- a/news/1567bugfix.md
+++ b/news/1567bugfix.md
@@ -1,0 +1,1 @@
+Replace the `__file__` usages with `importlib.resources`, to make PDM usable in a zipapp.

--- a/pdm.lock
+++ b/pdm.lock
@@ -636,7 +636,7 @@ summary = "Backported and Experimental Type Hints for Python 3.7+"
 
 [[package]]
 name = "unearth"
-version = "0.6.3"
+version = "0.7.0"
 requires_python = ">=3.7"
 summary = "A utility to fetch and download python packages"
 dependencies = [
@@ -682,7 +682,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:6755aecb54d7bb7c54b6e91bbc89a98ac5c0c2b3919edb80df61c5e48e7c8471"
+content_hash = "sha256:f254c34c79d74f03c95611ff3a7ce24e90be361c2cf880136a26675ad15580bf"
 
 [metadata.files]
 "arpeggio 1.10.2" = [
@@ -1144,9 +1144,9 @@ content_hash = "sha256:6755aecb54d7bb7c54b6e91bbc89a98ac5c0c2b3919edb80df61c5e48
     {url = "https://files.pythonhosted.org/packages/0b/8e/f1a0a5a76cfef77e1eb6004cb49e5f8d72634da638420b9ea492ce8305e8/typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
     {url = "https://files.pythonhosted.org/packages/e3/a7/8f4e456ef0adac43f452efc2d0e4b242ab831297f1bac60ac815d37eb9cf/typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
 ]
-"unearth 0.6.3" = [
-    {url = "https://files.pythonhosted.org/packages/31/2c/138768b7b6fc9e8084dd76f0b6a5803b6d4bbd49c06353a0188e6bb7a23e/unearth-0.6.3-py3-none-any.whl", hash = "sha256:efc42738f254d34f61381766f88d5218e27e64b6f4210e9e1cb8be346d1da0e7"},
-    {url = "https://files.pythonhosted.org/packages/c5/06/4eeb23ba770f73cb403ed9655e08592700b5601bed1016783773d928dd61/unearth-0.6.3.tar.gz", hash = "sha256:3b7e494b0b13a8bd15d54c7c85870d2c051d912846263d16da671ff7bd8eef4f"},
+"unearth 0.7.0" = [
+    {url = "https://files.pythonhosted.org/packages/5b/ad/c99b111829958996d104cf55cf772069dcd457696fbc96d8afa75e891c84/unearth-0.7.0-py3-none-any.whl", hash = "sha256:a7120c4dfcbf275340458a9557810601a8bd805affd80a20c459a18b0c24fa15"},
+    {url = "https://files.pythonhosted.org/packages/f9/8d/e072c0b76ecc9fb38dde79d0037fbc806deebb5207af24515f44f209bf79/unearth-0.7.0.tar.gz", hash = "sha256:cf54411b37b7a941f3cdfdf29aeee2bf18164a8afca35c467b97feab626e671e"},
 ]
 "urllib3 1.26.10" = [
     {url = "https://files.pythonhosted.org/packages/25/36/f056e5f1389004cf886bb7a8514077f24224238a7534497c014a6b9ac770/urllib3-1.26.10.tar.gz", hash = "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "virtualenv>=20",
     "pyproject-hooks",
     "requests-toolbelt",
-    "unearth>=0.6.3",
+    "unearth>=0.7",
     "findpython>=0.2.2",
     "tomlkit>=0.11.1,<1",
     "shellingham>=1.3.2",

--- a/src/pdm/__version__.py
+++ b/src/pdm/__version__.py
@@ -1,17 +1,11 @@
-from __future__ import annotations
-
-from packaging.version import Version, parse
-
 from pdm.compat import importlib_metadata
 
 
 def read_version() -> str:
-    return importlib_metadata.version(__package__)
+    return importlib_metadata.version(__package__ or "pdm")
 
 
 try:
     __version__ = read_version()
-    parsed_version: Version | None = parse(__version__)
 except importlib_metadata.PackageNotFoundError:
-    __version__ = "UNKNOWN"
-    parsed_version = None
+    __version__ = "0.0.0+local"

--- a/src/pdm/cli/actions.py
+++ b/src/pdm/cli/actions.py
@@ -26,6 +26,7 @@ from pdm.cli.utils import (
     find_importable_files,
     format_lockfile,
     format_resolution_impossible,
+    get_pep582_path,
     merge_dictionary,
     save_version_specifiers,
     set_env_in_reg,
@@ -44,8 +45,6 @@ from pdm.models.specifiers import get_specifier
 from pdm.project import Project
 from pdm.resolver import resolve
 from pdm.utils import cd, normalize_name
-
-PEP582_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "pep582")
 
 
 def do_lock(
@@ -752,13 +751,16 @@ def ask_for_import(project: Project) -> None:
     do_import(project, str(filepath), key)
 
 
-def print_pep582_command(ui: termui.UI, shell: str = "AUTO") -> None:
+def print_pep582_command(project: Project, shell: str = "AUTO") -> None:
     """Print the export PYTHONPATH line to be evaluated by the shell."""
     import shellingham
 
+    pep582_path = get_pep582_path(project)
+    ui = project.core.ui
+
     if os.name == "nt":
         try:
-            set_env_in_reg("PYTHONPATH", PEP582_PATH)
+            set_env_in_reg("PYTHONPATH", pep582_path)
         except PermissionError:
             ui.echo(
                 "Permission denied, please run the terminal as administrator.",
@@ -771,7 +773,7 @@ def print_pep582_command(ui: termui.UI, shell: str = "AUTO") -> None:
             style="success",
         )
         return
-    lib_path = PEP582_PATH.replace("'", "\\'")
+    lib_path = pep582_path.replace("'", "\\'")
     if shell == "AUTO":
         shell = shellingham.detect_shell()[0]
     shell = shell.lower()

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -12,11 +12,10 @@ from types import FrameType
 from typing import Any, Callable, Iterator, Mapping, NamedTuple, Sequence, cast
 
 from pdm import signals, termui
-from pdm.cli.actions import PEP582_PATH
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.hooks import KNOWN_HOOKS, HookManager
 from pdm.cli.options import skip_option
-from pdm.cli.utils import check_project_file
+from pdm.cli.utils import check_project_file, get_pep582_path
 from pdm.compat import TypedDict
 from pdm.exceptions import PdmUsageError
 from pdm.project import Project
@@ -165,7 +164,7 @@ class TaskRunner:
             else:
                 process_env = {**dotenv_env, **process_env}
         pythonpath = process_env.get("PYTHONPATH", "").split(os.pathsep)
-        pythonpath = [PEP582_PATH] + [
+        pythonpath = [get_pep582_path(project)] + [
             p for p in pythonpath if "pdm/pep582" not in p.replace("\\", "/")
         ]
         project_env = project.environment

--- a/src/pdm/cli/commands/self_cmd.py
+++ b/src/pdm/cli/commands/self_cmd.py
@@ -241,7 +241,7 @@ class UpdateCommand(BaseCommand):
         )
 
     def handle(self, project: Project, options: argparse.Namespace) -> None:
-        from pdm.__version__ import parsed_version, read_version
+        from pdm.__version__ import __version__, read_version
 
         if options.head:
             package = f"pdm @ git+{PDM_REPO}@main"
@@ -249,10 +249,8 @@ class UpdateCommand(BaseCommand):
         else:
             version = get_latest_pdm_version_from_pypi(project, options.pre)
             assert version is not None, "No version found"
-            if parsed_version and parsed_version >= parse(version):
-                project.core.ui.echo(
-                    f"Already up-to-date: [primary]{parsed_version}[/]"
-                )
+            if parse(__version__) >= parse(version):
+                project.core.ui.echo(f"Already up-to-date: [primary]{__version__}[/]")
                 return
             package = f"pdm=={version}"
         pip_args = ["install", "--upgrade"] + shlex.split(options.pip_args) + [package]

--- a/src/pdm/cli/utils.py
+++ b/src/pdm/cli/utils.py
@@ -724,3 +724,15 @@ def get_dist_location(dist: Distribution) -> str:
         editable = direct_url_data.get("dir_info", {}).get("editable", False)
         return f"{'-e ' if editable else ''}{path}"
     return ""
+
+
+def get_pep582_path(project: Project) -> str:
+    import importlib.resources
+
+    script_dir = project.global_config.config_file.parent / "pep582"
+    if script_dir.joinpath("sitecustomize.py").exists():
+        return str(script_dir)
+    script_dir.mkdir(parents=True, exist_ok=True)
+    with importlib.resources.open_binary("pdm.pep582", "sitecustomize.py") as f:
+        script_dir.joinpath("sitecustomize.py").write_bytes(f.read())
+    return str(script_dir)

--- a/src/pdm/core.py
+++ b/src/pdm/core.py
@@ -169,7 +169,7 @@ class Core:
             os.environ["PDM_IGNORE_SAVED_PYTHON"] = "1"
 
         if options.pep582:
-            print_pep582_command(self.ui, options.pep582)
+            print_pep582_command(project, options.pep582)
             sys.exit(0)
 
         if root_script and root_script not in project.scripts:

--- a/src/pdm/models/in_process/__init__.py
+++ b/src/pdm/models/in_process/__init__.py
@@ -9,20 +9,13 @@ import importlib.resources
 import json
 import os
 import subprocess
-import tempfile
 from typing import Any, Generator
 
 
 @contextlib.contextmanager
 def _in_process_script(name: str) -> Generator[str, None, None]:
-    with importlib.resources.open_binary(__name__, name) as f:
-        fp, name = tempfile.mkstemp(".py", prefix="pdm_in_process_")
-        with os.fdopen(fp, "wb") as tmp:
-            tmp.write(f.read())
-    try:
-        yield name
-    finally:
-        os.remove(name)
+    with importlib.resources.path(__name__, name) as script:
+        yield str(script)
 
 
 @functools.lru_cache()

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -405,10 +405,10 @@ def deprecation_warning(
     """Show a deprecation warning with the given message and raise an error
     after a specified version.
     """
-    from pdm.__version__ import parsed_version
+    from pdm.__version__ import __version__
 
-    if raise_since is not None and parsed_version:
-        if parsed_version >= Version(raise_since):
+    if raise_since is not None:
+        if Version(__version__) >= Version(raise_since):
             raise DeprecationWarning(message)
     warnings.warn(message, DeprecationWarning, stacklevel=stacklevel + 1)
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -9,7 +9,7 @@ import pytest
 
 from pdm import termui
 from pdm.cli import actions
-from pdm.cli.actions import PEP582_PATH
+from pdm.cli.utils import get_pep582_path
 from pdm.utils import cd
 
 
@@ -35,7 +35,7 @@ def test_pep582_launcher_for_python_interpreter(project, local_finder, invoke):
     result = invoke(["add", "first"], obj=project)
     assert result.exit_code == 0, result.stderr
     env = os.environ.copy()
-    env.update({"PYTHONPATH": PEP582_PATH})
+    env.update({"PYTHONPATH": get_pep582_path(project)})
     output = subprocess.check_output(
         [str(project.python.executable), str(project.root.joinpath("main.py"))],
         env=env,
@@ -45,7 +45,7 @@ def test_pep582_launcher_for_python_interpreter(project, local_finder, invoke):
 
 def test_auto_isolate_site_packages(project, invoke):
     env = os.environ.copy()
-    env.update({"PYTHONPATH": PEP582_PATH})
+    env.update({"PYTHONPATH": get_pep582_path(project)})
     proc = subprocess.run(
         [str(project.python.executable), "-c", "import sys;print(sys.path, sep='\\n')"],
         env=env,


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Use `importlib.resources` to read script or data inside the package, to replace the usages of `__file__` variable. This will enable PDM to be used in a zipapp.

## TODO

- [x] Update `unearth` to support being used in ziapp
- [x] Provide a way to get the PDM version in zipapp