### PR TITLE
[project] not [projects] for monorepo usage docs

### DIFF
--- a/docs/docs/usage/advanced.md
+++ b/docs/docs/usage/advanced.md
@@ -200,14 +200,14 @@ dev = [
 `packages/foo-cli/pyproject.toml`:
 
 ```toml
-[projects]
+[project]
 dependencies = ["foo-core"]
 ```
 
 `packages/foo-app/pyproject.toml`:
 
 ```toml
-[projects]
+[project]
 dependencies = ["foo-core"]
 ```
 


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

Neither required - this is fixing a typo.

## Describe what you have changed in this PR.

The monorepo docs under "advanced usage" have a typo in the example - `[projects]` should be `[project]`.