### PR TITLE
Allow specifying username and password in URL

### DIFF
--- a/news/2140.feature.md
+++ b/news/2140.feature.md
@@ -1,0 +1,1 @@
+Allow setting username and password in URL for publish command

--- a/src/pdm/cli/commands/publish/repository.py
+++ b/src/pdm/cli/commands/publish/repository.py
@@ -43,11 +43,14 @@ class Repository:
     def _ensure_credentials(self, username: str | None, password: str | None) -> tuple[str, str]:
         from pdm.models.auth import keyring
 
-        netloc = urlparse(self.url).netloc
+        parsed_url = urlparse(self.url)
+        netloc = parsed_url.netloc
         if username and password:
             return username, password
         if password:
             return "__token__", password
+        if parsed_url.username is not None and parsed_url.password is not None:
+            return parsed_url.username, parsed_url.password
         if keyring.enabled:
             auth = keyring.get_auth_info(self.url, username)
             if auth is not None:


### PR DESCRIPTION
This will allow setting authentication information when publishing like this: `pdm publish --repository
https://username:password@organization.pkgs.visualstudio.com/project/_packaging/feed/pypi/upload`

https://github.com/pdm-project/pdm/issues/2140