### PR TITLE
fix: resolve requirements paths relative to the requirement file they are specified in

### DIFF
--- a/news/2422.bugfix.md
+++ b/news/2422.bugfix.md
@@ -1,0 +1,1 @@
+Resolve `-r` requirements paths relative to the requirement file they are specified in

--- a/src/pdm/formats/requirements.py
+++ b/src/pdm/formats/requirements.py
@@ -52,7 +52,7 @@ class RequirementParser:
             return ""
         return line.split(" #", 1)[0].strip()
 
-    def _parse_line(self, line: str) -> None:
+    def _parse_line(self, filename: str, line: str) -> None:
         if not line.startswith("-"):
             # Starts with a requirement, just ignore all per-requirement options
             req_string = line.split(" -", 1)[0].strip()
@@ -76,7 +76,8 @@ class RequirementParser:
         if args.editable:
             self.requirements.append(parse_requirement(" ".join(args.editable), True))
         if args.requirement:
-            self.parse(args.requirement)
+            referenced_requirements = str(Path(filename).parent.joinpath(args.requirement))
+            self.parse(referenced_requirements)
 
     def parse(self, filename: str) -> None:
         with open(filename, encoding="utf-8") as f:
@@ -86,10 +87,10 @@ class RequirementParser:
                     this_line += line[:-1].rstrip() + " "
                     continue
                 this_line += line
-                self._parse_line(this_line)
+                self._parse_line(filename, this_line)
                 this_line = ""
             if this_line:
-                self._parse_line(this_line)
+                self._parse_line(filename, this_line)
 
 
 def check_fingerprint(project: Project, filename: PathLike) -> bool:


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

When the requirements parser encountered a `-r` requirements path reference it would pass the line directly to `open`, whereas under pip (I was importing a requirements project when encountered this) the `-r` references are resolved relative to the file in which they are specified. 

This diff changes the behaviour to resolve the file relative to where it was specified, rather than the current working directory.