### PR TITLE
Add notes about Python version and license classifiers

### DIFF
--- a/docs/docs/reference/pep621.md
+++ b/docs/docs/reference/pep621.md
@@ -50,6 +50,46 @@ See [TOML's specification on strings](https://toml.io/en/v1.0.0#string).
 
     Read more information about other configurations in [dynamic versioning](build.md#dynamic-versioning).
 
+## Python version
+
+The required version of Python is specified as the string `requires-python`:
+
+```
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    ...
+]
+```
+
+Note: As per [PEP 621](https://peps.python.org/pep-0621/#allow-tools-to-add-extend-data),
+PDM is not permitted to dynamically update the `classifiers` section like some other non-compliant tools.
+Thus, you should also include the appropriate [trove classifiers](https://pypi.org/classifiers/)
+as shown above if you plan on publishing your package on [PyPI](https://pypi.org/).
+
+## License
+
+<!-- TODO: update following paragraphs if PEP 639 is accepted,
+see https://peps.python.org/pep-0639/#deprecate-license-classifiers -->
+
+The license is specified as the string `license`:
+
+```
+license = {text = "BSD-2-Clause"}
+classifiers = [
+    "License :: OSI Approved :: BSD License",
+    ...
+]
+```
+
+Note: As per [PEP 621](https://peps.python.org/pep-0621/#allow-tools-to-add-extend-data),
+PDM is not permitted to dynamically update the `classifiers` section like some other non-compliant tools.
+Thus, you should also include the appropriate [trove classifiers](https://pypi.org/classifiers/)
+as shown above if you plan on publishing your package on [PyPI](https://pypi.org/).
+
 ## Dependency specification
 
 The `project.dependencies` is an array of dependency specification strings following the [PEP 440](https://www.python.org/dev/peps/pep-0440/)


### PR DESCRIPTION
I added the suggestion from @mforbes in https://github.com/pdm-project/pdm/issues/1773#issuecomment-1475479530 (and added them as a co-author using the name and description on their GitHub profile).
