### PR TITLE
fix: in project conda venv activate without argument

### DIFF
--- a/news/1735.doc.md
+++ b/news/1735.doc.md
@@ -1,0 +1,1 @@
+Support using `pdm venv activate` without specifying `env_name` to activate in project venv created by conda

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -281,19 +281,17 @@ def get_venv_like_prefix(interpreter: str | Path) -> Path | None:
     and return the prefix if found.
     """
     interpreter = Path(interpreter)
-    prefix = interpreter.parent.parent
-    if prefix.joinpath("pyvenv.cfg").exists():
+    prefix = interpreter.parent
+    if prefix.joinpath("conda-meta").exists():
+        return prefix
+
+    prefix = prefix.parent
+    if prefix.joinpath("pyvenv.cfg").exists() or prefix.joinpath("conda-meta").exists():
         return prefix
 
     virtual_env = os.getenv("VIRTUAL_ENV", os.getenv("CONDA_PREFIX"))
     if virtual_env and is_path_relative_to(interpreter, virtual_env):
         return Path(virtual_env)
-
-    with contextlib.suppress(FileNotFoundError, subprocess.CalledProcessError):
-        envs = json.loads(subprocess.check_output(["conda", "env", "list", "--json"]))["envs"]
-        for env in envs:
-            if is_path_relative_to(interpreter, env):
-                return Path(env)
     return None
 
 

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -288,6 +288,12 @@ def get_venv_like_prefix(interpreter: str | Path) -> Path | None:
     virtual_env = os.getenv("VIRTUAL_ENV", os.getenv("CONDA_PREFIX"))
     if virtual_env and is_path_relative_to(interpreter, virtual_env):
         return Path(virtual_env)
+
+    with contextlib.suppress(subprocess.CalledProcessError):
+        envs= json.loads(subprocess.check_output(["conda", "env", "list", "--json"]))["envs"]
+        for env in envs:
+            if is_path_relative_to(interpreter, env):
+                return Path(env)
     return None
 
 

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -290,7 +290,7 @@ def get_venv_like_prefix(interpreter: str | Path) -> Path | None:
         return Path(virtual_env)
 
     with contextlib.suppress(subprocess.CalledProcessError):
-        envs= json.loads(subprocess.check_output(["conda", "env", "list", "--json"]))["envs"]
+        envs = json.loads(subprocess.check_output(["conda", "env", "list", "--json"]))["envs"]
         for env in envs:
             if is_path_relative_to(interpreter, env):
                 return Path(env)

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -289,7 +289,7 @@ def get_venv_like_prefix(interpreter: str | Path) -> Path | None:
     if virtual_env and is_path_relative_to(interpreter, virtual_env):
         return Path(virtual_env)
 
-    with contextlib.suppress(subprocess.CalledProcessError):
+    with contextlib.suppress(FileNotFoundError, subprocess.CalledProcessError):
         envs = json.loads(subprocess.check_output(["conda", "env", "list", "--json"]))["envs"]
         for env in envs:
             if is_path_relative_to(interpreter, env):


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
~~- [ ] Test cases added for changed code.~~ (current tests do not cover `venv activate` without `env`)

## Describe what you have changed in this PR.

For in project venv created by `conda`, using `pdm venv activate` without specifying `env_name` would be a failure:

```bash
(base) programripper:~/conda-test$ echo $CONDA_PREFIX  # Actually it is quite common for conda that isn't installed normally (e.g. via pyenv) that not to have CONDA_PREFIX properly set, which will make pdm fail faster.
/home/programripper/.pyenv/shims/conda
(base) programripper:~/conda-test$ pdm venv list
Virtualenvs created with this project:

*  in-project: /home/programripper/conda-test/.venv
(base) programripper:~/conda-test$ cat .pdm.toml
[venv]
backend = "conda"

[python]
path = "/home/programripper/conda-test/.venv/bin/python"
(base) programripper:~/conda-test$ pdm venv activate
Can't activate a non-venv Python /home/programripper/conda-test/.venv/bin/python, you can specify one with pdm venv activate <env_name>
```

By this PR, user can activate in project venv created by `conda` using `pdm venv activate` as venv created by `venv` or `virtualvenv`.