### PR TITLE
feat(commands): added a `--json` option to `info` and `run` command

### DIFF
--- a/news/1854.feature.md
+++ b/news/1854.feature.md
@@ -1,0 +1,1 @@
+Added a `--json` flag to both `run` and `info` command allowing to dump scripts and infos as JSON.

--- a/src/pdm/cli/commands/info.py
+++ b/src/pdm/cli/commands/info.py
@@ -1,6 +1,8 @@
 import argparse
 import json
 
+from rich import print_json
+
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.options import ArgumentGroup, venv_option
 from pdm.cli.utils import check_project_file
@@ -22,6 +24,7 @@ class Command(BaseCommand):
         )
         group.add_argument("--packages", action="store_true", help="Show the local packages root")
         group.add_argument("--env", action="store_true", help="Show PEP 508 environment markers")
+        group.add_argument("--json", action="store_true", help="Dump the information in JSON")
         group.add_to_parser(parser)
 
     def handle(self, project: Project, options: argparse.Namespace) -> None:
@@ -38,6 +41,21 @@ class Command(BaseCommand):
             project.core.ui.echo(str(packages_path))
         elif options.env:
             project.core.ui.echo(json.dumps(project.environment.marker_environment, indent=2))
+        elif options.json:
+            print_json(
+                data={
+                    "pdm": {"version": project.core.version},
+                    "python": {
+                        "interpreter": str(interpreter.executable),
+                        "version": interpreter.identifier,
+                        "markers": project.environment.marker_environment,
+                    },
+                    "project": {
+                        "root": str(project.root),
+                        "pypackages": str(packages_path),
+                    },
+                }
+            )
         else:
             for name, value in zip(
                 [

--- a/tests/cli/test_others.py
+++ b/tests/cli/test_others.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -48,6 +49,19 @@ def test_info_command(project, pdm):
 
     result = pdm(["info", "--env"], obj=project)
     assert result.exit_code == 0
+
+
+def test_info_command_json(project, pdm):
+    result = pdm(["info", "--json"], obj=project, strict=True)
+
+    data = json.loads(result.outputs)
+
+    assert data["pdm"]["version"] == project.core.version
+    assert data["python"]["version"] == project.environment.interpreter.identifier
+    assert data["python"]["interpreter"] == str(project.environment.interpreter.executable)
+    assert isinstance(data["python"]["markers"], dict)
+    assert data["project"]["root"] == str(project.root)
+    assert isinstance(data["project"]["pypackages"], str)
 
 
 def test_info_global_project(pdm, tmp_path):


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

This PR adds a `--json` option (exclusive with other options) to `info` and `run` commands in order to dump those data as JSON.

On my current `pdm` workspace, it give those results

### `pdm run --json`
```json
{
  "complete": {
    "name": "complete",
    "kind": "call",
    "help": "Create autocomplete files for bash and fish",
    "args": "tasks.complete:main"
  },
  "doc": {
    "name": "doc",
    "kind": "shell",
    "help": "Start the dev server for doc preview",
    "args": "cd docs && mkdocs serve"
  },
  "lint": {
    "name": "lint",
    "kind": "cmd",
    "help": "pre-commit run --all-files",
    "args": "pre-commit run --all-files"
  },
  "pre_release": {
    "name": "pre_release",
    "kind": "cmd",
    "help": "python tasks/max_versions.py",
    "args": "python tasks/max_versions.py"
  },
  "release": {
    "name": "release",
    "kind": "cmd",
    "help": "python tasks/release.py",
    "args": "python tasks/release.py"
  },
  "test": {
    "name": "test",
    "kind": "cmd",
    "help": "pytest",
    "args": "pytest"
  },
  "tox": {
    "name": "tox",
    "kind": "cmd",
    "help": "tox",
    "args": "tox"
  }
}
```

### `pdm info --json`
```json
{
  "pdm": {
    "version": "2.5.4.dev5+g8d452e0d.d20230425.editable"
  },
  "python": {
    "interpreter": "/home/noirbizarre/Workspaces/_contribs/pdm/.venv/bin/python",
    "version": "3.11",
    "markers": {
      "implementation_name": "cpython",
      "implementation_version": "3.11.3",
      "os_name": "posix",
      "platform_machine": "x86_64",
      "platform_release": "6.2.12-arch1-1",
      "platform_system": "Linux",
      "platform_version": "#1 SMP PREEMPT_DYNAMIC Thu, 20 Apr 2023 16:11:55 +0000",
      "python_full_version": "3.11.3",
      "platform_python_implementation": "CPython",
      "python_version": "3.11",
      "sys_platform": "linux"
    }
  },
  "project": {
    "root": "/home/noirbizarre/Workspaces/_contribs/pdm",
    "pypackages": "/home/noirbizarre/Workspaces/_contribs/pdm/__pypackages__/3.11"
  }
}
```

## Use cases

Here some possible use cases:
- shell introspection using `jq`
- Conditional steps in CI (if command is present, then ...)
- automatic doc generation
- cross projects inventory/analysis