### PR TITLE
Document ability to install deps from a plain URL

### DIFF
--- a/docs/docs/usage/dependency.md
+++ b/docs/docs/usage/dependency.md
@@ -62,6 +62,19 @@ dependencies = [
     ```
     Other backends doesn't support encoding relative paths in the URL and will write the absolute path instead.
 
+### URL dependencies
+
+PDM also supports downloading and installing packages directly from a web address.
+
+Examples:
+
+```bash
+# Install gzipped package from a plain URL
+pdm add "https://github.com/numpy/numpy/releases/download/v1.20.0/numpy-1.20.0.tar.gz"
+# Install wheel from a plain URL
+pdm add "https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.5.0/en_core_web_trf-3.5.0-py3-none-any.whl"
+```
+
 ### VCS dependencies
 
 You can also install from a git repository url or other version control systems. The following are supported:


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Small edit to the docs explicitly indicating that you can install deps straight from a URL. Reading the section on VCS deps it wasn't obvious to me that any HTTP(s) url works fine with pdm.