### PR TITLE
fix: no need to check `PYTHONPATH` before setting it in fish

### DIFF
--- a/src/pdm/cli/actions.py
+++ b/src/pdm/cli/actions.py
@@ -722,15 +722,7 @@ def print_pep582_command(project: Project, shell: str = "AUTO") -> None:
             """
         ).strip()
     elif shell == "fish":
-        result = textwrap.dedent(
-            f"""
-            if test -n "$PYTHONPATH"
-                set -x PYTHONPATH '{lib_path}' $PYTHONPATH
-            else
-                set -x PYTHONPATH '{lib_path}'
-            end
-            """
-        ).strip()
+        result = f"set -x PYTHONPATH '{lib_path}' $PYTHONPATH"
     elif shell in ("tcsh", "csh"):
         result = textwrap.dedent(
             f"""


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Unlike other shells which use the `:` as the delimiter, fish will not add a zero-length element to the end of the list if the variable in the command was not set. Thus, it will not cause the issue described in #410.