### PR TITLE
Fix cach file path's type to Path | str

### DIFF
--- a/src/pdm/models/caches.py
+++ b/src/pdm/models/caches.py
@@ -31,7 +31,7 @@ VT = TypeVar("VT")
 class JSONFileCache(Generic[KT, VT]):
     """A file cache that stores key-value pairs in a json file."""
 
-    def __init__(self, cache_file: Path) -> None:
+    def __init__(self, cache_file: Path | str) -> None:
         self.cache_file = Path(cache_file)
         self._cache: dict[str, VT] = {}
         self._read_cache()

--- a/src/pdm/models/caches.py
+++ b/src/pdm/models/caches.py
@@ -118,8 +118,8 @@ class HashCache:
     FAVORITE_HASH = "sha256"
     STRONG_HASHES = ("sha256", "sha384", "sha512")
 
-    def __init__(self, directory: Path) -> None:
-        self.directory = directory
+    def __init__(self, directory: Path | str) -> None:
+        self.directory = Path(directory)
 
     def _read_from_link(self, link: Link, session: Session) -> Iterable[bytes]:
         if link.is_file:
@@ -192,8 +192,8 @@ class WheelCache:
     one sdist, the one with most preferred tag will be returned.
     """
 
-    def __init__(self, directory: Path) -> None:
-        self.directory = directory
+    def __init__(self, directory: Path | str) -> None:
+        self.directory = Path(directory)
         self.ephemeral_directory = Path(create_tracked_tempdir(prefix="pdm-wheel-cache-"))
 
     def _get_candidates(self, path: Path) -> Iterable[Path]:
@@ -321,5 +321,5 @@ class SafeFileCache(SeparateBodyBaseCache):
 
 
 @lru_cache(maxsize=128)
-def get_wheel_cache(directory: Path) -> WheelCache:
+def get_wheel_cache(directory: Path | str) -> WheelCache:
     return WheelCache(directory)

--- a/src/pdm/models/caches.py
+++ b/src/pdm/models/caches.py
@@ -32,7 +32,7 @@ class JSONFileCache(Generic[KT, VT]):
     """A file cache that stores key-value pairs in a json file."""
 
     def __init__(self, cache_file: Path) -> None:
-        self.cache_file = cache_file
+        self.cache_file = Path(cache_file)
         self._cache: dict[str, VT] = {}
         self._read_cache()
 


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

I'm writing tests for `caches.py`, and I find that using `str` directory path is more convenient.
