### PR TITLE
Update publish.md to use run instead of runs

### DIFF
--- a/docs/docs/usage/publish.md
+++ b/docs/docs/usage/publish.md
@@ -34,7 +34,7 @@ jobs:
       - uses: pdm-project/setup-pdm@v3
 
       - name: Publish package distributions to PyPI
-        runs: pdm publish
+        run: pdm publish
 ```
 
 ## Build and publish separately


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

The documentation for the GitHub workflow incorrectly uses the key "runs" when it should be "run", per the [GitHub Actions Documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun)
