### PR TITLE
Fix shell detection failure

### DIFF
--- a/news/2187.bugfix.md
+++ b/news/2187.bugfix.md
@@ -1,0 +1,1 @@
+Default behavior for pdm venv activate when shell detection fails.

--- a/src/pdm/cli/commands/venv/activate.py
+++ b/src/pdm/cli/commands/venv/activate.py
@@ -45,7 +45,10 @@ class ActivateCommand(BaseCommand):
         project.core.ui.echo(self.get_activate_command(venv))
 
     def get_activate_command(self, venv: VirtualEnv) -> str:  # pragma: no cover
-        shell, _ = shellingham.detect_shell()
+        try:
+            shell, _ = shellingham.detect_shell()
+        except shellingham.ShellDetectionFailure:
+            shell = None
         if shell == "fish":
             command, filename = "source", "activate.fish"
         elif shell == "csh":


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.
Now, if `pdm venv activate` fails to identify the shell (as it did with my zsh setup) it will use the default behavior instead of crashing.

Fixes #2187 