### PR TITLE
doc(cli): improve cli reference display

### DIFF
--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -2,9 +2,21 @@
 
 ```python exec="1" idprefix=""
 import argparse
+import re
 from pdm.core import Core
 
 parser = Core().parser
+
+MONOSPACED = ("pyproject.toml", "pdm.lock", ".pdm-python", ":pre", ":post", ":all")
+
+def clean_help(help: str) -> str:
+    # Make dunders monospaced avoiding italic markdown rendering
+    help = re.sub(r"__([\w\d\_]+)__", r"`__\1__`", help)
+    # Make env vars monospaced
+    help = re.sub(r"env var: ([A-Z_]+)", r"env var: `\1`", help)
+    for monospaced in MONOSPACED:
+        help = re.sub(rf"\s(['\"]?{monospaced}['\"]?)", f"`{monospaced}`", help)
+    return help
 
 
 def render_parser(
@@ -39,9 +51,9 @@ def render_parser(
                 line = f"- {', '.join(opts)}"
             if action.metavar:
                 line += f" `{action.metavar}`"
-            line += f": {action.help}"
+            line += f": {clean_help(action.help)}"
             if action.default and action.default != argparse.SUPPRESS:
-                line += f"(default: `{action.default}`)"
+                line += f" (default: `{action.default}`)"
             result.append(line)
         result.append("")
 

--- a/src/pdm/cli/commands/base.py
+++ b/src/pdm/cli/commands/base.py
@@ -5,7 +5,6 @@ from argparse import _SubParsersAction
 from typing import Any
 
 from pdm.cli.options import Option, global_option, project_option, verbose_option
-from pdm.cli.utils import PdmFormatter
 from pdm.project import Project
 
 
@@ -40,7 +39,6 @@ class BaseCommand:
             name,
             description=help_text,
             help=help_text,
-            formatter_class=PdmFormatter,
             **kwargs,
         )
         command = cls(parser)

--- a/src/pdm/cli/commands/build.py
+++ b/src/pdm/cli/commands/build.py
@@ -45,8 +45,8 @@ class Command(BaseCommand):
             "-C",
             action="append",
             help="Pass options to the backend. options with a value must be "
-            'specified after "=": "--config-setting=--opt(=value)" '
-            'or "-C--opt(=value)"',
+            'specified after "=": `--config-setting=--opt(=value)` '
+            "or `-C--opt(=value)`",
         )
 
     def handle(self, project: Project, options: argparse.Namespace) -> None:

--- a/src/pdm/cli/options.py
+++ b/src/pdm/cli/options.py
@@ -127,7 +127,7 @@ verbose_option = Option(
     "--verbose",
     action="count",
     default=0,
-    help="-v for detailed output and -vv for more detailed",
+    help="Use `-v` for detailed output and `-vv` for more detailed",
 )
 
 
@@ -184,7 +184,7 @@ groups_group.add_argument(
     metavar="GROUP",
     action=split_lists(","),
     help="Select group of optional-dependencies separated by comma "
-    "or dev-dependencies(with -d). Can be supplied multiple times, "
+    "or dev-dependencies (with `-d`). Can be supplied multiple times, "
     'use ":all" to include all groups under the same species.',
     default=[],
 )
@@ -296,12 +296,12 @@ global_option = Option(
 )
 
 clean_group = ArgumentGroup("clean", is_mutually_exclusive=True)
-clean_group.add_argument("--clean", action="store_true", help="clean packages not in the lockfile")
-clean_group.add_argument("--only-keep", action="store_true", help="only keep the selected packages")
+clean_group.add_argument("--clean", action="store_true", help="Clean packages not in the lockfile")
+clean_group.add_argument("--only-keep", action="store_true", help="Only keep the selected packages")
 
 sync_group = ArgumentGroup("sync", is_mutually_exclusive=True)
-sync_group.add_argument("--sync", action="store_true", dest="sync", help="sync packages")
-sync_group.add_argument("--no-sync", action="store_false", dest="sync", help="don't sync packages")
+sync_group.add_argument("--sync", action="store_true", dest="sync", help="Sync packages")
+sync_group.add_argument("--no-sync", action="store_false", dest="sync", help="Don't sync packages")
 
 packages_group = ArgumentGroup("Package Arguments")
 packages_group.add_argument(

--- a/src/pdm/core.py
+++ b/src/pdm/core.py
@@ -23,7 +23,7 @@ from pdm.__version__ import __version__
 from pdm.cli.actions import check_update
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.options import ignore_python_option, pep582_option, verbose_option
-from pdm.cli.utils import ErrorArgumentParser, PdmFormatter
+from pdm.cli.utils import ArgumentParser, ErrorArgumentParser
 from pdm.compat import importlib_metadata
 from pdm.exceptions import PdmArgumentError, PdmUsageError
 from pdm.installers import InstallManager, Synchronizer
@@ -57,7 +57,6 @@ class Core:
         self.parser = ErrorArgumentParser(
             prog="pdm",
             description=__doc__,
-            formatter_class=PdmFormatter,
         )
         self.parser.is_root = True  # type: ignore[attr-defined]
         self.parser.add_argument(
@@ -68,19 +67,19 @@ class Core:
                 termui.style("PDM", style="bold"),
                 termui.style(self.version, style="success"),
             ),
-            help="show the version and exit",
+            help="Show the version and exit",
         )
         self.parser.add_argument(
             "-c",
             "--config",
-            help="Specify another config file path(env var: PDM_CONFIG_FILE)",
+            help="Specify another config file path [env var: PDM_CONFIG_FILE] ",
         )
         self.parser._positionals.title = "Commands"
         verbose_option.add_to_parser(self.parser)
         ignore_python_option.add_to_parser(self.parser)
         pep582_option.add_to_parser(self.parser)
 
-        self.subparsers = self.parser.add_subparsers(parser_class=argparse.ArgumentParser)
+        self.subparsers = self.parser.add_subparsers(parser_class=ArgumentParser)
         for _, name, _ in pkgutil.iter_modules(COMMANDS_MODULE_PATH):
             module = importlib.import_module(f"pdm.cli.commands.{name}", __name__)
             try:


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new (I don't think this requires a dedicated changelog entry, but if this is the case, I'll add it)
- [x] Test cases added for changed code. (NA: doc generate properly)

## Describe what you have changed in this PR.

Improve cli reference display by:

- fixes dunders being rendered as bold markdown
- adds the missing spaces before `(default:` or `[env var`
- monospace some known reccuring references (`pyproject.toml`, `pdm.lock`, `.pdm-python`, `:all`, `:pre` and `:post`)
- apply the same casing to all help messages (Title)
- use the same format for all env vars
- use the same format (backticked) for parameters in help