### PR TITLE
fix(docs): use `pdm sync` instead of `pdm install --no-lock`

### DIFF
--- a/docs/docs/usage/advanced.md
+++ b/docs/docs/usage/advanced.md
@@ -166,7 +166,7 @@ COPY src/ /project/src
 
 # install dependencies and project into the local packages directory
 WORKDIR /project
-RUN mkdir __pypackages__ && pdm install --prod --no-lock --no-editable
+RUN mkdir __pypackages__ && pdm sync --prod --no-editable
 
 
 # run stage

--- a/news/1947.doc.md
+++ b/news/1947.doc.md
@@ -1,0 +1,1 @@
+Update advanced.md to use `pdm sync` instead of `pdm install --no-lock`.


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

I changed the `Dockerfile` in the multi stages exemple to use `pdm sync` instead of `pdm install --no-lock`. Unless I am missing something both command do the same result but `pdm sync` seems to me to be the idomatic way, as described in [the doc](https://pdm.fming.dev/latest/usage/dependency/#install-the-packages-pinned-in-lock-file).