### PR TITLE
fix: Never wrap the output of the `export` command

### DIFF
--- a/news/2390.bugfix.md
+++ b/news/2390.bugfix.md
@@ -1,0 +1,1 @@
+Never wrap the output of the `export` command.

--- a/src/pdm/cli/commands/export.py
+++ b/src/pdm/cli/commands/export.py
@@ -75,4 +75,5 @@ class Command(BaseCommand):
         if options.output:
             Path(options.output).write_text(content, encoding="utf-8")
         else:
-            project.core.ui.echo(content, markup=False)
+            # Use a regular print to avoid any formatting / wrapping.
+            print(content)


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
We now use a regular print to avoid any formatting of the export command output.

Closes #2390