### PR TITLE
Set VIRTUAL_ENV in pdm run

### DIFF
--- a/news/1652.bugfix.md
+++ b/news/1652.bugfix.md
@@ -1,0 +1,1 @@
+Set VIRTUAL_ENV in `pdm run`.

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -182,6 +182,8 @@ class TaskRunner:
         )
         if project_env.packages_path:
             process_env.update({"PEP582_PACKAGES": str(project_env.packages_path)})
+        if project_env.venv_path:
+            process_env.update({"VIRTUAL_ENV": str(project_env.venv_path)})
         if env:
             process_env.update(env)
         if shell:

--- a/src/pdm/models/environment.py
+++ b/src/pdm/models/environment.py
@@ -112,6 +112,13 @@ class Environment:
         return pypackages
 
     @cached_property
+    def venv_path(self) -> Path | None:
+        """The path of the venv (None if this isn't a venv)"""
+        if not self.is_global:
+            return None
+        return get_venv_like_prefix(self.interpreter.executable)
+
+    @cached_property
     def target_python(self) -> unearth.TargetPython:
         python_version = self.interpreter.version_tuple
         python_abi_tag = get_python_abi_tag(str(self.interpreter.executable))


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

If the environment is a virtualenv, `pdm run` will set the `VIRTUAL_ENV` environment variable, which lets tools know that a virtualenv is in use. This means that (for example) the `py` launcher on Windows correctly locates the environment's Python rather than using the system Python.

Fixes #1650