### PR TITLE
Export find-links correctly

### DIFF
--- a/news/2342.bugfix.md
+++ b/news/2342.bugfix.md
@@ -1,0 +1,1 @@
+Fix find_link sources being exported as `--extra--index-url`

--- a/src/pdm/formats/requirements.py
+++ b/src/pdm/formats/requirements.py
@@ -199,7 +199,13 @@ def export(
         url = source["url"]
         if options.expandvars:
             url = expand_env_vars_in_auth(url)
-        prefix = "--index-url" if source["name"] == "pypi" else "--extra-index-url"
+        source_type = source.get("type", "index")
+        if source_type == "index":
+            prefix = "--index-url" if source["name"] == "pypi" else "--extra-index-url"
+        elif source_type == "find_links":
+            prefix = "--find-links"
+        else:
+            raise ValueError(f"Unknown source type: {source_type}")
         lines.append(f"{prefix} {url}\n")
         if not source.get("verify_ssl", True):
             host = urllib.parse.urlparse(url).hostname

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -171,6 +171,13 @@ def test_expand_env_vars_in_source(project, monkeypatch):
     assert result.strip().splitlines()[-1] == "--index-url https://foo:bar@test.pypi.org/simple"
 
 
+def test_export_find_links(project, monkeypatch):
+    url = "https://storage.googleapis.com/jax-releases/jax_cuda_releases.html"
+    project.pyproject.settings["source"] = [{"url": url, "name": "jax", "type": "find_links"}]
+    result = requirements.export(project, [], Namespace(expandvars=False))
+    assert result.strip().splitlines()[-1] == f"--find-links {url}"
+
+
 def test_export_replace_project_root(project):
     artifact = FIXTURES / "artifacts/first-2.0.2-py2.py3-none-any.whl"
     shutil.copy2(artifact, project.root)


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.
Fix issue with find-links being exported as `--extra-index-url`.

Closes #2342 