### PR TITLE
fix(installers): don't warn when overwriting its own symlink on `install` with cache enabled (fixes #2502)

### DIFF
--- a/news/2502.bugfix.md
+++ b/news/2502.bugfix.md
@@ -1,0 +1,1 @@
+`pdm install` should not warn when overwriting its own symlinks on `install`/`update`.

--- a/src/pdm/installers/installers.py
+++ b/src/pdm/installers/installers.py
@@ -98,7 +98,8 @@ def _create_links_recursively(
             # A package, create link for the parent dir and don't proceed
             # for child directories
             if os.path.exists(destination_root):
-                warnings.warn(f"Overwriting existing package: {destination_root}", PDMWarning, stacklevel=2)
+                if not os.path.islink(destination_root):
+                    warnings.warn(f"Overwriting existing package: {destination_root}", PDMWarning, stacklevel=2)
                 if os.path.isdir(destination_root) and not os.path.islink(destination_root):
                     shutil.rmtree(destination_root)
                 else:


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code: N/A

## Describe what you have changed in this PR.

This PR ensure that `pdm` does not raise warning on `install`/`update` for symlinks it created himself when cache is enabled.

Fixes #2502
