### PR TITLE
fix: Subprocess signal forwarding on Windows

### DIFF
--- a/news/2292.bugfix.md
+++ b/news/2292.bugfix.md
@@ -1,0 +1,1 @@
+Fix pdm run does not catch ctrl-c on 2nd run (Win11)

--- a/news/2292.bugfix.md
+++ b/news/2292.bugfix.md
@@ -1,1 +1,1 @@
-Fix pdm run does not catch ctrl-c on 2nd run (Win11)
+Fix a bug preventing ctrl-c from interrupting program execution on 2nd invocation when using "pdm run" (Windows only).

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -198,7 +198,7 @@ class TaskRunner:
 
         def forward_signal(signum: int, frame: FrameType | None) -> None:
             if sys.platform == "win32" and signum == signal.SIGINT:
-                signum = signal.CTRL_C_EVENT
+                signum = signal.SIGTERM
             process.send_signal(signum)
 
         handle_term = signal.signal(signal.SIGTERM, forward_signal)


### PR DESCRIPTION
## Pull Request Checklist

- [ x] A news fragment is added in `news/` describing what is new.
- [ -] Test cases added for changed code.

## Describe what you have changed in this PR.
Updated the signal used to interrupt a process (CTRL-C pressed) on windows.

Tested with the following python script as adding a test case is not practical.
Verification:
1. Run the script. "pdm run test.py"
2. Enter CTRL-C : Script is terminated
3. Run the script. "pdm run test.py"
4. Enter CTRL-C : Script is terminated

Without the pull request step 4 will not terminante the process.
 
```python
from time import sleep

print(1)
while True:
    print(".", end="", flush=True)
    sleep(1)

```
