### PR TITLE
fix: don't use pypi.org when pypi.url is set

### DIFF
--- a/news/2560.bugfix.md
+++ b/news/2560.bugfix.md
@@ -1,0 +1,1 @@
+Don't use pypi.org when pypi.url is set.

--- a/src/pdm/environments/base.py
+++ b/src/pdm/environments/base.py
@@ -164,6 +164,7 @@ class BaseEnvironment(abc.ABC):
             verbosity=self.project.core.ui.verbosity,
             minimal_version=minimal_version,
         )
+        finder.sources.clear()
         for source in sources:
             assert source.url
             if source.type == "find_links":


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Set `index_urls` and `find_links` when init finder. Fix #2560
