### PR TITLE
docs: fix Nox install command

### DIFF
--- a/docs/docs/usage/advanced.md
+++ b/docs/docs/usage/advanced.md
@@ -80,12 +80,12 @@ os.environ.update({"PDM_IGNORE_SAVED_PYTHON": "1"})
 
 @nox.session
 def tests(session):
-    session.run('pdm', 'install', '-G', 'test', external=True)
+    session.run_always('pdm', 'install', '-G', 'test', external=True)
     session.run('pytest')
 
 @nox.session
 def lint(session):
-    session.run('pdm', 'install', '-G', 'lint', external=True)
+    session.run_always('pdm', 'install', '-G', 'lint', external=True)
     session.run('flake8', '--import-order-style', 'google')
 ```
 


### PR DESCRIPTION
See https://github.com/wntrblm/nox/issues/711

`session.run_always` works more similarly to `session.install`.

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
Changed `session.run` to `session.run_always` for installing dependencies on Nox example.