### PR TITLE
Fix `venv.md` markup

### DIFF
--- a/docs/docs/usage/venv.md
+++ b/docs/docs/usage/venv.md
@@ -87,8 +87,11 @@ Instead of spawning a subshell like what `pipenv` and `poetry` do, `pdm venv` do
     ```bash
     $ eval $(pdm venv activate for-test)
     (test-project-for-test) $  # Virtualenv entered
-    Fish
+    ```
 
+=== "Fish"
+
+    ```bash
     $ eval (pdm venv activate for-test)
     ```
 


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

This is how current markup is rendered:
<img width="699" alt="Снимок экрана 2023-10-17 в 20 02 47" src="https://github.com/pdm-project/pdm/assets/4660275/28380eb5-165e-413b-ba37-5ddacef8792a">

I think that this is not the intention. And the intention is to have a thrid tab with "Fish".