### PR TITLE
feat(pytest): expose pytest fixtures and helpers for pdm plugins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,4 @@ repos:
         additional_dependencies:
           - types-requests
           - types-certifi
+          - pytest

--- a/docs/docs/plugin/fixtures.md
+++ b/docs/docs/plugin/fixtures.md
@@ -1,0 +1,8 @@
+# Pytest fixtures
+
+::: pdm.pytest
+    options:
+      show_source: false
+      show_root_heading: false
+      show_root_toc_entry: false
+      heading_level: 2

--- a/docs/docs/plugin/reference.md
+++ b/docs/docs/plugin/reference.md
@@ -1,7 +1,13 @@
 # API Reference
 
 ::: pdm.core.Core
-    rendering:
+    options:
+      show_root_heading: yes
+      show_source: false
+      heading_level: 2
+
+::: pdm.core.Project
+    options:
       show_root_heading: yes
       show_source: false
       heading_level: 2
@@ -11,5 +17,5 @@
 _New in version 1.12.0_
 
 ::: pdm.signals
-    rendering:
+    options:
       heading_level: 3

--- a/docs/docs/plugin/write.md
+++ b/docs/docs/plugin/write.md
@@ -122,7 +122,7 @@ Besides of commands and configurations, the `core` object exposes some other met
 PDM also provides some signals you can listen to.
 Please read the [API reference](reference.md) for more details.
 
-### Tips about developing a PDM plugin.
+### Tips about developing a PDM plugin
 
 When developing a plugin, one hopes to activate and plugin in development and get updated when the code changes. This is usually done
 by `pip install -e .` or `python setup.py develop` in the **traditional** Python packaging world which leverages `setup.py` to do so. However,
@@ -139,6 +139,30 @@ After that, all the dependencies are available with a compatible Python interpre
 to the codebase will take effect immediately without re-installation. The `pdm` executable also uses a Python interpreter under the hood,
 so if you run `pdm` from inside the plugin project, the plugin in development will be activated automatically, and you can do some testing to see how it works.
 That is how PEP 582 benefits our development workflow.
