### PR TITLE
doc: improve help info format for subcommands

### DIFF
--- a/src/pdm/cli/commands/cache.py
+++ b/src/pdm/cli/commands/cache.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
     arguments = (verbose_option,)
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
-        subparsers = parser.add_subparsers(title="commands", metavar="cache")
+        subparsers = parser.add_subparsers(title="commands", metavar="")
         ClearCommand.register_to(subparsers, "clear")
         RemoveCommand.register_to(subparsers, "remove")
         ListCommand.register_to(subparsers, "list")

--- a/src/pdm/cli/commands/self_cmd.py
+++ b/src/pdm/cli/commands/self_cmd.py
@@ -65,7 +65,7 @@ class Command(BaseCommand):
         return super().register_to(subparsers, name, aliases=["plugin"], **kwargs)
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
-        subparsers = parser.add_subparsers(title="commands", metavar="self")
+        subparsers = parser.add_subparsers(title="commands", metavar="")
         ListCommand.register_to(subparsers)
         if not is_in_zipapp():
             AddCommand.register_to(subparsers)

--- a/src/pdm/cli/commands/venv/__init__.py
+++ b/src/pdm/cli/commands/venv/__init__.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
         group = parser.add_mutually_exclusive_group()
         group.add_argument("--path", help="Show the path to the given virtualenv")
         group.add_argument("--python", help="Show the python interpreter path for the given virtualenv")
-        subparser = parser.add_subparsers(metavar="venv", title="commands")
+        subparser = parser.add_subparsers(title="commands", metavar="")
         CreateCommand.register_to(subparser, "create")
         ListCommand.register_to(subparser, "list")
         RemoveCommand.register_to(subparser, "remove")

--- a/src/pdm/core.py
+++ b/src/pdm/core.py
@@ -78,12 +78,11 @@ class Core:
             "--config",
             help="Specify another config file path [env var: PDM_CONFIG_FILE] ",
         )
-        self.parser._positionals.title = "Commands"
         verbose_option.add_to_parser(self.parser)
         ignore_python_option.add_to_parser(self.parser)
         pep582_option.add_to_parser(self.parser)
 
-        self.subparsers = self.parser.add_subparsers(parser_class=ArgumentParser, dest="fooo")
+        self.subparsers = self.parser.add_subparsers(parser_class=ArgumentParser, title="commands", metavar="")
         for _, name, _ in pkgutil.iter_modules(COMMANDS_MODULE_PATH):
             module = importlib.import_module(f"pdm.cli.commands.{name}", __name__)
             try:

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -819,6 +819,6 @@ def test_empty_positionnal_args_still_display_usage(project, pdm, args):
 def test_empty_positional_args_display_help(project, pdm):
     result = pdm([], obj=project)
     assert result.exit_code == 0
-    assert "Usage" in result.output
-    assert "Commands" in result.output
-    assert "Option" in result.output
+    assert "Usage:" in result.output
+    assert "Commands:" in result.output
+    assert "Options:" in result.output


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Improve help info format for subcommands. 

* Set `metavar` to empty for subparsers
* Remove extra line breaks and indent block when action_help is empty
* Remove extra continuous spaces in usage info

By the way, it also fixed the help info difference for older Python version.