### PR TITLE
feat: Add `.pdm-python` file to project root `.gitignore`

### DIFF
--- a/news/1749.feature.md
+++ b/news/1749.feature.md
@@ -1,0 +1,1 @@
+Include `.pdm-python` in project root `.gitignore` when running `pdm init`.

--- a/src/pdm/cli/actions.py
+++ b/src/pdm/cli/actions.py
@@ -514,6 +514,8 @@ def do_init(
             readme = project.root.joinpath("README.md")
             readme.write_text(f"# {name}\n\n{description}\n", encoding="utf-8")
         data["project"]["readme"] = readme.name
+    with project.root.joinpath(".gitignore").open("a", encoding="utf-8") as file:
+        file.write(".pdm-python")
     get_specifier(python_requires)
     project.pyproject._data.update(data)
     project.pyproject.write()


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

When running `pdm init` the `.gitignore` file at the root of the project will be updated to include the `.pdm-python` file which is not meant to be committed to git. If the project has no `.gitignore` one will be created, and then the ignore rule will be appended to the file.

Apologies for the lack of test case for the change, I couldn't see any prexisting tests for the file create logic in `pdm init`. 

Closes #1749 