### PR TITLE
Separate private pypi password with @ instead of slash

### DIFF
--- a/docs/docs/usage/config.md
+++ b/docs/docs/usage/config.md
@@ -156,7 +156,7 @@ You can specify credentials in the URL with `${ENV_VAR}` variable expansion and 
 ```toml
 [[tool.pdm.source]]
 name = "private"
-url = "https://${PRIVATE_PYPI_USERNAME}:${PRIVATE_PYPI_PASSWORD}/private.pypi.org/simple"
+url = "https://${PRIVATE_PYPI_USERNAME}:${PRIVATE_PYPI_PASSWORD}@private.pypi.org/simple"
 ```
 
 ### Configure HTTPS certificates


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Docs separate private pypi password and url with slash but should be a @ sign.