### PR TITLE
fix(scripts): expose `$PYTHONPATH` in scripts if needed

### DIFF
--- a/news/2515.bugfix.md
+++ b/news/2515.bugfix.md
@@ -1,0 +1,1 @@
+Add `package-dir` to scripts `$PYTHONPATH` if project is not a library

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -189,6 +189,10 @@ class TaskRunner:
         project_env = project.environment
         this_path = project_env.get_paths()["scripts"]
         process_env.update(project_env.process_env)
+        if not project.is_library and project.package_dir:
+            pythonpath.insert(0, str(project.root / project.package_dir))
+        if pythonpath:
+            process_env["PYTHONPATH"] = os.pathsep.join(pythonpath)
         if env:
             process_env.update(env)
         if shell:

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -681,3 +681,9 @@ class Project:
     @property
     def is_library(self) -> bool:
         return bool(self.name) and self.pyproject.settings.get("package-type", "library") == "library"
+
+    @property
+    def package_dir(self) -> str | None:
+        """An optional directory containing the project sources"""
+        default = "src" if self.root.joinpath("src").exists() else None
+        return self.pyproject.settings.get("build", {}).get("package-dir", default)


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

This PR fixes the missing `PYTHONPATH` environment variable missing for script execution.
Before 2.11, it was not an issue because project were self-installing on `pdm install`.
Now, in `pdm>=2.11`, project are either `package-type=library` or `package-type=application`. Applications aren't self-installed anymore (and can't) so sources not at the project root are not visible anymore in scripts.
It is documented that `pdm` automatically handle non-root packages in 2 ways:
- explicit `tool.pdm:package-dir`
- implicit if there is a `src` directory
But this mechanism only exists in `pdm-backend`: https://github.com/pdm-project/pdm-backend/blob/main/src/pdm/backend/config.py#L250-L254

This PR:
- expose the resolved `package_dir` on the `Project` using the same algorithm than `pdm-backend`
- ensure the script `PYTHONPATH` is properly computed for `package-type=application` when `package-dir` is not the project root
- ensure the `PYTHONPATH` is properly injected (var was existing but not injected in the environment)