### PR TITLE
fix: Fix installing PEP 561 stub-only packages

### DIFF
--- a/news/2466.bugfix.md
+++ b/news/2466.bugfix.md
@@ -1,0 +1,1 @@
+Fix installing PEP 561 stub-only packages with `install.cache_method = "symlink"`.

--- a/src/pdm/installers/installers.py
+++ b/src/pdm/installers/installers.py
@@ -40,7 +40,7 @@ def _is_python_package(root: str | Path) -> bool:
     for child in Path(root).iterdir():
         if (
             child.is_file()
-            and child.suffix in (".py", ".pyc", ".pyo", ".pyd")
+            and child.suffix in (".py", ".pyc", ".pyo", ".pyd", ".pyi")
             or child.is_dir()
             and _is_python_package(child)
         ):


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

I have the following, very specific setup:
```
foo-bar:
foo/
    bar/
        __init__.py

foo-baz:
foo/
    baz.cpython-39-x86_64-linux-gnu.so
    baz/
        __init__.pyi
```

The `foo-bar` dependency provides a normal python module `foo.bar` inside a namespace package `foo`.
The `foo-baz` dependency provides an extension module `foo.baz` along with type stubs (`.pyi`), also inside namespace `foo`.

PDM currently mishandles those when installing with symlink support:
```
PDMWarning: Overwriting existing package: [...]
```

That's because the logic for installing namespace packages doesn't mark `foo/` in the `foo-baz` dependency as a namespace package since it not being a package at all:
https://github.com/pdm-project/pdm/blob/82a45743f0025322a155e8f5cb5af0aa6189c3a7/src/pdm/installers/installers.py#L97-L101
https://github.com/pdm-project/pdm/blob/82a45743f0025322a155e8f5cb5af0aa6189c3a7/src/pdm/installers/installers.py#L67-L69
https://github.com/pdm-project/pdm/blob/82a45743f0025322a155e8f5cb5af0aa6189c3a7/src/pdm/installers/installers.py#L39-L43

I see 2 issues here with PDM not being able to detect:
- packages providing only extension modules (`.so`)
- packages providing only type stubs (`.pyi`) ([PEP 561](https://peps.python.org/pep-0561/))

This fix hopefully addresses the second issue, which is enough for my use case.

I don't know whether extension modules can be safely detected similar way by the presence of `.so` files (not all `.so` files necessarily indicate a python module), so I didn't touch that one.