### PR TITLE
fix: updates instructions for private repositories in pdm publish.

### DIFF
--- a/docs/docs/usage/publish.md
+++ b/docs/docs/usage/publish.md
@@ -26,6 +26,8 @@ jobs:
     name: upload release to PyPI
     runs-on: ubuntu-latest
     permissions:
+      # This permission is needed for private repositories.
+      contents: read
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

I have updated docs s.t. the github actions workflow example in the `Build and Publish` page would work for private repositories.

The reason it would previously not work is because settings of 
```yaml
permissions:
      id-token: write
```
would overwrite the default which is 
```yaml
permissions:
      contents: read
```
which results in a checkout fail.

See: actions/checkout#254 (not the issue itself, but the explanation here https://github.com/actions/checkout/issues/254#issuecomment-1603109591)