### PR TITLE
add support for `{pdm}` placeholder in scripts

### DIFF
--- a/docs/docs/usage/scripts.md
+++ b/docs/docs/usage/scripts.md
@@ -245,11 +245,10 @@ $ pdm run test
 
 ### `{pdm}` placeholder
 
-Sometimes, you may have multiple PDM installations, or `pdm` installed with a different name. This
+Sometimes you may have multiple PDM installations, or `pdm` installed with a different name. This
 could for example occur in a CI/CD situation, or when working with different PDM versions in
-different repos. To make your scripts more robust you can use `{pdm}` in your shell scripts. This
-will expand to `{sys.executable} -m pdm`, which should invoke the same PDM variant with the same
-interpreter.
+different repos. To make your scripts more robust you can use `{pdm}` to use the PDM entrypoint
+executing the script. This will expand to `{sys.executable} -m pdm`.
 
 ```toml
 [tool.pdm.scripts]

--- a/docs/docs/usage/scripts.md
+++ b/docs/docs/usage/scripts.md
@@ -243,6 +243,32 @@ $ pdm run test
     `call` scripts don't support the `{args}` placeholder as they have
     access to `sys.argv` directly to handle such complexe cases and more.
 
+### `{pdm}` placeholder
+
+Sometimes, you may have multiple PDM installations, or `pdm` installed with a different name. This
+could for example occur in a CI/CD situation, or when working with different PDM versions in
+different repos. To make your scripts more robust you can use `{pdm}` in your shell scripts. This
+will expand to `{sys.executable} -m pdm`, which should invoke the same PDM variant with the same
+interpreter.
+
+```toml
+[tool.pdm.scripts]
+whoami = { shell = "echo `{pdm} -V` was called as '{pdm} -V'" }
+```
+will produce the following output:
+```shell
+$ pdm whoami
+PDM, version 0.1.dev2501+g73651b7.d20231115 was called as /usr/bin/python3 -m pdm -V
+
+$ pdm2.8 whoami
+PDM, version 2.8.0 was called as <snip>/venvs/pdm2-8/bin/python -m pdm -V
+```
+
+!!! note
+    While the above example uses PDM 2.8, this functionality was introduced in the 2.10 series and only backported for the showcase.
+
+
+
 ## Show the List of Scripts
 
 Use `pdm run --list/-l` to show the list of available script shortcuts:

--- a/news/2408.feature.md
+++ b/news/2408.feature.md
@@ -1,0 +1,1 @@
+Add support for {pdm} placeholder in script definitions to call the same PDM entrypoint

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -270,6 +270,7 @@ class TaskRunner:
         if kind == "composite":
             args = list(args)
             should_interpolate = any(RE_ARGS_PLACEHOLDER.search(script) for script in value)
+            should_interpolate = should_interpolate or any(RE_PDM_PLACEHOLDER.search(script) for script in value)
             code = 0
             for script in value:
                 if should_interpolate:

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -308,6 +308,20 @@ def test_run_script_with_args_placeholder_with_default(project, pdm, capfd, scri
     assert out.strip().splitlines()[1:] == expected
 
 
+def test_run_shell_script_with_pdm_placeholder(project, pdm):
+    project.pyproject.settings["scripts"] = {
+        "test_script": {
+            "shell": "{pdm} -V > output.txt",
+            "help": "test it won't fail",
+        }
+    }
+    project.pyproject.write()
+    with cd(project.root):
+        result = pdm(["run", "test_script"], obj=project)
+    assert result.exit_code == 0
+    assert (project.root / "output.txt").read_text().strip().startswith("PDM, version")
+
+
 def test_run_expand_env_vars(project, pdm, capfd, monkeypatch):
     (project.root / "test_script.py").write_text("import os; print(os.getenv('FOO'))")
     project.pyproject.settings["scripts"] = {


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code. 
    - Only found a single meaningful test-case -- I tried to do some more testing for the interpolation but it got far too complex with paths, dev versions etc.  

## Describe what you have changed in this PR.

As discussed on Discord, this adds support for using a `{pdm}` placeholder in scripts to refer to the current interpreter. I'm not sure if this should affect calls in any way, but I don't think so since they'd (presumably) use the same python interpreter/venv.