### PR TITLE
add optional keyring dependency target in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,7 @@ copier = ["copier"]
 cookiecutter = ["cookiecutter"]
 keyring = ["keyring"]
 template = [
-    "pdm[copier]",
-    "pdm[cookiecutter]",
+    "pdm[copier,cookiecutter]",
 ]
 truststore = ["truststore; python_version >= \"3.10\""]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ pytest = [
     "pytest",
     "pytest-mock",
 ]
+keyring = [
+    "keyring",
+]
 all = [
     "copier",
     "cookiecutter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,14 +53,16 @@ pytest = [
     "pytest",
     "pytest-mock",
 ]
-keyring = [
-    "keyring",
+copier = ["copier"]
+cookiecutter = ["cookiecutter"]
+keyring = ["keyring"]
+template = [
+    "pdm[copier]",
+    "pdm[cookiecutter]",
 ]
+truststore = ["truststore; python_version >= \"3.10\""]
 all = [
-    "copier",
-    "cookiecutter",
-    "keyring",
-    "truststore; python_version >= \"3.10\"",
+    "pdm[keyring,template,truststore]",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Hello.
Thank you very much for PDM, incredible work, much appreciated here.

We are considering recommending PDM for the whole company, but we would *very much* need our contributors being able to install PDM "the right way" (meaning: with keyring included from the start) in one go, simply (and not having to run `pip install keyring` or `pipx inject pdm keyring` afterward), because we really value the password being stored in a safe way. And what comes with the `all` optional dependencies really looks irrelevant and cumbersome for our use case.
We think `keyring` is a very, very import dependency. For comparison, Poetry made it mandatory.

If you think it's worth an entry in the NEWS file, I will fill one.

Thank you very much.