### PR TITLE
add a `PDM_CACHE_DIR` environment variable

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -32,9 +32,9 @@ pdm config theme.success '#51c7bd'
 The following configuration items can be retrieved and modified by [`pdm config`][pdm-config] command.
 
 | Config Item                       | Description                                                                          | Default Value                                                         | Available in Project | Env var                   |
-| --------------------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------- | -------------------- | ------------------------- |
+| --------------------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------- | -------------------- |---------------------------|
 | `build_isolation`                 | Isolate the build environment from the project environment                           | Yes                                                                   | Yes                  | `PDM_BUILD_ISOLATION`     |
-| `cache_dir`                       | The root directory of cached files                                                   | The default cache location on OS                                      | No                   |                           |
+| `cache_dir`                       | The root directory of cached files                                                   | The default cache location on OS                                      | No                   | `PDM_CACHE_DIR`           |
 | `check_update`                    | Check if there is any newer version available                                        | True                                                                  | No                   | `PDM_CHECK_UPDATE`        |
 | `global_project.fallback`         | Use the global project implicitly if no local project is found                       | `False`                                                               | No                   |                           |
 | `global_project.fallback_verbose` | If True show message when global project is used implicitly                          | `True`                                                                | No                   |                           |

--- a/news/2485.feature.md
+++ b/news/2485.feature.md
@@ -1,0 +1,1 @@
+add `PDM_CACHE_DIR` environment variable to configure cache directory location.

--- a/src/pdm/project/config.py
+++ b/src/pdm/project/config.py
@@ -99,6 +99,7 @@ class Config(MutableMapping[str, str]):
             "The root directory of cached files",
             platformdirs.user_cache_dir("pdm"),
             True,
+            env_var="PDM_CACHE_DIR",
         ),
         "check_update": ConfigItem(
             "Check if there is any newer version available",


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
I made `cache_dir`configurable through an environment variable. Some CI impose some restriction on the location of what can be cached. For example, Gitlab CI mandates that the cache directory be a children of the build directory. And `pdm config cache_dir` is hardly usable when you have a big CI configuration where many blocs override each others.

I saw the `$HOME` tricks recommended by the env var but I think it would break our code base.