### PR TITLE
Accommodate virtual envs on Windows that use Unix path hierarchy.

### DIFF
--- a/news/2236.bugfix.md
+++ b/news/2236.bugfix.md
@@ -1,0 +1,2 @@
+On Windows, try looking for the `virtualenv` `python.exe` binary under `bin/`
+as well as `Scripts/` and the `virtualenv`/`conda` root.

--- a/src/pdm/models/venv.py
+++ b/src/pdm/models/venv.py
@@ -17,7 +17,11 @@ def get_venv_python(venv: Path) -> Path:
     suffix = ".exe" if IS_WIN else ""
     result = venv / BIN_DIR / f"python{suffix}"
     if IS_WIN and not result.exists():
-        return venv / "python.exe"  # for conda
+        result = venv / "bin" / f"python{suffix}"  # for mingw64/msys2
+        if result.exists():
+            return result
+        else:
+            return venv / "python.exe"  # for conda
     return result
 
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code. **I'm not sure how to test this?** The [relevant test](https://github.com/cr1901/pdm/blob/25ae034dd2a4651cbb93513352e7f5e23765bfa4/tests/test_project.py#L111-L121) is going to always find `python` under `Scripts`.

## Describe what you have changed in this PR.

If using (a `pip install`'ed) `pdm` with a Python from the [MSYS2 project](https://www.msys2.org/), sometimes it is possible for `pdm` to fail to find the `python` binary in a freshly-created `virtualenv`:

```
William@DESKTOP-3H1DSBV MINGW64 ~/Projects/FPGA/amaranth/template-fpga
$ pdm install -v
STATUS: Resolving packages from lockfile...
The saved Python interpreter doesn't match the project's requirement. Trying to find another one.
python.use_venv is on, creating a virtualenv for this project...
Cleaning existing target directory C:/msys64/home/William/Projects/FPGA/amaranth/template-fpga/.venv
Run command: ['C:/msys64/mingw64/bin/python.exe', '-m', 'virtualenv',
'C:/msys64/home/William/Projects/FPGA/amaranth/template-fpga/.venv', '-p', 'C:/msys64/mingw64/bin/python.EXE',
'--prompt=template-fpga-3.11', '--no-pip', '--no-setuptools', '--no-wheel']
created virtual environment CPython3.11.5.final.0-64 in 196ms
  creator CPython3Windows(dest=C:/msys64/home/William/Projects/FPGA/amaranth/template-fpga/.venv, clear=False, no_vcs_ignore=False, glo

bal=False)
  activators BashActivator,BatchActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
Virtualenv is created successfully at C:/msys64/home/William/Projects/FPGA/amaranth/template-fpga/.venv
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:/msys64/mingw64/bin/pdm.exe/__main__.py", line 7, in <module>
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/core.py", line 290, in main
    return Core().main(args or sys.argv[1:])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/core.py", line 208, in main
    raise cast(Exception, err).with_traceback(traceback) from None
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/core.py", line 203, in main
    self.handle(project, options)
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/core.py", line 157, in handle
    command.handle(project, options)
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/cli/commands/install.py", line 95, in handle
    actions.do_sync(
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/cli/actions.py", line 197, in do_sync
    candidates = resolve_candidates_from_lockfile(project, requirements)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/cli/actions.py", line 138, in resolve_candidates_from_lockfile
    provider = project.get_provider(for_install=True)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/project/core.py", line 429, in get_provider
    repository = self.get_repository(ignore_compatibility=ignore_compatibility)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/project/core.py", line 397, in get_repository
    return cls(sources, self.environment, ignore_compatibility=ignore_compatibility)
                        ^^^^^^^^^^^^^^^^
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/project/core.py", line 280, in environment
    self._environment = self.get_environment()
                        ^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/project/core.py", line 259, in get_environment
    if self.config["python.use_venv"] and self.python.get_venv() is not None
                                          ^^^^^^^^^^^
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/project/core.py", line 150, in python
    if self._python.major < 3:
       ^^^^^^^^^^^^^^^^^^
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/models/python.py", line 57, in major
    return self.version.major
           ^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.11/functools.py", line 1001, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/models/python.py", line 53, in version
    return self._py_ver.version
           ^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.11/site-packages/findpython/python.py", line 81, in version
    self._version = self._get_version()
                    ^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.11/site-packages/findpython/python.py", line 180, in _get_version
    version = _run_script(
              ^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.11/site-packages/findpython/python.py", line 23, in _run_script
    return subprocess.run(
           ^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.11/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.11/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:/msys64/mingw64/lib/python3.11/subprocess.py", line 1538, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

This patch looks for the `virtualenv` `python` binary in an additional location (under `bin`) before falling back to the `conda` `python` binary.