### PR TITLE
fix: lock hooks emitted with dry_run=True when doing update

### DIFF
--- a/news/2060.bugfix.md
+++ b/news/2060.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug that `*_lock` hooks are always emitted with dry_run=True in `pdm update`.


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
