### PR TITLE
docs: fix `pdm use` example for in-project venv

### DIFF
--- a/docs/docs/usage/venv.md
+++ b/docs/docs/usage/venv.md
@@ -171,7 +171,7 @@ By default, if you use `pdm use` and select a non-venv Python, the project will 
 # Switch to a virtualenv named test
 $ pdm use --venv test
 # Switch to the in-project venv located at $PROJECT_ROOT/.venv
-$ pdm use --venv
+$ pdm use --venv in-project
 ```
 
 ## Disable virtualenv mode


### PR DESCRIPTION
Without specifying the `in-project` name:

> pdm use: error: argument --venv: expected one argument

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