+
+### Testing your plugin
+
+PDM exposes some pytest fixtures as a plugin in the [`pdm.pytest`](fixtures.md) module.
+To benefit from them, you must add `pdm[pytest]` as a test dependency.
+
+To enable them in your test, add `pdm.pytest` as a plugin. You can do so by in your root `conftest.py`:
+
+```python title="conftest.py"
+# single plugin
+pytest_plugins = "pytest.plugin"
+
+# many plugins
+pytest_plugins = [
+    ...
+    "pdm.pytest",
+    ...
+]
+```
+
+You can see some usage examples into PDM own [tests](https://github.com/pdm-project/pdm/tree/main/tests), especially the [conftest.py file](https://github.com/pdm-project/pdm/blob/main/tests/conftest.py) for configuration.
+
+See the [pytest fixtures documentation](fixtures.md) for more details.
+
 
 ## Publish your plugin
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -35,7 +35,7 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          selection:
+          options:
             docstring_style: google
 
 nav:
@@ -57,6 +57,7 @@ nav:
   - Plugins:
       - plugin/write.md
       - plugin/reference.md
+      - plugin/fixtures.md
   - Development:
       - dev/contributing.md
       - dev/changelog.md
@@ -92,3 +93,7 @@ extra:
       link: https://twitter.com/pdm_project
     - icon: fontawesome/brands/discord
       link: https://discord.gg/Phn8smztpv
+
+
+watch:
+  - ../src

--- a/news/1594.feature.md
+++ b/news/1594.feature.md
@@ -1,0 +1,1 @@
+- Expose PDM fixtures as a `pytest` plugin `pdm.pytest` for plugin developers.

--- a/pdm.lock
+++ b/pdm.lock
@@ -4,12 +4,6 @@ version = "1.10.2"
 summary = "Packrat parser interpreter"
 
 [[package]]
-name = "atomicwrites"
-version = "1.4.1"
-requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-summary = "Atomic file writes."
-
-[[package]]
 name = "attrs"
 version = "21.4.0"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -109,6 +103,12 @@ dependencies = [
 name = "distlib"
 version = "0.3.6"
 summary = "Distribution utilities"
+
+[[package]]
+name = "exceptiongroup"
+version = "1.1.0"
+requires_python = ">=3.7"
+summary = "Backport of PEP 654 (exception groups)"
 
 [[package]]
 name = "execnet"
@@ -420,19 +420,18 @@ dependencies = [
 
 [[package]]
 name = "pytest"
-version = "7.1.2"
+version = "7.2.0"
 requires_python = ">=3.7"
 summary = "pytest: simple powerful testing with Python"
 dependencies = [
-    "atomicwrites>=1.0; sys_platform == \"win32\"",
     "attrs>=19.2.0",
     "colorama; sys_platform == \"win32\"",
+    "exceptiongroup>=1.0.0rc8; python_version < \"3.11\"",
     "importlib-metadata>=0.12; python_version < \"3.8\"",
     "iniconfig",
     "packaging",
     "pluggy<2.0,>=0.12",
-    "py>=1.8.2",
-    "tomli>=1.0.0",
+    "tomli>=1.0.0; python_version < \"3.11\"",
 ]
 
 [[package]]
@@ -682,15 +681,12 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:f254c34c79d74f03c95611ff3a7ce24e90be361c2cf880136a26675ad15580bf"
+content_hash = "sha256:3573097107d6cf81f6a30eff58707084307ada33ef53200e28424340e5d57cec"
 
 [metadata.files]
 "arpeggio 1.10.2" = [
     {url = "https://files.pythonhosted.org/packages/1a/ae/a2dfd99042b8952e86ea6cd6ad5ba8b81c3f9f150e24475cf55e09fbe3e4/Arpeggio-1.10.2-py2.py3-none-any.whl", hash = "sha256:fed68a1cb7f529cbd4d725597cc811b7506885fcdef17d4cdcf564341a1e210b"},
     {url = "https://files.pythonhosted.org/packages/8d/4b/042f027e6b818350f4863509884559f0fc744df8c5c36f4a084511b9457a/Arpeggio-1.10.2.tar.gz", hash = "sha256:bfe349f252f82f82d84cb886f1d5081d1a31451e6045275e9f90b65d0daa06f1"},
-]
-"atomicwrites 1.4.1" = [
-    {url = "https://files.pythonhosted.org/packages/87/c6/53da25344e3e3a9c01095a89f16dbcda021c609ddb42dd6d7c0528236fb2/atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
 ]
 "attrs 21.4.0" = [
     {url = "https://files.pythonhosted.org/packages/be/be/7abce643bfdf8ca01c48afa2ddf8308c2308b0c3b239a44e57d020afa0ef/attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
@@ -777,6 +773,10 @@ content_hash = "sha256:f254c34c79d74f03c95611ff3a7ce24e90be361c2cf880136a26675ad
 "distlib 0.3.6" = [
     {url = "https://files.pythonhosted.org/packages/58/07/815476ae605bcc5f95c87a62b95e74a1bce0878bc7a3119bc2bf4178f175/distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
     {url = "https://files.pythonhosted.org/packages/76/cb/6bbd2b10170ed991cf64e8c8b85e01f2fb38f95d1bc77617569e0b0b26ac/distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
+]
+"exceptiongroup 1.1.0" = [
+    {url = "https://files.pythonhosted.org/packages/15/ab/dd27fb742b19a9d020338deb9ab9a28796524081bca880ac33c172c9a8f6/exceptiongroup-1.1.0.tar.gz", hash = "sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23"},
+    {url = "https://files.pythonhosted.org/packages/e8/14/9c6a7e5f12294ccd6975a45e02899ed25468cd7c2c86f3d9725f387f9f5f/exceptiongroup-1.1.0-py3-none-any.whl", hash = "sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e"},
 ]
 "execnet 1.9.0" = [
     {url = "https://files.pythonhosted.org/packages/7a/3c/b5ac9fc61e1e559ced3e40bf5b518a4142536b34eb274aa50dff29cb89f5/execnet-1.9.0.tar.gz", hash = "sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5"},
@@ -1010,9 +1010,9 @@ content_hash = "sha256:f254c34c79d74f03c95611ff3a7ce24e90be361c2cf880136a26675ad
     {url = "https://files.pythonhosted.org/packages/25/c1/374304b8407d3818f7025457b7366c8e07768377ce12edfe2aa58aa0f64c/pyproject_hooks-1.0.0.tar.gz", hash = "sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5"},
     {url = "https://files.pythonhosted.org/packages/d5/ea/9ae603de7fbb3df820b23a70f6aff92bf8c7770043254ad8d2dc9d6bcba4/pyproject_hooks-1.0.0-py3-none-any.whl", hash = "sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8"},
 ]
-"pytest 7.1.2" = [
-    {url = "https://files.pythonhosted.org/packages/4e/1f/34657c6ac56f3c58df650ba41f8ffb2620281ead8e11bcdc7db63cf72a78/pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
-    {url = "https://files.pythonhosted.org/packages/fb/d0/bae533985f2338c5d02184b4a7083b819f6b3fc101da792e0d96e6e5299d/pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
+"pytest 7.2.0" = [
+    {url = "https://files.pythonhosted.org/packages/0b/21/055f39bf8861580b43f845f9e8270c7786fe629b2f8562ff09007132e2e7/pytest-7.2.0.tar.gz", hash = "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"},
+    {url = "https://files.pythonhosted.org/packages/67/68/a5eb36c3a8540594b6035e6cdae40c1ef1b6a2bfacbecc3d1a544583c078/pytest-7.2.0-py3-none-any.whl", hash = "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71"},
 ]
 "pytest-cov 3.0.0" = [
     {url = "https://files.pythonhosted.org/packages/20/49/b3e0edec68d81846f519c602ac38af9db86e1e71275528b3e814ae236063/pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
@@ -1107,10 +1107,6 @@ content_hash = "sha256:f254c34c79d74f03c95611ff3a7ce24e90be361c2cf880136a26675ad
 "setuptools 65.6.3" = [
     {url = "https://files.pythonhosted.org/packages/b6/21/cb9a8d0b2c8597c83fce8e9c02884bce3d4951e41e807fc35791c6b23d9a/setuptools-65.6.3.tar.gz", hash = "sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75"},
     {url = "https://files.pythonhosted.org/packages/ef/e3/29d6e1a07e8d90ace4a522d9689d03e833b67b50d1588e693eec15f26251/setuptools-65.6.3-py3-none-any.whl", hash = "sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54"},
-]
-"shellingham 1.5.0" = [
-    {url = "https://files.pythonhosted.org/packages/3d/1a/d31fce69c119df1fddab3706b63c53d363982c55d841d9c3839b12f15327/shellingham-1.5.0-py2.py3-none-any.whl", hash = "sha256:a8f02ba61b69baaa13facdba62908ca8690a94b8119b69f5ec5873ea85f7391b"},
-    {url = "https://files.pythonhosted.org/packages/bd/e6/fdf53ebbf08016dba98f2b047d4db95790157f0e2eed3b14bb5754271475/shellingham-1.5.0.tar.gz", hash = "sha256:72fb7f5c63103ca2cb91b23dee0c71fe8ad6fbfd46418ef17dbe40db51592dad"},
 ]
 "six 1.16.0" = [
     {url = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ Documentation = "https://pdm.fming.dev"
 Changelog = "https://pdm.fming.dev/latest/dev/changelog/"
 
 [project.optional-dependencies]
+pytest = [
+    "pytest",
+    "pytest-mock",
+]
 
 [project.scripts]
 pdm = "pdm.core:main"
@@ -76,9 +80,8 @@ complete = {call = "tasks.complete:main", help = "Create autocomplete files for 
 
 [tool.pdm.dev-dependencies]
 test = [
-    "pytest",
+    "pdm[pytest]",
     "pytest-cov",
-    "pytest-mock",
     "pytest-xdist>=1.31.0",
     "pytest-rerunfailures>=10.2",
 ]

--- a/src/pdm/pytest.py
+++ b/src/pdm/pytest.py
@@ -1,0 +1,665 @@
+"""
+Some reusable fixtures for `pytest`.
+
+_New in version 2.4.0_
+
+To enable them in your test, add `pdm.pytest` as a plugin.
+You can do so in your root `conftest.py`:
+
+```python title="conftest.py"
+# single plugin
+pytest_plugins = "pytest.plugin"
+
+# many plugins
+pytest_plugins = [
+    ...
+    "pdm.pytest",
+    ...
+]
+```
+"""
+from __future__ import annotations
+
+import collections
+import json
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from io import BufferedReader, BytesIO, StringIO
+from pathlib import Path
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    BinaryIO,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    Mapping,
+    Tuple,
+    Union,
+    cast,
+)
+from urllib.parse import urlparse
+
+import pytest
+import requests
+from packaging.version import parse as parse_version
+from pytest_mock import MockerFixture
+from unearth import Link
+
+from pdm.cli.actions import do_init
+from pdm.cli.hooks import HookManager
+from pdm.compat import Protocol
+from pdm.core import Core
+from pdm.exceptions import CandidateInfoNotFound
+from pdm.installers.installers import install_wheel
+from pdm.models.backends import get_backend
+from pdm.models.candidates import Candidate
+from pdm.models.environment import Environment, PrefixEnvironment
+from pdm.models.repositories import BaseRepository
+from pdm.models.requirements import (
+    Requirement,
+    filter_requirements_with_extras,
+    parse_requirement,
+)
+from pdm.models.session import PDMSession
+from pdm.project.config import Config
+from pdm.project.core import Project
+from pdm.utils import find_python_in_path, normalize_name, path_to_url
+
+if TYPE_CHECKING:
+    from _pytest.fixtures import SubRequest
+
+    from pdm._types import CandidateInfo, Source
+
+
+class LocalFileAdapter(requests.adapters.BaseAdapter):
+    """
+    A local file adapter for request.
+
+    Allows to mock some HTTP requests with some local files
+    """
+
+    def __init__(
+        self,
+        aliases: dict[str, Path],
+        overrides: dict | None = None,
+        strip_suffix: bool = False,
+    ):
+        super().__init__()
+        self.aliases = sorted(
+            aliases.items(), key=lambda item: len(item[0]), reverse=True
+        )
+        self.overrides = overrides if overrides is not None else {}
+        self.strip_suffix = strip_suffix
+        self._opened_files: list[BytesIO | BufferedReader | BinaryIO] = []
+
+    def get_file_path(self, path: str) -> Path | None:
+        for prefix, base_path in self.aliases:
+            if path.startswith(prefix):
+                file_path = base_path / path[len(prefix) :].lstrip("/")
+                if not self.strip_suffix:
+                    return file_path
+                return next(
+                    (p for p in file_path.parent.iterdir() if p.stem == file_path.name),
+                    None,
+                )
+        return None
+
+    def send(
+        self,
+        request: requests.PreparedRequest,
+        stream: bool = False,
+        timeout: float | tuple[float, float] | tuple[float, None] | None = None,
+        verify: bool | str = True,
+        cert: str | bytes | tuple[bytes | str, str | bytes] | None = None,
+        proxies: Mapping[str, str] | None = None,
+    ) -> requests.models.Response:
+        request_path = str(urlparse(request.url).path)
+        file_path = self.get_file_path(request_path)
+        response = requests.models.Response()
+        response.url = request.url or ""
+        response.request = request
+        if request_path in self.overrides:
+            response.status_code = 200
+            response.reason = "OK"
+            response.raw = BytesIO(self.overrides[request_path])
+            response.headers["Content-Type"] = "text/html"
+        elif file_path is None or not file_path.exists():
+            response.status_code = 404
+            response.reason = "Not Found"
+            response.raw = BytesIO(b"Not Found")
+        else:
+            response.status_code = 200
+            response.reason = "OK"
+            response.raw = file_path.open("rb")
+            if file_path.suffix == ".html":
+                response.headers["Content-Type"] = "text/html"
+        self._opened_files.append(response.raw)
+        return response
+
+    def close(self) -> None:
+        for fp in self._opened_files:
+            fp.close()
+        self._opened_files.clear()
+
+
+class _FakeLink:
+    is_wheel = False
+
+
+class TestRepository(BaseRepository):
+    """
+    A mock repository to ease testing dependencies
+    """
+
+    def __init__(
+        self, sources: list[Source], environment: Environment, pypi_json: Path
+    ):
+        super().__init__(sources, environment)
+        self._pypi_data: dict[str, Any] = {}
+        self._pypi_json = pypi_json
+        self.load_fixtures()
+
+    def get_raw_dependencies(self, candidate: Candidate) -> list[str]:
+        try:
+            pypi_data = self._pypi_data[cast(str, candidate.req.key)][
+                cast(str, candidate.version)
+            ]
+        except KeyError:
+            return candidate.prepare(self.environment).metadata.requires or []
+        else:
+            return pypi_data.get("dependencies", [])
+
+    def add_candidate(self, name: str, version: str, requires_python: str = "") -> None:
+        pypi_data = self._pypi_data.setdefault(normalize_name(name), {}).setdefault(
+            version, {}
+        )
+        pypi_data["requires_python"] = requires_python
+
+    def add_dependencies(
+        self, name: str, version: str, requirements: list[str]
+    ) -> None:
+        pypi_data = self._pypi_data[normalize_name(name)][version]
+        pypi_data.setdefault("dependencies", []).extend(requirements)
+
+    def _get_dependencies_from_fixture(
+        self, candidate: Candidate
+    ) -> tuple[list[str], str, str]:
+        try:
+            pypi_data = self._pypi_data[cast(str, candidate.req.key)][
+                cast(str, candidate.version)
+            ]
+        except KeyError:
+            raise CandidateInfoNotFound(candidate)
+        deps = pypi_data.get("dependencies", [])
+        deps = filter_requirements_with_extras(
+            cast(str, candidate.req.name), deps, candidate.req.extras or ()
+        )  # type: ignore
+        return deps, pypi_data.get("requires_python", ""), ""
+
+    def dependency_generators(self) -> Iterable[Callable[[Candidate], CandidateInfo]]:
+        return (
+            self._get_dependencies_from_cache,
+            self._get_dependencies_from_fixture,
+            self._get_dependencies_from_metadata,
+        )
+
+    def get_hashes(self, candidate: Candidate) -> dict[Link, str] | None:
+        return {}
+
+    def _find_candidates(self, requirement: Requirement) -> Iterable[Candidate]:
+        for version, candidate in sorted(
+            self._pypi_data.get(cast(str, requirement.key), {}).items(),
+            key=lambda item: parse_version(item[0]),
+            reverse=True,
+        ):
+            c = Candidate(
+                requirement,
+                name=requirement.project_name,
+                version=version,
+            )
+            c.requires_python = candidate.get("requires_python", "")
+            c.link = cast(Link, _FakeLink())
+            yield c
+
+    def load_fixtures(self) -> None:
+        self._pypi_data = json.loads(self._pypi_json.read_text())
+
+
+class Metadata(dict):
+    def get_all(self, name: str, fallback: list[str] | None = None) -> list[str] | None:
+        return [self[name]] if name in self else fallback
+
+    def __getitem__(self, __key: str) -> str:
+        return cast(str, dict.get(self, __key))
+
+
+class Distribution:
+    """A mock Distribution"""
+
+    def __init__(
+        self,
+        key: str,
+        version: str,
+        editable: bool = False,
+        metadata: Metadata | None = None,
+    ):
+        self.version = version
+        self.link_file = "editable" if editable else None
+        self.dependencies: list[str] = []
+        self._metadata = {"Name": key, "Version": version}
+        if metadata:
+            self._metadata.update(metadata)
+        self.name = key
+
+    @property
+    def metadata(self) -> Metadata:
+        return Metadata(self._metadata)
+
+    def as_req(self) -> Requirement:
+        return parse_requirement(f"{self.name}=={self.version}")
+
+    @property
+    def requires(self) -> list[str]:
+        return self.dependencies
+
+    def read_text(self, path: Path | str) -> None:
+        return None
+
+
+class MockWorkingSet(collections.abc.MutableMapping):
+    """A mock working set"""
+
+    _data: dict[str, Distribution]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self._data = {}
+
+    def add_distribution(self, dist: Distribution) -> None:
+        self._data[dist.name] = dist
+
+    def __getitem__(self, key: str) -> Distribution:
+        return self._data[key]
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __setitem__(self, key: str, value: Distribution) -> None:
+        self._data[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._data[key]
+
+
+# Note:
+#   When going through pytest assertions rewrite, the future annotations is ignored.
+#   As a consequence, type definition must comply with Python 3.7 syntax
+
+IndexMap = Dict[str, Path]
+"""Path some root-relative http paths to some local paths"""
+IndexOverrides = Dict[str, str]
+"""PyPI indexes overrides fixture format"""
+IndexesDefinition = Dict[str, Union[Tuple[IndexMap, IndexOverrides, bool], IndexMap]]
+"""Mock PyPI indexes format"""
+
+
+@pytest.fixture(scope="session")
+def build_env_wheels() -> Iterable[Path]:
+    """
+    Expose some wheels to be installed in the build environment.
+
+    Override to provide your owns.
+
+    Returns:
+        a list of wheels paths to install
+    """
+    return []
+
+
+@pytest.fixture(scope="session")
+def build_env(
+    build_env_wheels: Iterable[Path], tmp_path_factory: pytest.TempPathFactory
+) -> Path:
+    """
+    A fixture build environment
+
+    Args:
+        build_env_wheels: a list of wheel to install in the environment
+
+    Returns:
+        The build environment temporary path
+    """
+    d = tmp_path_factory.mktemp("pdm-test-env")
+    p = Core().create_project(d)
+    env = PrefixEnvironment(p, str(d))
+    for wheel in build_env_wheels:
+        install_wheel(str(wheel), env)
+    return d
+
+
+@pytest.fixture
+def pypi_indexes() -> IndexesDefinition:
+    """
+    Provides some mocked PyPI entries
+
+    Returns:
+        a definition of the mocked indexes
+    """
+    return {}
+
+
+@pytest.fixture
+def pdm_session(pypi_indexes: IndexesDefinition) -> Callable[[Any], PDMSession]:
+    def get_pypi_session(*args: Any, **kwargs: Any) -> PDMSession:
+        session = PDMSession(*args, **kwargs)
+        for root, specs in pypi_indexes.items():
+            index, overrides, strip = (
+                specs if isinstance(specs, tuple) else (specs, None, False)
+            )
+            session.mount(
+                root, LocalFileAdapter(index, overrides=overrides, strip_suffix=strip)
+            )
+        return session
+
+    return get_pypi_session
+
+
+def remove_pep582_path_from_pythonpath(pythonpath: str) -> str:
+    """Remove all pep582 paths of PDM from PYTHONPATH"""
+    paths = pythonpath.split(os.pathsep)
+    paths = [path for path in paths if "pdm/pep582" not in path]
+    return os.pathsep.join(paths)
+
+
+@pytest.fixture
+def core() -> Iterator[Core]:
+    old_config_map = Config._config_map.copy()
+    # Turn off use_venv by default, for testing
+    Config._config_map["python.use_venv"].default = False
+    main = Core()
+    yield main
+    # Restore the config items
+    Config._config_map = old_config_map
+
+
+@pytest.fixture
+def project_no_init(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    core: Core,
+    pdm_session: type[PDMSession],
+    monkeypatch: pytest.MonkeyPatch,
+    build_env: Path,
+) -> Project:
+    """
+    A fixture creating a non-initialized test project for the current test.
+
+    Returns:
+        The non-initialized project
+    """
+    test_home = tmp_path / ".pdm-home"
+    test_home.mkdir(parents=True)
+    test_home.joinpath("config.toml").write_text(
+        '[global_project]\npath = "{}"\n'.format(
+            test_home.joinpath("global-project").as_posix()
+        )
+    )
+    p = core.create_project(
+        tmp_path, global_config=test_home.joinpath("config.toml").as_posix()
+    )
+    p.global_config["venv.location"] = str(tmp_path / "venvs")
+    mocker.patch("pdm.models.environment.PDMSession", pdm_session)
+    mocker.patch(
+        "pdm.builders.base.EnvBuilder.get_shared_env", return_value=str(build_env)
+    )
+    tmp_path.joinpath("caches").mkdir(parents=True)
+    p.global_config["cache_dir"] = tmp_path.joinpath("caches").as_posix()
+    python_path = find_python_in_path(sys.base_prefix)
+    if python_path is None:
+        raise ValueError("Unable to find a Python path")
+    p.project_config["python.path"] = python_path.as_posix()
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.delenv("CONDA_PREFIX", raising=False)
+    monkeypatch.delenv("PEP582_PACKAGES", raising=False)
+    monkeypatch.delenv("NO_SITE_PACKAGES", raising=False)
+    pythonpath = os.getenv("PYTHONPATH", "")
+    pythonpath = remove_pep582_path_from_pythonpath(pythonpath)
+    if pythonpath:
+        monkeypatch.setenv("PYTHONPATH", pythonpath)
+    return p
+
+
+@pytest.fixture
+def project(project_no_init: Project) -> Project:
+    """
+    A fixture creating an initialized test project for the current test.
+
+    Returns:
+        The initialized project
+    """
+    hooks = HookManager(project_no_init, ["post_init"])
+    do_init(
+        project_no_init,
+        "test_project",
+        "0.0.0",
+        hooks=hooks,
+        build_backend=get_backend("pdm-pep517"),
+    )
+    # Clean the cached property
+    project_no_init._environment = None
+    return project_no_init
+
+
+@pytest.fixture
+def working_set(mocker: MockerFixture, repository: TestRepository) -> MockWorkingSet:
+    """
+    a mock working set as a fixture
+
+    Returns:
+        a mock working set
+    """
+    rv = MockWorkingSet()
+    mocker.patch.object(Environment, "get_working_set", return_value=rv)
+
+    def install(candidate: Candidate) -> None:
+        key = normalize_name(candidate.name)  # type: ignore
+        dist = Distribution(key, cast(str, candidate.version), candidate.req.editable)
+        dist.dependencies = repository.get_raw_dependencies(candidate)
+        rv.add_distribution(dist)
+
+    def uninstall(dist: Distribution) -> None:
+        del rv[dist.name]
+
+    install_manager = mocker.MagicMock()
+    install_manager.install.side_effect = install
+    install_manager.uninstall.side_effect = uninstall
+    mocker.patch(
+        "pdm.installers.Synchronizer.get_manager", return_value=install_manager
+    )
+
+    return rv
+
+
+@pytest.fixture
+def local_finder_artifacts() -> Path:
+    """
+    The local finder search path as a fixture
+
+    Override to provides your own artifacts.
+
+    Returns:
+        The path to the artifacts root
+    """
+    return Path()
+
+
+@pytest.fixture
+def local_finder(project_no_init: Project, local_finder_artifacts: Path) -> None:
+    artifacts_dir = str(local_finder_artifacts)
+    project_no_init.pyproject.settings["source"] = [
+        {
+            "type": "find_links",
+            "verify_ssl": False,
+            "url": path_to_url(artifacts_dir),
+            "name": "pypi",
+        }
+    ]
+    project_no_init.pyproject.write()
+
+
+@pytest.fixture
+def repository_pypi_json() -> Path:
+    """
+    The test repository fake PyPI definition path as a fixture
+
+    Override to provides your own definition path.
+
+    Returns:
+        The path to a fake PyPI repository JSON definition
+    """
+    return Path()
+
+
+@pytest.fixture()
+def repository(
+    project: Project,
+    mocker: MockerFixture,
+    repository_pypi_json: Path,
+    local_finder: type[None],
+) -> TestRepository:
+    """
+    A fixture providing a mock PyPI repository
+
+    Returns:
+        A mock repository
+    """
+    rv = TestRepository([], project.environment, repository_pypi_json)
+    mocker.patch.object(project, "get_repository", return_value=rv)
+    return rv
+
+
+@dataclass
+class RunResult:
+    """
+    Store a command execution result.
+    """
+
+    exit_code: int
+    """The execution exit code"""
+    stdout: str
+    """The execution `stdout` output"""
+    stderr: str
+    """The execution `stderr` output"""
+    exception: Exception | None = None
+    """If set, the exception raised on execution"""
+
+    @property
+    def output(self) -> str:
+        """The execution `stdout` output (`stdout` alias)"""
+        return self.stdout
+
+    @property
+    def outputs(self) -> str:
+        """The execution `stdout` and `stderr` outputs concatenated"""
+        return self.stdout + self.stderr
+
+    def print(self) -> None:
+        """A debugging facility"""
+        print("# exit code:", self.exit_code)
+        print("# stdout:", self.stdout, sep="\n")
+        print("# stderr:", self.stderr, sep="\n")
+
+
+class PDMCallable(Protocol):
+    """The PDM fixture callable signature"""
+
+    def __call__(
+        self,
+        args: str | list[str],
+        strict: bool = False,
+        input: str | None = None,
+        obj: Project | None = None,
+        env: Mapping[str, str] | None = None,
+        **kwargs: Any,
+    ) -> RunResult:
+        """
+        Args:
+            args: the command arguments as a single lexable string or a strings array
+            strict: raise an exception on failure instead of returning if enabled
+            input: an optional string to be submitted too `stdin`
+            obj: an optional existing `Project`.
+            env: override the environment variables with those
+
+        Returns:
+            The command result
+        """
+        ...
+
+
+@pytest.fixture
+def pdm(core: Core, monkeypatch: pytest.MonkeyPatch) -> PDMCallable:
+    """
+    A fixture alloowing to execute PDM commands
+
+    Returns:
+        A `pdm` fixture command.
+    """
+
+    def caller(
+        args: str | list[str],
+        strict: bool = False,
+        input: str | None = None,
+        obj: Project | None = None,
+        env: Mapping[str, str] | None = None,
+        **kwargs: Any,
+    ) -> RunResult:
+        __tracebackhide__ = True
+
+        stdin = StringIO(input)
+        stdout = StringIO()
+        stderr = StringIO()
+        exit_code: int = 0
+        exception: Exception | None = None
+        args = args.split() if isinstance(args, str) else args
+
+        with monkeypatch.context() as m:
+            m.setattr("sys.stdin", stdin)
+            m.setattr("sys.stdout", stdout)
+            m.setattr("sys.stderr", stderr)
+            for key, value in (env or {}).items():
+                m.setenv(key, value)
+            try:
+                core.main(args, "pdm", obj=obj, **kwargs)
+            except SystemExit as e:
+                exit_code = e.code  # type: ignore
+            except Exception as e:
+                exit_code = 1
+                exception = e
+
+        result = RunResult(exit_code, stdout.getvalue(), stderr.getvalue(), exception)
+
+        if strict and result.exit_code != 0:
+            raise RuntimeError(
+                f"Call command {args} failed({result.exit_code}): {result.stderr}"
+            )
+        return result
+
+    return caller
+
+
+VENV_BACKENDS = ["virtualenv", "venv"]
+
+
+@pytest.fixture(params=VENV_BACKENDS)
+def venv_backends(project: Project, request: SubRequest) -> None:
+    """A fixture iterating over `venv` backends"""
+    project.project_config["venv.backend"] = request.param
+    project.project_config["venv.prompt"] = "{project_name}-{python_version}"
+    project.project_config["python.use_venv"] = True
+    shutil.rmtree(project.root / "__pypackages__", ignore_errors=True)

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -2,7 +2,7 @@ import pytest
 
 from pdm.cli import actions
 from pdm.models.requirements import parse_requirement
-from tests.conftest import Distribution
+from pdm.pytest import Distribution
 
 
 @pytest.mark.usefixtures("repository")

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -9,8 +9,8 @@ from rich.box import ASCII
 from pdm.cli import actions
 from pdm.cli.commands.list import Command
 from pdm.models.specifiers import PySpecSet
+from pdm.pytest import Distribution
 from tests import FIXTURES
-from tests.conftest import Distribution
 
 
 def test_list_command(project, invoke, mocker):


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

This PR follows the discussion https://github.com/pdm-project/pdm/discussions/1571 and extract most pytest fixtures into their own public module `pdm.pytest`.

This allows pdm plugin developpers to benefits from them by importing them as a plugin:
```python
pytest_plugins = [
    "pdm.pytest",
]
```

When relying on local file fixtures or any other configurable part, this is done by a dependency fixture.
The PDM test suite rely on those fixtures and configure them with PDM test fixtures (and so the PDM test suite is an usage example of those fixtures)

Given those fixtures are now in `src`, type hinting has been completed to comply with MyPy.
Documentation has been added in a dedicated page to differentiate from the real PDM API. Obviously, given I didn't write those, there might be some issues with the documentation and typing.