### PR TITLE
fix default verbosity level in UI.echo docstring

### DIFF
--- a/src/pdm/termui.py
+++ b/src/pdm/termui.py
@@ -184,7 +184,7 @@ class UI:
 
         :param message: message with rich markup, defaults to "".
         :param err: if true print to stderr, defaults to False.
-        :param verbosity: verbosity level, defaults to NORMAL.
+        :param verbosity: verbosity level, defaults to QUIET.
         """
         if self.verbosity >= verbosity:
             console = _err_console if err else _console


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

`UI.echo` docstring default verobsity level was wrong. it was changed in [#2304](https://github.com/pdm-project/pdm/pull/2304/files#diff-731843a62f3036f02e987fb915be5c721aaad5010b252aa88383dd7184dafb11R180)
However, I am bit skeptical: shouldn't the default level be `NORMAL`?
