### PR TITLE
feat: create venv when running pdm init -n

### DIFF
--- a/src/pdm/cli/actions.py
+++ b/src/pdm/cli/actions.py
@@ -155,7 +155,7 @@ def check_lockfile(project: Project, raise_not_exist: bool = True) -> str | None
             raise ProjectError("Lock file does not exist, nothing to install")
         project.core.ui.echo("Lock file does not exist", style="warning", err=True)
         return "all"
-    elif not project.is_lockfile_compatible():
+    elif not project.lockfile.is_compatible():
         project.core.ui.echo(
             "Lock file version is not compatible with PDM, installation may fail",
             style="warning",

--- a/src/pdm/cli/commands/init.py
+++ b/src/pdm/cli/commands/init.py
@@ -60,20 +60,6 @@ class Command(BaseCommand):
                 ignore_requires_python=True,
                 hooks=hooks,
             )
-            if project.config["python.use_venv"] and get_venv_like_prefix(python.executable) is None:
-                if termui.confirm(
-                    f"Would you like to create a virtualenv with [success]{python.executable}[/]?",
-                    default=True,
-                ):
-                    try:
-                        path = project._create_virtualenv()
-                        python = project.python = PythonInfo.from_path(get_venv_python(path))
-                    except Exception as e:  # pragma: no cover
-                        project.core.ui.echo(
-                            f"Error occurred when creating virtualenv: {e}\nPlease fix it and create later.",
-                            style="error",
-                            err=True,
-                        )
         else:
             python = actions.do_use(
                 project,
@@ -84,6 +70,20 @@ class Command(BaseCommand):
                 save=False,
                 hooks=hooks,
             )
+        if project.config["python.use_venv"] and get_venv_like_prefix(python.executable) is None:
+            if not self.interactive or termui.confirm(
+                f"Would you like to create a virtualenv with [success]{python.executable}[/]?",
+                default=True,
+            ):
+                try:
+                    path = project._create_virtualenv()
+                    python = project.python = PythonInfo.from_path(get_venv_python(path))
+                except Exception as e:  # pragma: no cover
+                    project.core.ui.echo(
+                        f"Error occurred when creating virtualenv: {e}\nPlease fix it and create later.",
+                        style="error",
+                        err=True,
+                    )
         if get_venv_like_prefix(python.executable) is None:
             project.core.ui.echo(
                 "You are using the PEP 582 mode, no virtualenv is created.\n"

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -26,7 +26,7 @@ from pdm.models.candidates import Candidate, make_candidate
 from pdm.models.python import PythonInfo
 from pdm.models.repositories import BaseRepository, LockedRepository
 from pdm.models.requirements import Requirement, parse_requirement, strip_extras
-from pdm.models.specifiers import PySpecSet, get_specifier
+from pdm.models.specifiers import PySpecSet
 from pdm.project.config import Config
 from pdm.project.lockfile import Lockfile
 from pdm.project.project_file import PyProject
@@ -526,20 +526,6 @@ class Project:
         algo, hash_value = hash_in_lockfile.split(":")
         content_hash = self.pyproject.content_hash(algo)
         return content_hash == hash_value
-
-    def is_lockfile_compatible(self) -> bool:
-        """Within the same major version, the higher lockfile generator can work with
-        lower lockfile but not vice versa.
-        """
-        if not self.lockfile.exists():
-            return True
-        lockfile_version = str(self.lockfile.file_version)
-        if not lockfile_version:
-            return False
-        if "." not in lockfile_version:
-            lockfile_version += ".0"
-        accepted = get_specifier(f"~={lockfile_version},>={lockfile_version}")
-        return accepted.contains(self.lockfile.spec_version)
 
     def get_pyproject_dependencies(self, group: str, dev: bool = False) -> tuple[list[str], bool]:
         """Get the dependencies array in the pyproject.toml

--- a/src/pdm/project/project_file.py
+++ b/src/pdm/project/project_file.py
@@ -10,6 +10,14 @@ from pdm.project.toml_file import TOMLBase
 from pdm.utils import deprecation_warning
 
 
+def _remove_empty_tables(doc: dict) -> None:
+    for k, v in list(doc.items()):
+        if isinstance(v, dict):
+            _remove_empty_tables(v)
+            if not v:
+                del doc[k]
+
+
 class PyProject(TOMLBase):
     """The data object representing th pyproject.toml file"""
 
@@ -30,6 +38,7 @@ class PyProject(TOMLBase):
 
     def write(self, show_message: bool = True) -> None:
         """Write the TOMLDocument to the file."""
+        _remove_empty_tables(self._data)
         super().write()
         if show_message:
             self.ui.echo("Changes are written to [success]pyproject.toml[/].")


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

When running `pdm init -n`(non-interactive mode), a venv will be created by default. Previously, the selected Python will be used under PEP 582 mode.