### PR TITLE
cut local versions with < or > markers

### DIFF
--- a/src/pdm/models/requirements.py
+++ b/src/pdm/models/requirements.py
@@ -469,14 +469,17 @@ def parse_as_pkg_requirement(line: str) -> PackageRequirement:
 
     def fix_wildcard(match: Match[str]) -> str:
         operator, _, version = match.groups()
-        if ".*" not in version or operator in ("==", "!="):
-            return match.group(0)
-        version = version.replace(".*", ".0")
-        if operator in ("<", "<="):  # <4.* and <=4.* are equivalent to <4.0
-            operator = "<"
-        elif operator in (">", ">="):  # >4.* and >=4.* are equivalent to >=4.0
-            operator = ">="
-        return f"{operator}{version}"
+        rval = match.group(0)
+        if ".*" in version:
+            version = version.replace(".*", ".0")
+            if operator in ("<", "<="):  # <4.* and <=4.* are equivalent to <4.0
+                operator = "<"
+            elif operator in (">", ">="):  # >4.* and >=4.* are equivalent to >=4.0
+                operator = ">="
+            rval = f"{operator}{version}"
+        if operator in ("<", "<=", ">", ">="):
+            rval = rval.split("+")[0]
+        return rval
 
     try:
         return PackageRequirement(line)

--- a/tests/models/test_requirements.py
+++ b/tests/models/test_requirements.py
@@ -61,6 +61,11 @@ REQUIREMENTS = [
         "foo<5.0,>=4.0",
         marks=pytest.mark.skipif(not PACKAGING_22, reason="packaging 22+ required"),
     ),
+    pytest.param(
+        "foo (>=4.0+gabcde, <=5.0.dev0+gabcde)",
+        "foo<=5.0.dev0,>=4.0",
+        marks=pytest.mark.skipif(not PACKAGING_22, reason="packaging 22+ required"),
+    ),
 ]
 
 


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Since a change to packaging (version 22+) we have an issue with our local wheel versions and ">"/"<".

This is a so far only checked with unit tests. Please have a look.

Best regards,
Franz