### PR TITLE
fix: don't overwrite lockfile when locking in `pdm install`

### DIFF
--- a/news/2086.bugfix.md
+++ b/news/2086.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug that lockfile groups are overwritten when running locking in a preceding step of `pdm install`.

--- a/src/pdm/cli/commands/install.py
+++ b/src/pdm/cli/commands/install.py
@@ -83,7 +83,13 @@ class Command(BaseCommand):
                 project.core.ui.echo("Updating the lock file...", style="success", err=True)
                 unseleted = GroupSelection(project)
                 actions.do_lock(
-                    project, strategy=strategy, dry_run=options.dry_run, hooks=hooks, groups=unseleted.all()
+                    project,
+                    strategy=strategy,
+                    dry_run=options.dry_run,
+                    hooks=hooks,
+                    # We would like to keep the selected groups when the lockfile exists
+                    # but use the groups passed-in when creating a new lockfile.
+                    groups=unseleted.all() if strategy != "all" else selection.all(),
                 )
 
         actions.do_sync(

--- a/src/pdm/cli/commands/install.py
+++ b/src/pdm/cli/commands/install.py
@@ -81,9 +81,9 @@ class Command(BaseCommand):
                 sys.exit(1)
             if options.lock:
                 project.core.ui.echo("Updating the lock file...", style="success", err=True)
-
+                unseleted = GroupSelection(project)
                 actions.do_lock(
-                    project, strategy=strategy, dry_run=options.dry_run, hooks=hooks, groups=selection.all()
+                    project, strategy=strategy, dry_run=options.dry_run, hooks=hooks, groups=unseleted.all()
                 )
 
         actions.do_sync(


### PR DESCRIPTION
Fixes #2086

Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
