### PR TITLE
feat(scripts): hide tasks starting with an underscore from listing

### DIFF
--- a/docs/docs/usage/scripts.md
+++ b/docs/docs/usage/scripts.md
@@ -260,6 +260,9 @@ $ pdm run --list
 
 You can add an `help` option with the description of the script, and it will be displayed in the `Description` column in the above output.
 
+!!! note
+    Tasks with a name starting with an underscore (`_`) are considered internal (helpers...) and are not shown in the listing.
+
 ## Pre & Post Scripts
 
 Like `npm`, PDM also supports tasks composition by pre and post scripts, pre script will be run before the given task and post script will be run after.

--- a/news/1855.feature.md
+++ b/news/1855.feature.md
@@ -1,0 +1,1 @@
+Consider tasks with a name starting by an underscore (`_`) as internal tasks and hide them from the listing.

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -289,7 +289,7 @@ class TaskRunner:
         columns = ["Name", "Type", "Description"]
         result = []
         for name in sorted(self.project.scripts):
-            if name == "_":
+            if name.startswith("_"):
                 continue
             task = self.get_task(name)
             assert task is not None

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -386,6 +386,17 @@ def test_run_show_list_of_scripts(project, invoke):
     assert result_lines[4][1:-1].strip() == "test_shell     │ shell     │ shell command"
 
 
+def test_run_show_list_of_scripts_hide_internals(project, invoke):
+    project.pyproject.settings["scripts"] = {
+        "public": "true",
+        "_internal": "true",
+    }
+    project.pyproject.write()
+    result = invoke(["run", "--list"], obj=project)
+    assert "public" in result.output
+    assert "_internal" not in result.output
+
+
 def test_run_json_list_of_scripts(project, invoke):
     project.pyproject.settings["scripts"] = {
         "_": {"env_file": ".env"},


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

This PR is considering the tasks with a name starting with an underscore as internal tasks (helpers for composite...) and hide them from the listing.