### PR TITLE
Update references to Python 3.7 in `docs/`

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -24,14 +24,14 @@ in a similar way to `npm` that doesn't need to create a virtualenv at all!
 
 ## Installation
 
-PDM requires Python 3.7+ to be installed. It works on multiple platforms including Windows, Linux and macOS.
+PDM requires Python 3.8+ to be installed. It works on multiple platforms including Windows, Linux and macOS.
 
 !!! note
     You can still have your project working on lower Python versions, read how to do it [here](usage/project.md#working-with-python-37).
 
 ### Recommended installation method
 
-PDM requires python version 3.7 or higher.
+PDM requires python version 3.8 or higher.
 
 Like Pip, PDM provides an installation script that will install PDM into an isolated environment.
 

--- a/docs/docs/usage/project.md
+++ b/docs/docs/usage/project.md
@@ -62,9 +62,9 @@ The value of `requires-python` is a [version specifier as defined in PEP 440](ht
 | `>=3.7,<3.11`           | Python 3.7, 3.8, 3.9 and 3.10            |
 | `>=3.6,!=3.8.*,!=3.9.*` | Python 3.6 and above, except 3.8 and 3.9 |
 
-## Working with Python < 3.7
+## Working with older Python versions
 
-Although PDM run on Python 3.7 and above, you can still have lower Python versions for your **working project**. But remember, if your project is a library, which needs to be built, published or installed, you make sure the PEP 517 build backend being used supports the lowest Python version you need. For instance, the default backend `pdm-backend` only works on Python 3.7+, so if you run [`pdm build`](../reference/cli.md#build) on a project with Python 3.6, you will get an error. Most modern build backends have dropped the support for Python 3.6 and lower, so it is highly recommended to upgrade the Python version to 3.7+. Here are the supported Python range for some commonly used build backends, we only list those that support PEP 621 since otherwise PDM can't work with them.
+Although PDM run on Python 3.8 and above, you can still have lower Python versions for your **working project**. But remember, if your project is a library, which needs to be built, published or installed, you make sure the PEP 517 build backend being used supports the lowest Python version you need. For instance, the default backend `pdm-backend` only works on Python 3.7+, so if you run [`pdm build`](../reference/cli.md#build) on a project with Python 3.6, you will get an error. Most modern build backends have dropped the support for Python 3.6 and lower, so it is highly recommended to upgrade the Python version to 3.7+. Here are the supported Python range for some commonly used build backends, we only list those that support PEP 621 since otherwise PDM can't work with them.
 
 | Backend               | Supported Python | Support PEP 621 |
 | --------------------- | ---------------- | --------------- |


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [X] Test cases added for changed code. (N/A)

## Describe what you have changed in this PR.
Drop references to Python 3.7 in docs/ files. I was reading the index page on `pdm-project.org/latest` when I noticed that some vestigial references to Python 3.7 were still hanging around after the `2.11.0` release.

There's also #2494, but it looks like that PR doesn't touch these files, only `ci.yml`.

