### PR TITLE
fix: avoid duplicate .pdm-python in .gitignore

### DIFF
--- a/news/1800.bugfix.md
+++ b/news/1800.bugfix.md
@@ -1,0 +1,1 @@
+Avoid duplicate .pdm-python in .gitignore.

--- a/src/pdm/cli/commands/fix/fixers.py
+++ b/src/pdm/cli/commands/fix/fixers.py
@@ -48,7 +48,8 @@ class ProjectConfigFixer(BaseFixer):
         if not gitignore.exists():
             return
         content = gitignore.read_text("utf8")
-        content = re.sub(r"^\.pdm\.toml$", ".pdm-python", content, flags=re.M)
+        if ".pdm-python" not in content:
+            content = re.sub(r"^\.pdm\.toml$", ".pdm-python", content, flags=re.M)
         gitignore.write_text(content, "utf8")
 
     def fix(self) -> None:


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
Avoids duplicating `.pdm-python` in `.gitignore`.
Fixes #1800 