### PR TITLE
Fix comparable_version()

### DIFF
--- a/news/2182.bugfix.md
+++ b/news/2182.bugfix.md
@@ -1,0 +1,1 @@
+Makes `comarable_version("1.2.3+local1") == Version("1.2.3")`.

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -19,7 +19,7 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from packaging.version import Version
+from packaging.version import Version, _cmpkey
 
 from pdm.compat import importlib_metadata
 
@@ -344,6 +344,17 @@ def comparable_version(version: str) -> Version:
     if parsed.local is not None:
         # strip the local part
         parsed._version = parsed._version._replace(local=None)
+
+        # To make comparable_version("1.2.3+local1") == Version("1.2.3")
+        parsed._key = _cmpkey(
+            parsed._version.epoch,
+            parsed._version.release,
+            parsed._version.pre,
+            parsed._version.post,
+            parsed._version.dev,
+            parsed._version.local,
+        )
+
     return parsed
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -147,6 +147,7 @@ def test_deprecation_warning():
     with pytest.raises(FutureWarning):
         utils.deprecation_warning("Test warning", raise_since="0.0")
 
+
 def test_comparable_version():
     assert utils.comparable_version("1.2.3") == Version("1.2.3")
     assert utils.comparable_version("1.2.3a1+local1") == Version("1.2.3a1")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import sys
 
 import pytest
 import tomlkit
+from packaging.version import Version
 
 from pdm import utils
 from pdm.cli import utils as cli_utils
@@ -145,3 +146,7 @@ def test_deprecation_warning():
 
     with pytest.raises(FutureWarning):
         utils.deprecation_warning("Test warning", raise_since="0.0")
+
+def test_comparable_version():
+    assert utils.comparable_version("1.2.3") == Version("1.2.3")
+    assert utils.comparable_version("1.2.3a1+local1") == Version("1.2.3a1")


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

This will complete the attribute editing procedure.
It makes `comarable_version("1.2.3+local1") == Version("1.2.3")` which is not achievable now.