### PR TITLE
fix: avoid mistakenly passing command-line arguments while testing

### DIFF
--- a/news/2083.bugfix.md
+++ b/news/2083.bugfix.md
@@ -1,0 +1,1 @@
+Avoid mistakenly passing command-line arguments while testing.

--- a/src/pdm/core.py
+++ b/src/pdm/core.py
@@ -177,8 +177,9 @@ class Core:
     ) -> None:
         """The main entry function"""
 
-        # Ensure same behavior while testing and using the CLI
-        args = self._get_cli_args(args or sys.argv[1:], obj)
+        if args is None:
+            args = []
+        args = self._get_cli_args(args, obj)
         # Keep it for after project parsing to check if its a defined script
         root_script = None
         try:
@@ -287,4 +288,4 @@ class Core:
 
 def main(args: list[str] | None = None) -> None:
     """The CLI entry function"""
-    return Core().main(args)
+    return Core().main(args or sys.argv[1:])


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

* Separate the use cases for CLI and API
* for CLI usage, pass `args or sys.argv[1:]` as `args` to Core
* for API usage, use `[]` instead of `sys.argv[1:]` as default value of `args`, if `args` is `None`