### PR TITLE
Fix powershell completion script

### DIFF
--- a/src/pdm/cli/completions/pdm.ps1
+++ b/src/pdm/cli/completions/pdm.ps1
@@ -429,7 +429,7 @@ function TabExpansion($line, $lastWord) {
                         $completer.AddOpts((
                             [Option]::new(("--with", "-w")).WithValues(@("venv", "virtualenv", "conda")),
                             [Option]::new(("--name", "-n")).WithValues(@()),
-                            [Option]::new(("--with-pip", "-f", "--force")),
+                            [Option]::new(("--with-pip", "-f", "--force"))
                         ))
                     }
                     "list" {$command = $subCommand}
@@ -443,7 +443,7 @@ function TabExpansion($line, $lastWord) {
                         $completer.AddOpts(([Option]::new(("-i", "--interactive", "--force", "-f"))))
                     }
                     Default {
-                        $completer.AddOpts(([Option]::new(("--python", "--path"))
+                        $completer.AddOpts(([Option]::new(("--python", "--path"))))
                         $completer.AddParams(@("create", "list", "remove", "activate", "purge"), $false)
                         break
                     }


### PR DESCRIPTION
Powershell completion script was giving errors due to a trailing comma, as well as unclosed parentheses

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
