### PR TITLE
feat: Remove unused section from converted pyptoject.toml

### DIFF
--- a/news/2126.feature.md
+++ b/news/2126.feature.md
@@ -1,0 +1,1 @@
+Add code for remove unused toml section to conversion process for import command.

--- a/src/pdm/cli/commands/import_cmd.py
+++ b/src/pdm/cli/commands/import_cmd.py
@@ -92,4 +92,9 @@ class Command(BaseCommand):
                 "The project's [primary]requires-python[/] has been set to [primary]>="
                 f"{python_version}[/]. You can change it later if necessary."
             )
+
+        unused_keys = [key for key in pyproject["tool"].keys() if key not in ["pdm"]]
+        for key in unused_keys:
+            pyproject["tool"].pop(key)
+
         project.pyproject.write()


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

This PR is part of the solution to problem #2126.
It is intended to solve the following problem.

 * Existing sections `[tool.poetry.*]` are retained. there does not seem to be much need for these to be done.

These codes don't allow sections other than "pdm" to exist at the level below `[tool.*]` in the converted pyproject.toml.