### PR TITLE
fix: Empty source tables causing errors when runing pdm

### DIFF
--- a/news/2034.bugfix.md
+++ b/news/2034.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug that empty source tables in configuration files causes errors when running pdm commands.

--- a/src/pdm/project/config.py
+++ b/src/pdm/project/config.py
@@ -260,7 +260,7 @@ class Config(MutableMapping[str, str]):
 
     def iter_sources(self) -> Iterator[RepositoryConfig]:
         for name, data in self._data.items():
-            if name.startswith(f"{SOURCE}.") and name not in self._config_map:
+            if name.startswith(f"{SOURCE}.") and name not in self._config_map and data:
                 yield RepositoryConfig(**data, name=name[len(SOURCE) + 1 :], config_prefix=SOURCE)
 
     def _save_config(self) -> None:

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -380,7 +380,7 @@ class Project:
             merge_sources(self.project_config.iter_sources())
             merge_sources(self.global_config.iter_sources())
         for source in result.values():
-            assert source.url, "Source URL must not be empty"
+            assert source.url, f"Source URL must not be empty for {source.name}"
             source.url = expand_env_vars_in_auth(source.url)
         return list(result.values())
 


### PR DESCRIPTION
Fixes #2034

Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
