### PR TITLE
Add pyright/eglot config for emacs

### DIFF
--- a/docs/docs/usage/advanced.md
+++ b/docs/docs/usage/advanced.md
@@ -222,6 +222,28 @@ Below is a sample code snippet showing how to make PDM work with [lsp-python-ms]
                (lsp))))  ; or lsp-deferred
 ```
 
+## Work with pyright and eglot in Emacs
+
+Using [pyright](https://github.com/microsoft/pyright) and [eglot](https://github.com/joaotavora/eglot) (which is included in Emacs 29), add the following to your config:
+
+```emacs-lisp
+(defun maybe-from-dir (cmd &optional dir)
+  (if dir
+      (format "cd %s && %s" dir cmd)
+    cmd))
+
+(defun get-packages-path (&optional dir)
+  (let* ((get-packages-cmd-str (maybe-from-dir "pdm info --packages" dir))
+         (get-packages-cmd (string-trim (shell-command-to-string get-packages-cmd-str))))
+    (concat get-packages-cmd "/lib")))
+
+(defun my/eglot-workspace-config (server)
+  (list :python.analysis
+        (list :extraPaths (vector (get-packages-path)))))
+        
+(setq-default eglot-workspace-configuration #'my/eglot-workspace-config)
+```
+
 ## Hooks for `pre-commit`
 
 [`pre-commit`](https://pre-commit.com/) is a powerful framework for managing git hooks in a centralized fashion. PDM already uses `pre-commit` [hooks](https://github.com/pdm-project/pdm/blob/main/.pre-commit-config.yaml) for its internal QA checks. PDM exposes also several hooks that can be run locally or in CI pipelines.

--- a/docs/docs/usage/advanced.md
+++ b/docs/docs/usage/advanced.md
@@ -182,7 +182,9 @@ CMD ["python", "-m", "project"]
 
 ## Integrate with other IDE or editors
 
-### Work with lsp-python-ms in Emacs
+### Emacs
+
+#### LSP-Mode + lsp-python-ms
 
 Below is a sample code snippet showing how to make PDM work with [lsp-python-ms](https://github.com/emacs-lsp/lsp-python-ms) in Emacs. Contributed by [@linw1995](https://github.com/pdm-project/pdm/discussions/372#discussion-3303501).
 
@@ -222,7 +224,7 @@ Below is a sample code snippet showing how to make PDM work with [lsp-python-ms]
                (lsp))))  ; or lsp-deferred
 ```
 
-## Work with pyright and eglot in Emacs
+#### eglot + pyright
 
 Using [pyright](https://github.com/microsoft/pyright) and [eglot](https://github.com/joaotavora/eglot) (which is included in Emacs 29), add the following to your config:
 

--- a/docs/docs/usage/advanced.md
+++ b/docs/docs/usage/advanced.md
@@ -229,20 +229,15 @@ Below is a sample code snippet showing how to make PDM work with [lsp-python-ms]
 Using [pyright](https://github.com/microsoft/pyright) and [eglot](https://github.com/joaotavora/eglot) (which is included in Emacs 29), add the following to your config:
 
 ```emacs-lisp
-(defun maybe-from-dir (cmd &optional dir)
-  (if dir
-      (format "cd %s && %s" dir cmd)
-    cmd))
-
-(defun get-packages-path (&optional dir)
-  (let* ((get-packages-cmd-str (maybe-from-dir "pdm info --packages" dir))
-         (get-packages-cmd (string-trim (shell-command-to-string get-packages-cmd-str))))
-    (concat get-packages-cmd "/lib")))
+(defun get-pdm-packages-path ()
+  "For the current PDM project, find the path to the packages."
+  (let ((packages-path (string-trim (shell-command-to-string "pdm info --packages"))))
+    (concat packages-path "/lib")))
 
 (defun my/eglot-workspace-config (server)
-  (list :python.analysis
-        (list :extraPaths (vector (get-packages-path)))))
-        
+  "For the current PDM project, dynamically generate a python lsp config."
+  `(:python\.analysis (:extraPaths ,(vector (get-pdm-packages-path)))))
+
 (setq-default eglot-workspace-configuration #'my/eglot-workspace-config)
 ```
 

--- a/docs/docs/usage/advanced.md
+++ b/docs/docs/usage/advanced.md
@@ -180,67 +180,6 @@ COPY --from=builder /project/__pypackages__/3.8/lib /project/pkgs
 CMD ["python", "-m", "project"]
 ```
 
-## Integrate with other IDE or editors
-
-### Emacs
-
-#### LSP-Mode + lsp-python-ms
-
-Below is a sample code snippet showing how to make PDM work with [lsp-python-ms](https://github.com/emacs-lsp/lsp-python-ms) in Emacs. Contributed by [@linw1995](https://github.com/pdm-project/pdm/discussions/372#discussion-3303501).
-
-```emacs-lisp
-  ;; TODO: Cache result
-  (defun linw1995/pdm-get-python-executable (&optional dir)
-    (let ((pdm-get-python-cmd "pdm info --python"))
-      (string-trim
-       (shell-command-to-string
-        (if dir
-            (concat "cd "
-                    dir
-                    " && "
-                    pdm-get-python-cmd)
-          pdm-get-python-cmd)))))
-
-  (defun linw1995/pdm-get-packages-path (&optional dir)
-    (let ((pdm-get-packages-cmd "pdm info --packages"))
-      (concat (string-trim
-               (shell-command-to-string
-                (if dir
-                    (concat "cd "
-                            dir
-                            " && "
-                            pdm-get-packages-cmd)
-                  pdm-get-packages-cmd)))
-              "/lib")))
-
-  (use-package lsp-python-ms
-    :ensure t
-    :init (setq lsp-python-ms-auto-install-server t)
-    :hook (python-mode
-           . (lambda ()
-               (setq lsp-python-ms-python-executable (linw1995/pdm-get-python-executable))
-               (setq lsp-python-ms-extra-paths (vector (linw1995/pdm-get-packages-path)))
-               (require 'lsp-python-ms)
-               (lsp))))  ; or lsp-deferred
-```
-
-#### eglot + pyright
-
-Using [pyright](https://github.com/microsoft/pyright) and [eglot](https://github.com/joaotavora/eglot) (which is included in Emacs 29), add the following to your config:
-
-```emacs-lisp
-(defun get-pdm-packages-path ()
-  "For the current PDM project, find the path to the packages."
-  (let ((packages-path (string-trim (shell-command-to-string "pdm info --packages"))))
-    (concat packages-path "/lib")))
-
-(defun my/eglot-workspace-config (server)
-  "For the current PDM project, dynamically generate a python lsp config."
-  `(:python\.analysis (:extraPaths ,(vector (get-pdm-packages-path)))))
-
-(setq-default eglot-workspace-configuration #'my/eglot-workspace-config)
-```
-
 ## Hooks for `pre-commit`
 
 [`pre-commit`](https://pre-commit.com/) is a powerful framework for managing git hooks in a centralized fashion. PDM already uses `pre-commit` [hooks](https://github.com/pdm-project/pdm/blob/main/.pre-commit-config.yaml) for its internal QA checks. PDM exposes also several hooks that can be run locally or in CI pipelines.

--- a/docs/docs/usage/pep582.md
+++ b/docs/docs/usage/pep582.md
@@ -189,6 +189,12 @@ Using [pyright](https://github.com/microsoft/pyright) and [eglot](https://github
 (setq-default eglot-workspace-configuration #'my/eglot-workspace-config)
 ```
 
+You'll want pyright installed either globally, or in your project (probably as a dev dependency). You can add this with, for example:
+
+```bash
+pdm add --dev --group devel pyright
+```
+
 #### LSP-Mode + lsp-python-ms
 
 Below is a sample code snippet showing how to make PDM work with [lsp-python-ms](https://github.com/emacs-lsp/lsp-python-ms) in Emacs. Contributed by [@linw1995](https://github.com/pdm-project/pdm/discussions/372#discussion-3303501).

--- a/docs/docs/usage/pep582.md
+++ b/docs/docs/usage/pep582.md
@@ -161,4 +161,70 @@ project's `pyproject.toml`.
 extraPaths = ["__pypackages__/<major.minor>/lib/"]
 ```
 
-### [Seek for other IDEs or editors](advanced.md#integrate-with-other-ide-or-editors)
+### Emacs
+
+#### Using `pyproject.toml` and pyright
+
+Add this to your project's `pyproject.toml`:
+
+```toml
+[tool.pyright]
+extraPaths = ["__pypackages__/<major.minor>/lib/"]
+```
+
+#### eglot + pyright
+
+Using [pyright](https://github.com/microsoft/pyright) and [eglot](https://github.com/joaotavora/eglot) (included in Emacs 29), add the following to your config:
+
+```emacs-lisp
+(defun get-pdm-packages-path ()
+  "For the current PDM project, find the path to the packages."
+  (let ((packages-path (string-trim (shell-command-to-string "pdm info --packages"))))
+    (concat packages-path "/lib")))
+
+(defun my/eglot-workspace-config (server)
+  "For the current PDM project, dynamically generate a python lsp config."
+  `(:python\.analysis (:extraPaths ,(vector (get-pdm-packages-path)))))
+
+(setq-default eglot-workspace-configuration #'my/eglot-workspace-config)
+```
+
+#### LSP-Mode + lsp-python-ms
+
+Below is a sample code snippet showing how to make PDM work with [lsp-python-ms](https://github.com/emacs-lsp/lsp-python-ms) in Emacs. Contributed by [@linw1995](https://github.com/pdm-project/pdm/discussions/372#discussion-3303501).
+
+```emacs-lisp
+  ;; TODO: Cache result
+  (defun linw1995/pdm-get-python-executable (&optional dir)
+    (let ((pdm-get-python-cmd "pdm info --python"))
+      (string-trim
+       (shell-command-to-string
+        (if dir
+            (concat "cd "
+                    dir
+                    " && "
+                    pdm-get-python-cmd)
+          pdm-get-python-cmd)))))
+
+  (defun linw1995/pdm-get-packages-path (&optional dir)
+    (let ((pdm-get-packages-cmd "pdm info --packages"))
+      (concat (string-trim
+               (shell-command-to-string
+                (if dir
+                    (concat "cd "
+                            dir
+                            " && "
+                            pdm-get-packages-cmd)
+                  pdm-get-packages-cmd)))
+              "/lib")))
+
+  (use-package lsp-python-ms
+    :ensure t
+    :init (setq lsp-python-ms-auto-install-server t)
+    :hook (python-mode
+           . (lambda ()
+               (setq lsp-python-ms-python-executable (linw1995/pdm-get-python-executable))
+               (setq lsp-python-ms-extra-paths (vector (linw1995/pdm-get-packages-path)))
+               (require 'lsp-python-ms)
+               (lsp))))  ; or lsp-deferred
+```

--- a/docs/docs/usage/pep582.md
+++ b/docs/docs/usage/pep582.md
@@ -163,6 +163,8 @@ extraPaths = ["__pypackages__/<major.minor>/lib/"]
 
 ### Emacs
 
+You have a few options, but basically you'll want to tell an LSP client to add `__pypackages__` to the paths it looks at. Here are a few options that are available:
+
 #### Using `pyproject.toml` and pyright
 
 Add this to your project's `pyproject.toml`:

--- a/news/1721.doc.md
+++ b/news/1721.doc.md
@@ -1,0 +1,1 @@
+Add config example for Emacs using eglot + pyright


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [N/A] Test cases added for changed code.

## Describe what you have changed in this PR.
MS's python lang server (as well as lsp-python-ms) are archived in favor of pyright. Additionally, eglot will be packaged with Emacs once Emacs 29 is released. 