### PR TITLE
Fix a number of `ResourceWarning`s when running the test suite

### DIFF
--- a/news/1915.fix.md
+++ b/news/1915.fix.md
@@ -1,0 +1,1 @@
+Fix a number of `ResourceWarning`s when running the test suite with warnings enabled.

--- a/src/pdm/installers/installers.py
+++ b/src/pdm/installers/installers.py
@@ -50,11 +50,8 @@ def _is_namespace_package(root: str) -> bool:
         return False
     if not os.path.exists(os.path.join(root, "__init__.py")):  # PEP 420 style
         return True
-    init_py_lines = [
-        line.strip()
-        for line in Path(root, "__init__.py").open(encoding="utf-8")
-        if line.strip() and not line.strip().startswith("#")
-    ]
+    with Path(root, "__init__.py").open(encoding="utf-8") as f:
+        init_py_lines = [line.strip() for line in f if line.strip() and not line.strip().startswith("#")]
     namespace_identifiers = [
         # pkg_resources style
         "__import__('pkg_resources').declare_namespace(__name__)",

--- a/src/pdm/installers/installers.py
+++ b/src/pdm/installers/installers.py
@@ -50,7 +50,7 @@ def _is_namespace_package(root: str) -> bool:
         return False
     if not os.path.exists(os.path.join(root, "__init__.py")):  # PEP 420 style
         return True
-    int_py_lines = [
+    init_py_lines = [
         line.strip()
         for line in Path(root, "__init__.py").open(encoding="utf-8")
         if line.strip() and not line.strip().startswith("#")
@@ -63,7 +63,7 @@ def _is_namespace_package(root: str) -> bool:
     ]
     checker = namespace_identifiers[:]
     checker.extend(item.replace("'", '"') for item in namespace_identifiers)
-    return any(line in checker for line in int_py_lines)
+    return any(line in checker for line in init_py_lines)
 
 
 def _create_symlinks_recursively(source: str, destination: str) -> Iterable[str]:

--- a/src/pdm/installers/uninstallers.py
+++ b/src/pdm/installers/uninstallers.py
@@ -147,7 +147,8 @@ class BaseRemovePaths(abc.ABC):
                     dist.metadata["Name"],
                 )
             else:
-                link_pointer = os.path.normcase(egg_link_path.open("rb").readline().decode().strip())
+                with egg_link_path.open("rb") as f:
+                    link_pointer = os.path.normcase(f.readline().decode().strip())
                 if link_pointer != dist_location:
                     raise UninstallError(
                         f"The link pointer in {egg_link_path} doesn't match "
@@ -193,7 +194,8 @@ class BaseRemovePaths(abc.ABC):
         if path.endswith(".py"):
             self._paths.update(_cache_file_from_source(normalized_path))
         elif path.replace("\\", "/").endswith(".dist-info/REFER_TO"):
-            line = open(path, "rb").readline().decode().strip()
+            with open(path, "rb") as f:
+                line = f.readline().decode().strip()
             if line:
                 self.refer_to = line
 
@@ -217,7 +219,8 @@ class StashedRemovePaths(BaseRemovePaths):
     def _remove_pth(self) -> None:
         if not self._pth_entries:
             return
-        self._saved_pth = open(self._pth_file, "rb").read()
+        with open(self._pth_file, "rb") as f:
+            self._saved_pth = f.read()
         endline = "\r\n" if b"\r\n" in self._saved_pth else "\n"
         lines = self._saved_pth.decode().splitlines()
         for item in self._pth_entries:

--- a/src/pdm/termui.py
+++ b/src/pdm/termui.py
@@ -251,6 +251,7 @@ class UI:
         finally:
             logger.removeHandler(handler)
             unearth_logger.removeHandler(handler)
+            handler.close()
 
     def open_spinner(self, title: str) -> Spinner:
         """Open a spinner as a context manager."""


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [X] Test cases added for changed code.

Running the test suite with warnings enabled generates a large number of warnings because of open file descriptors. This PR closes the two offending file handles and also a few others found in the same code files. ~~Two~~ Four warnings remain, one of which is outside this project's control.
