### PR TITLE
feat: add `--project` option to `pdm venv`

### DIFF
--- a/news/2042.feature.md
+++ b/news/2042.feature.md
@@ -1,0 +1,1 @@
+Add `--project` option to `pdm venv` to support another path as the project root.

--- a/src/pdm/cli/commands/venv/__init__.py
+++ b/src/pdm/cli/commands/venv/__init__.py
@@ -9,7 +9,7 @@ from pdm.cli.commands.venv.list import ListCommand
 from pdm.cli.commands.venv.purge import PurgeCommand
 from pdm.cli.commands.venv.remove import RemoveCommand
 from pdm.cli.commands.venv.utils import get_venv_with_name
-from pdm.cli.options import Option
+from pdm.cli.options import project_option
 from pdm.project import Project
 
 
@@ -17,7 +17,7 @@ class Command(BaseCommand):
     """Virtualenv management"""
 
     name = "venv"
-    arguments: list[Option] = []
+    arguments = [project_option]
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         group = parser.add_mutually_exclusive_group()

--- a/tests/cli/test_venv.py
+++ b/tests/cli/test_venv.py
@@ -51,6 +51,16 @@ def test_venv_create_in_project(pdm, project):
 
 
 @pytest.mark.usefixtures("fake_create")
+def test_venv_create_other_location(pdm, project):
+    pdm(["venv", "-p", project.root.as_posix(), "create"], strict=True)
+    venv_path = project.root / ".venv"
+    assert venv_path.exists()
+    result = pdm(["venv", "-p", project.root.as_posix(), "create"])
+    assert result.exit_code == 1
+    assert "is not empty" in result.stderr
+
+
+@pytest.mark.usefixtures("fake_create")
 def test_venv_show_path(pdm, project):
     project.project_config["venv.in_project"] = True
     pdm(["venv", "create"], obj=project, strict=True)


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Add `--project` option to `pdm venv` to support another path as the project root.

Closes #2042 