### PR TITLE
doc: fix XDG_CONFIG_HOME and XDG_CONFIG_DIRS on macOS, fix macOS capi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -763,7 +763,7 @@ Release v1.14.0 (2022-04-08)
 
 - Fix a bug that requirement with extras isn't resolved to the version as specified by the range. [#1001](https://github.com/pdm-project/pdm/issues/1001)
 - Replace the `${PROJECT_ROOT}` in the output of `pdm list`. [#1004](https://github.com/pdm-project/pdm/issues/1004)
-- Further fix the python path issue of MacOS system installed Python. [#1023](https://github.com/pdm-project/pdm/issues/1023)
+- Further fix the python path issue of macOS system installed Python. [#1023](https://github.com/pdm-project/pdm/issues/1023)
 - Fix the install path issue on Python 3.10 installed from homebrew. [#996](https://github.com/pdm-project/pdm/issues/996)
 
 ### Improved Documentation
@@ -1035,7 +1035,7 @@ Release v1.11.3 (2021-12-15)
 
 ### Miscellany
 
-- Fix an installation failure of the bootstrap script on MacOS Catalina. [#793](https://github.com/pdm-project/pdm/issues/793)
+- Fix an installation failure of the bootstrap script on macOS Catalina. [#793](https://github.com/pdm-project/pdm/issues/793)
 - Add a basic benchmarking script. [#794](https://github.com/pdm-project/pdm/issues/794)
 
 
@@ -1350,7 +1350,7 @@ Release v1.6.3 (2021-06-17)
 - Fix the format of dependency arrays when a new value is appended. [#487](https://github.com/pdm-project/pdm/issues/487)
 - Allow missing email attribute for authors and maintainers. [#492](https://github.com/pdm-project/pdm/issues/492)
 - Fix a bug that editable install shouldn't require pyproject.toml to be valid. [#497](https://github.com/pdm-project/pdm/issues/497)
-- Fix a bug on MacOS that purelib and platlib paths of isolated build envs cannot be substituted correctly if the Python is a framework build. [#502](https://github.com/pdm-project/pdm/issues/502)
+- Fix a bug on macOS that purelib and platlib paths of isolated build envs cannot be substituted correctly if the Python is a framework build. [#502](https://github.com/pdm-project/pdm/issues/502)
 - Fix the version sort of candidates. [#506](https://github.com/pdm-project/pdm/issues/506)
 
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ You can either pass the options after the script or set the env var value.
 
 ### Alternative Installation Methods
 
-If you are on MacOS and using `homebrew`, install it by:
+If you are on macOS and using `homebrew`, install it by:
 
 ```bash
 brew install pdm

--- a/README_zh.md
+++ b/README_zh.md
@@ -109,7 +109,7 @@ optional arguments:
 
 ### 其他安装方法
 
-如果你使用的是 MacOS 并且安装了 `homebrew`：
+如果你使用的是 macOS 并且安装了 `homebrew`：
 
 ```bash
 brew install pdm

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -24,7 +24,7 @@ in a similar way to `npm` that doesn't need to create a virtualenv at all!
 
 ## Installation
 
-PDM requires Python 3.7+ to be installed. It works on multiple platforms including Windows, Linux and MacOS.
+PDM requires Python 3.7+ to be installed. It works on multiple platforms including Windows, Linux and macOS.
 
 !!! note
     You can still have your project working on lower Python versions, read how to do it [here](usage/project.md#working-with-python-37).

--- a/docs/docs/usage/config.md
+++ b/docs/docs/usage/config.md
@@ -40,13 +40,13 @@ The configuration files are searched in the following order:
 where `<CONFIG_ROOT>` is:
 
 - `$XDG_CONFIG_HOME/pdm` (`~/.config/pdm` in most cases) on Linux as defined by [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
-- `~/Library/Preference/pdm` on MacOS as defined by [Apple File System Basics](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html)
+- `~/Library/Preferences/pdm` on macOS as defined by [Apple File System Basics](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html)
 - `%USERPROFILE%\AppData\Local\pdm` on Windows as defined in [Known folders](https://docs.microsoft.com/en-us/windows/win32/shell/known-folders)
 
 and `<SITE_CONFIG_ROOT>` is:
 
 - `$XDG_CONFIG_DIRS/pdm` (`/etc/xdg/pdm` in most cases) on Linux as defined by [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
-- `/Library/Preference/pdm` on MacOS as defined by [Apple File System Basics](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html)
+- `/Library/Preferences/pdm` on macOS as defined by [Apple File System Basics](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html)
 - `C:\ProgramData\pdm\pdm` on Windows as defined in [Known folders](https://docs.microsoft.com/en-us/windows/win32/shell/known-folders)
 
 If `-g/--global` option is used, the first item will be replaced by `<CONFIG_ROOT>/global-project/pdm.toml`.


### PR DESCRIPTION
## Describe what you have changed in this PR.

Documentation only:
on macOS `XDG_CONFIG_HOME` and `XDG_CONFIG_DIRS` is plural `Preferences` instead of singular `Preference`, as it is described in the link provided in the corrected file.

Changed MacOS to [macOS](https://en.wikipedia.org/wiki/MacOS) while I was at it.