### PR TITLE
feat: Show subcommand's help info when passing unrecognized arguments

### DIFF
--- a/news/2480.feature.md
+++ b/news/2480.feature.md
@@ -1,0 +1,1 @@
+Show subcommand's help info when passing unrecognized arguments.

--- a/src/pdm/cli/utils.py
+++ b/src/pdm/cli/utils.py
@@ -9,6 +9,7 @@ import sys
 from collections import ChainMap, OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from fnmatch import fnmatch
+from gettext import gettext as _
 from json import dumps
 from pathlib import Path
 from typing import (
@@ -151,6 +152,13 @@ class ArgumentParser(argparse.ArgumentParser):
             "-h", "--help", action="help", default=argparse.SUPPRESS, help="Show this help message and exit."
         )
         self._optionals.title = "options"
+
+    def parse_known_args(self, args: Any = None, namespace: Any = None) -> Any:
+        args, argv = super().parse_known_args(args, namespace)
+        if argv:
+            msg = _("unrecognized arguments: %s")
+            self.error(msg % " ".join(argv))
+        return args, argv
 
 
 class ErrorArgumentParser(ArgumentParser):

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -1,0 +1,4 @@
+def test_help_with_unknown_arguments(pdm):
+    result = pdm(["add", "--unknown-args"])
+    assert "Usage: pdm add " in result.stderr
+    assert result.exit_code == 2


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

When passing unrecognized arguments to a pdm subcommand, pdm displays its own help info instead of the subcommand's one. It would be more helpful for users if pdm could display the help info of the subcommand.

This issue is caused by a known design of Python's argparse module, and the argparse module is not planning to improve it. (Refs: https://github.com/python/cpython/issues/83287 )

I found a modification on Stackoverflow, which I tried and found to be effective. (Refs: https://stackoverflow.com/a/61724607 )
