### PR TITLE
remove "isolated_build" tox option in docs

### DIFF
--- a/docs/docs/usage/advanced.md
+++ b/docs/docs/usage/advanced.md
@@ -10,7 +10,6 @@ You can configure a `tox.ini` like the following to integrate your testing with 
 ```ini
 [tox]
 env_list = py{36,37,38},lint
-isolated_build = true
 
 [testenv]
 setenv =


### PR DESCRIPTION
`isolated_build` is [the default since tox 4](https://tox.wiki/en/latest/upgrading.html#isolated-environment-on-by-default) Tox 4.0.0 was released on [2022-12-07](https://tox.wiki/en/latest/changelog.html#v4-0-0-2022-12-07).
