### PR TITLE
doc: fix the invalid dynamic versioning link

### DIFF
--- a/docs/docs/reference/pep621.md
+++ b/docs/docs/reference/pep621.md
@@ -48,7 +48,7 @@ See [TOML's specification on strings](https://toml.io/en/v1.0.0#string).
 
     The version will be read from the `mypackage/__version__.py` file searching for the pattern: `__version__ = "{version}"`.
 
-    Read more information about other configurations in [dynamic versioning](build.md#dynamic-versioning).
+    Read more information about other configurations in [dynamic project version](https://pdm-backend.fming.dev/metadata/#dynamic-project-version) from the `pdm-backend` documentation.
 
 ## Python version
 


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
Just link to the `pdm-backend` documentation, I guess most users are using the default backend.
Related issue: https://github.com/pdm-project/pdm/issues/2089