### PR TITLE
feat: display the help information when running pdm directly

### DIFF
--- a/news/2081.feature.md
+++ b/news/2081.feature.md
@@ -1,0 +1,1 @@
+Displays the help information when running pdm directly

--- a/src/pdm/core.py
+++ b/src/pdm/core.py
@@ -153,7 +153,8 @@ class Core:
             use_venv(project, cast(str, options.use_venv))
 
         if command is None:
-            self.parser.error("No command given")
+            self.parser.print_help()
+            sys.exit(0)
         command.handle(project, options)
 
     def _get_cli_args(self, args: list[str], obj: Project | None) -> list[str]:

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -821,4 +821,4 @@ def test_empty_positional_args_display_help(project, pdm):
     assert result.exit_code == 0
     assert "Usage" in result.output
     assert "Commands" in result.output
-    assert "Options" in result.output
+    assert "Option" in result.output

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -806,7 +806,6 @@ def test_run_shortcut_fail_with_usage_if_script_not_found(project, pdm):
 @pytest.mark.parametrize(
     "args",
     [
-        pytest.param([], id="no args"),
         pytest.param(["-ko"], id="unknown param"),
         pytest.param(["pip", "--version"], id="not an user script"),
     ],
@@ -815,3 +814,11 @@ def test_empty_positionnal_args_still_display_usage(project, pdm, args):
     result = pdm(args, obj=project)
     assert result.exit_code != 0
     assert "Usage" in result.stderr
+
+
+def test_empty_positional_args_display_help(project, pdm):
+    result = pdm([], obj=project)
+    assert result.exit_code == 0
+    assert "Usage" in result.output
+    assert "Commands" in result.output
+    assert "Options" in result.output


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

As issue #2081 described, pdm will display the help information with exit code 0 when running directly.
