### PR TITLE
drop support for python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set Python 3.7
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.7
-          architecture: ${{ matrix.arch }}
       - name: Set Python 3.8
         uses: actions/setup-python@v4
         if: matrix.python-version != '3.8'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ extend-select = [
 extend-ignore = ["B018", "B019"]
 src = ["src"]
 exclude = ["tests/fixtures"]
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.mccabe]
 max-complexity = 10


### PR DESCRIPTION
support for python 3.7 has already been dropped, but some traces remain in a couple of places