### PR TITLE
Close IO objects

### DIFF
--- a/src/pdm/cli/commands/publish/package.py
+++ b/src/pdm/cli/commands/publish/package.py
@@ -30,7 +30,11 @@ wheel_file_re = re.compile(
 
 
 def parse_metadata(fp: IO[bytes]) -> email.message.Message:
-    return email.message_from_file(io.TextIOWrapper(fp, encoding="utf-8", errors="surrogateescape"))
+    """
+    Note that this function will close fp. See https://github.com/python/cpython/issues/65562.
+    """
+    with io.TextIOWrapper(fp, encoding="utf-8", errors="surrogateescape") as file:
+        return email.message_from_file(file)
 
 
 @dataclass

--- a/src/pdm/models/working_set.py
+++ b/src/pdm/models/working_set.py
@@ -19,7 +19,8 @@ class EgglinkFinder(im.DistributionFinder):
         meta_finder = im.MetadataPathFinder()
         for link in found_links:
             name = link.stem
-            link_pointer = Path(link.open("rb").readline().decode().strip())
+            with link.open("rb") as file_link:
+                link_pointer = Path(file_link.readline().decode().strip())
             dist = next(
                 iter(
                     meta_finder.find_distributions(im.DistributionFinder.Context(name=name, path=[str(link_pointer)]))

--- a/tests/models/test_setup_parsing.py
+++ b/tests/models/test_setup_parsing.py
@@ -84,9 +84,10 @@ setup(name="foo", version="0.1.0", install_requires=['click', 'requests'],
             Setup("foo", "0.1.0", ["click", "requests"], {"tui": ["rich"]}, ">=3.6"),
         ),
         (
-            """from setuptools import setup
+            """from pathlib import Path
+from setuptools import setup
 
-version = open('__version__.py').read().strip()
+version = Path('__version__.py').read_text().strip()
 
 setup(name="foo", version=version)
 """,


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Close file handles. Attempt to fix e.g., these warnings.

```console
$ pdm lock --production
python.use_venv is on, creating a virtualenv for this project...
/usr/lib/python3.11/subprocess.py:1127: ResourceWarning: subprocess 76 is still running
  _warn("subprocess %s is still running" % self.pid,
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/usr/lib/python3.11/subprocess.py:1127: ResourceWarning: subprocess 75 is still running
  _warn("subprocess %s is still running" % self.pid,
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/usr/lib/python3.11/subprocess.py:1127: ResourceWarning: subprocess 77 is still running
  _warn("subprocess %s is still running" % self.pid,
ResourceWarning: Enable tracemalloc to get the object allocation traceback
sys:1: ResourceWarning: unclosed file <_io.BufferedReader name=4>
sys:1: ResourceWarning: unclosed file <_io.BufferedReader name=6>
sys:1: ResourceWarning: unclosed file <_io.BufferedReader name=3>
sys:1: ResourceWarning: unclosed file <_io.BufferedReader name=9>
sys:1: ResourceWarning: unclosed file <_io.BufferedReader name=7>
sys:1: ResourceWarning: unclosed file <_io.BufferedReader name=11>
Virtualenv is created successfully at /opt/templatepython/.venv
```