### PR TITLE
Fix: Deduplicate lists when running pdm import

### DIFF
--- a/src/pdm/cli/utils.py
+++ b/src/pdm/cli/utils.py
@@ -676,6 +676,7 @@ def merge_dictionary(
 ) -> None:
     """Merge the input dict with the target while preserving the existing values
     properly. This will update the target dictionary in place.
+    List values will be extended, but only if the value is not already in the list.
     """
     for key, value in input.items():
         if key not in target:
@@ -683,7 +684,7 @@ def merge_dictionary(
         elif isinstance(value, dict):
             target[key].update(value)
         elif isinstance(value, list):
-            target[key].extend(value)
+            target[key].extend([x for x in value if x not in target[key]])
         else:
             target[key] = value
 

--- a/src/pdm/cli/utils.py
+++ b/src/pdm/cli/utils.py
@@ -28,7 +28,6 @@ from pdm import termui
 from pdm.exceptions import PdmArgumentError, PdmUsageError, ProjectError
 from pdm.formats import FORMATS
 from pdm.formats.base import make_array, make_inline_table
-
 from pdm.models.requirements import (
     Requirement,
     filter_requirements_with_extras,
@@ -44,15 +43,18 @@ from pdm.utils import (
 )
 
 if TYPE_CHECKING:
-    from packaging.version import Version
-    from resolvelib.resolvers import RequirementInformation, ResolutionImpossible
     from argparse import Action, _ArgumentGroup
 
+    from packaging.version import Version
+    from resolvelib.resolvers import RequirementInformation, ResolutionImpossible
+
     from pdm.compat import Distribution
-    from pdm.models.candidates import Candidate
-    from pdm.project import Project
     from pdm.compat import importlib_metadata as im
+    from pdm.models.candidates import Candidate
     from pdm.models.repositories import BaseRepository
+    from pdm.project import Project
+
+
 class ErrorArgumentParser(argparse.ArgumentParser):
     """A subclass of argparse.ArgumentParser that raises
     parsing error rather than exiting.

--- a/src/pdm/cli/utils.py
+++ b/src/pdm/cli/utils.py
@@ -4,7 +4,6 @@ import argparse
 import json
 import os
 import sys
-from argparse import Action, _ArgumentGroup
 from collections import ChainMap, OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from json import dumps
@@ -26,11 +25,10 @@ from resolvelib.structs import DirectedGraph
 from rich.tree import Tree
 
 from pdm import termui
-from pdm.compat import importlib_metadata as im
 from pdm.exceptions import PdmArgumentError, PdmUsageError, ProjectError
 from pdm.formats import FORMATS
 from pdm.formats.base import make_array, make_inline_table
-from pdm.models.repositories import BaseRepository
+
 from pdm.models.requirements import (
     Requirement,
     filter_requirements_with_extras,
@@ -38,7 +36,6 @@ from pdm.models.requirements import (
     strip_extras,
 )
 from pdm.models.specifiers import get_specifier
-from pdm.project import Project
 from pdm.utils import (
     comparable_version,
     is_path_relative_to,
@@ -49,11 +46,13 @@ from pdm.utils import (
 if TYPE_CHECKING:
     from packaging.version import Version
     from resolvelib.resolvers import RequirementInformation, ResolutionImpossible
+    from argparse import Action, _ArgumentGroup
 
     from pdm.compat import Distribution
     from pdm.models.candidates import Candidate
-
-
+    from pdm.project import Project
+    from pdm.compat import importlib_metadata as im
+    from pdm.models.repositories import BaseRepository
 class ErrorArgumentParser(argparse.ArgumentParser):
     """A subclass of argparse.ArgumentParser that raises
     parsing error rather than exiting.

--- a/src/pdm/formats/poetry.py
+++ b/src/pdm/formats/poetry.py
@@ -4,11 +4,9 @@ import functools
 import operator
 import os
 import re
-from argparse import Namespace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, cast
 
-from pdm._types import RequirementDict, Source
 from pdm.compat import tomllib
 from pdm.formats.base import (
     MetaConverter,
@@ -24,6 +22,8 @@ from pdm.models.specifiers import PySpecSet
 
 if TYPE_CHECKING:
     from pdm.project.core import Project
+    from argparse import Namespace
+    from pdm._types import RequirementDict, Source
 
 from pdm.utils import cd
 


### PR DESCRIPTION
## Pull Request Check List

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Avoid duplicates in dependencies/authors when importing from requirements, Poetry (#1584)

As there is some logic in the `do_import` action, we may want to add testing for the CLI command `import` or move this logic in the converters.
