### PR TITLE
Provide response body upon HTTP fault with publish

### DIFF
--- a/news/2400.feature.md
+++ b/news/2400.feature.md
@@ -1,0 +1,1 @@
+Log the response text when `pdm publish` fails with HTTP error.

--- a/src/pdm/cli/commands/publish/__init__.py
+++ b/src/pdm/cli/commands/publish/__init__.py
@@ -25,8 +25,6 @@ if TYPE_CHECKING:
 
     from pdm.project import Project
 
-LIMIT_SIZE_RESPONSEDATA = 4096
-
 
 class Command(BaseCommand):
     """Build and publish the project to PyPI"""
@@ -73,11 +71,7 @@ class Command(BaseCommand):
         )
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
-            "--no-very-ssl",
-            action="store_false",
-            dest="verify_ssl",
-            help="Disable SSL verification",
-            default=None,
+            "--no-very-ssl", action="store_false", dest="verify_ssl", help="Disable SSL verification", default=None
         )
         group.add_argument(
             "--ca-certs",
@@ -112,11 +106,9 @@ class Command(BaseCommand):
             try:
                 response.raise_for_status()
             except requests.HTTPError as err:
-                message = str(err) + "\n"
-                if len(response.text) <= LIMIT_SIZE_RESPONSEDATA:
-                    message += response.text
-                else:
-                    message += response.text[:LIMIT_SIZE_RESPONSEDATA] + "\n...\n(truncated)\n"
+                message = str(err)
+                if response.text:
+                    logger.debug(response.text)
         if message:
             raise PublishError(message)
 
@@ -139,14 +131,7 @@ class Command(BaseCommand):
             config.ca_certs = ca_certs
         if options.verify_ssl is False:
             config.verify_ssl = options.verify_ssl
-        return Repository(
-            project,
-            config.url,
-            config.username,
-            config.password,
-            config.ca_certs,
-            config.verify_ssl,
-        )
+        return Repository(project, config.url, config.username, config.password, config.ca_certs, config.verify_ssl)
 
     def handle(self, project: Project, options: argparse.Namespace) -> None:
         hooks = HookManager(project, options.skip)

--- a/src/pdm/cli/commands/publish/__init__.py
+++ b/src/pdm/cli/commands/publish/__init__.py
@@ -87,9 +87,7 @@ class Command(BaseCommand):
         )
 
     @staticmethod
-    def _make_package(
-        filename: str, signatures: dict[str, str], options: argparse.Namespace
-    ) -> PackageFile:
+    def _make_package(filename: str, signatures: dict[str, str], options: argparse.Namespace) -> PackageFile:
         p = PackageFile.from_filename(filename, options.comment)
         if p.base_filename in signatures:
             p.add_gpg_signature(signatures[p.base_filename], p.base_filename + ".asc")
@@ -118,9 +116,7 @@ class Command(BaseCommand):
                 if len(response.text) <= LIMIT_SIZE_RESPONSEDATA:
                     message += response.text
                 else:
-                    message += (
-                        response.text[:LIMIT_SIZE_RESPONSEDATA] + "\n...\n(truncated)\n"
-                    )
+                    message += response.text[:LIMIT_SIZE_RESPONSEDATA] + "\n...\n(truncated)\n"
         if message:
             raise PublishError(message)
 
@@ -160,16 +156,8 @@ class Command(BaseCommand):
         if options.build:
             build.Command.do_build(project, hooks=hooks)
 
-        package_files = [
-            str(p)
-            for p in project.root.joinpath("dist").iterdir()
-            if not p.name.endswith(".asc")
-        ]
-        signatures = {
-            p.stem: str(p)
-            for p in project.root.joinpath("dist").iterdir()
-            if p.name.endswith(".asc")
-        }
+        package_files = [str(p) for p in project.root.joinpath("dist").iterdir() if not p.name.endswith(".asc")]
+        signatures = {p.stem: str(p) for p in project.root.joinpath("dist").iterdir() if p.name.endswith(".asc")}
 
         repository = self.get_repository(project, options)
         uploaded: list[PackageFile] = []
@@ -192,9 +180,7 @@ class Command(BaseCommand):
             )
             for package in packages:
                 resp = repository.upload(package, progress)
-                logger.debug(
-                    "Response from %s:\n%s %s", resp.url, resp.status_code, resp.reason
-                )
+                logger.debug("Response from %s:\n%s %s", resp.url, resp.status_code, resp.reason)
                 self._check_response(resp)
                 uploaded.append(package)
 


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Debugging the issue described in #2399 was hard, since PDM didn't provide the very helpful response body
`{"message":"Validation failed: Description is too long (maximum is 4000 characters)"}`. For some reason, capturing the traffic also didn't work out for me. And resorting to that would require much expertise from users.

This enhancement improves things in a straightforward, but simplistic manner. Ideal would be the ability to log all (structured) API endpoint response data to stdout throughout PDM. That would require more investment and architectural redesign.