### PR TITLE
fix: Don't crash when trying to update the shebang in a binary script

### DIFF
--- a/news/1709.bugfix.md
+++ b/news/1709.bugfix.md
@@ -1,0 +1,1 @@
+Don't crash when trying to update the shebang in a binary script.

--- a/src/pdm/models/environment.py
+++ b/src/pdm/models/environment.py
@@ -63,10 +63,10 @@ def _replace_shebang(contents: bytes, new_executable: bytes) -> bytes:
     match = re.search(_complex_shebang_re, contents, flags=re.M)
     if match:
         return contents.replace(match.group(1), new_executable, 1)
-    else:
-        match = re.search(_simple_shebang_re, contents, flags=re.M)
-        assert match is not None
+    match = re.search(_simple_shebang_re, contents, flags=re.M)
+    if match:
         return contents.replace(match.group(1), new_executable, 1)
+    return contents
 
 
 class PackageFinder(unearth.PackageFinder):


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code: maybe I could generate a binary file on the fly in a test and assert PDM does not crash?

## Describe what you have changed in this PR.

PDM would previously crash (assertion error) when trying to update the shebang in a script that is a binary file.
This change prevents that.

Fixes #1709.