### PR TITLE
Cookiecutter raising exception instead of returning errcode

### DIFF
--- a/src/pdm/cli/commands/init.py
+++ b/src/pdm/cli/commands/init.py
@@ -71,9 +71,10 @@ class Command(BaseCommand):
                 err=True,
                 style="warning",
             )
-        retval = cookiecutter.main([options.template, *options.generator_args], standalone_mode=False)
-        if retval != 0:
-            raise RuntimeError("Cookiecutter exited with non-zero status code")
+        try:
+            cookiecutter.main([options.template, *options.generator_args], standalone_mode=False)
+        except SystemExit as e:
+            raise RuntimeError("Cookiecutter exited with an error") from e
 
     def _init_builtin(self, project: Project, options: argparse.Namespace) -> None:
         metadata = self.get_metadata_from_input(project, options)


### PR DESCRIPTION
Seems like click of cookiecutter has changed to return None instead of 0

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Seems like click of cookiecutter has changed to return None instead of 0
