### PR TITLE
Update docs to remove export to `setup.py` information since that is not supported

### DIFF
--- a/docs/docs/usage/advanced.md
+++ b/docs/docs/usage/advanced.md
@@ -219,9 +219,9 @@ Look at the [🚀 Example repository](https://github.com/pdm-project/pdm-example
 
 [`pre-commit`](https://pre-commit.com/) is a powerful framework for managing git hooks in a centralized fashion. PDM already uses `pre-commit` [hooks](https://github.com/pdm-project/pdm/blob/main/.pre-commit-config.yaml) for its internal QA checks. PDM exposes also several hooks that can be run locally or in CI pipelines.
 
-### Export `requirements.txt` or `setup.py`
+### Export `requirements.txt`
 
-This hook wraps the command `pdm export` along with any valid argument. It can be used as a hook (e.g., for CI) to ensure that you are going to check in the codebase a `requirements.txt` or a `setup.py` file, which reflects the actual content of [`pdm lock`](../reference/cli.md#lock).
+This hook wraps the command `pdm export` along with any valid argument. It can be used as a hook (e.g., for CI) to ensure that you are going to check in the codebase a `requirements.txt`, which reflects the actual content of [`pdm lock`](../reference/cli.md#lock).
 
 ```yaml
 # export python requirements


### PR DESCRIPTION


## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Simply updated the docs to remove any references to an export to `setup.py`, since this is not supported.

I did not make a news fragment because it did not seem worthy to do that, and no test cases are needed.
