### PR TITLE
docs: Fix typo in usage example

### DIFF
--- a/docs/docs/usage/dependency.md
+++ b/docs/docs/usage/dependency.md
@@ -421,7 +421,7 @@ You can also pass `--resolve` to `pdm list`, which will show the packages resolv
 By default, name, version and location will be shown in the list output, you can view more fields or specify the order of fields by `--fields` option:
 
 ```bash
-pdm list --fields name,license,version
+pdm list --fields name,licenses,version
 ```
 
 For all supported fields, please refer to the [CLI reference](../reference/cli.md#list_1).

--- a/news/0.doc.md
+++ b/news/0.doc.md
@@ -1,0 +1,1 @@
+Fix typo in usage/dependency docs.


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.

## Describe what you have changed in this PR.

Simply fixed a typo in an example of `pdm list`.
The `license` field doesn't exist, it should be `licenses`.