### PR TITLE
fix: Don't copy file permissions for templates

### DIFF
--- a/news/2379.bugfix.md
+++ b/news/2379.bugfix.md
@@ -1,0 +1,1 @@
+Fix template files created by `pdm init` being read-only when copied from a read-only PDM installation.

--- a/src/pdm/cli/templates/__init__.py
+++ b/src/pdm/cli/templates/__init__.py
@@ -93,7 +93,7 @@ class ProjectTemplate:
         src: ST,
         dst: Path,
         skip: list[ST] | None = None,
-        copyfunc: Callable[[ST, Path], Any] = shutil.copy2,  # type: ignore[assignment]
+        copyfunc: Callable[[ST, Path], Any] = shutil.copyfile,  # type: ignore[assignment]
         *,
         overwrite: bool = False,
     ) -> None:
@@ -113,7 +113,7 @@ class ProjectTemplate:
         from pdm.compat import importlib_resources
 
         with importlib_resources.as_file(src) as f:
-            return shutil.copy2(f, dst)
+            return shutil.copyfile(f, dst)
 
     def _generate_pyproject(self, path: Path, metadata: dict[str, Any]) -> None:
         import tomlkit

--- a/tests/cli/test_template.py
+++ b/tests/cli/test_template.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from pdm.cli.templates import ProjectTemplate
@@ -26,6 +28,7 @@ def test_module_project_template(project_no_init):
     assert project_no_init.pyproject.metadata["dependencies"] == ["idna", "chardet; os_name=='nt'"]
     assert project_no_init.pyproject.metadata["optional-dependencies"]["tests"] == ["pytest"]
     assert (project_no_init.root / "foo.py").exists()
+    assert os.access(project_no_init.root / "foo.py", os.W_OK)
 
 
 def test_module_project_template_generate_application(project_no_init):


### PR DESCRIPTION
When installing PDM through Nix (and other package managers with read-only file permissions) copying template permissions results in files which can't be used without chmod'ing them back to having write permissions.

It's best that we just create the files as the user copying them with default permissions.

Before:
```
$ pdm init
$ ls -la
total 16
drwx------  6 adisbladis users  200 Nov  8 12:47 .
drwxrwxrwt 56 root       root  1580 Nov  8 12:49 ..
-r--r--r--  1 adisbladis users 3102 Jan  1  1970 .gitignore
-rw-r--r--  1 adisbladis users   36 Nov  8 12:47 .pdm-python
drwxr-xr-x  2 adisbladis users   40 Nov  8 12:47 __pycache__
-rw-r--r--  1 adisbladis users  215 Nov  8 12:47 pyproject.toml
-r--r--r--  1 adisbladis users   18 Jan  1  1970 README.md
drwxr-xr-x  3 adisbladis users   60 Nov  8 12:47 src
drwxr-xr-x  3 adisbladis users   80 Nov  8 12:47 tests
drwxr-xr-x  4 adisbladis users  120 Nov  8 12:47 .venv
```

After:
```
$ pdm init
$ ls -la
total 16
drwx------  5 adisbladis users  180 Nov  8 12:50 .
drwxrwxrwt 56 root       root  1580 Nov  8 12:49 ..
-rw-r--r--  1 adisbladis users 3102 Nov  8 12:50 .gitignore
-rw-r--r--  1 adisbladis users   69 Nov  8 12:50 .pdm-python
drwxr-xr-x  2 adisbladis users   40 Nov  8 12:50 __pycache__
-rw-r--r--  1 adisbladis users  215 Nov  8 12:50 pyproject.toml
-rw-r--r--  1 adisbladis users   18 Nov  8 12:50 README.md
drwxr-xr-x  3 adisbladis users   60 Nov  8 12:50 src
drwxr-xr-x  3 adisbladis users   80 Nov  8 12:50 tests
```

## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.
