### PR TITLE
An option to run full composite despite to errors

### DIFF
--- a/docs/docs/usage/scripts.md
+++ b/docs/docs/usage/scripts.md
@@ -105,6 +105,17 @@ all = {composite = ["lint", "test"]}
 
 Running `pdm run all` will run `lint` first and then `test` if `lint` succeeded.
 
+To override the default behavior and continue the execution of the remaining
+scripts after a failure, set the `keep_going` option to `true`:
+
+```toml
+[tool.pdm.scripts]
+lint = "flake8"
+test = "pytest"
+all = {composite = ["lint", "test"]}
+all.keep_going = true
+```
+
 You can also provide arguments to the called scripts:
 
 ```toml

--- a/docs/docs/usage/scripts.md
+++ b/docs/docs/usage/scripts.md
@@ -116,6 +116,8 @@ all = {composite = ["lint", "test"]}
 all.keep_going = true
 ```
 
+If `keep_going` set to `true` return code of composite script is either '0' if all succeeded or the code of last failed individual script.
+
 You can also provide arguments to the called scripts:
 
 ```toml

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
         env: Mapping[str, str]
         env_file: EnvFileOptions | str | None
         help: str
+        keep_going: bool
         site_packages: bool
 
 
@@ -103,7 +104,7 @@ class TaskRunner:
     """The task runner for pdm project"""
 
     TYPES = ("cmd", "shell", "call", "composite")
-    OPTIONS = ("env", "env_file", "help", "site_packages")
+    OPTIONS = ("env", "env_file", "help", "keep_going", "site_packages")
 
     def __init__(self, project: Project, hooks: HookManager) -> None:
         self.project = project
@@ -270,7 +271,8 @@ class TaskRunner:
             args = list(args)
             should_interpolate = any(RE_ARGS_PLACEHOLDER.search(script) for script in value)
             should_interpolate = should_interpolate or any(RE_PDM_PLACEHOLDER.search(script) for script in value)
-            code = 0
+            composite_code = 0
+            keep_going = options.pop("keep_going", False) if options else False
             for script in value:
                 if should_interpolate:
                     script, _ = interpolate(script, args)
@@ -279,8 +281,10 @@ class TaskRunner:
                 subargs = split[1:] + ([] if should_interpolate else args)
                 code = self.run(cmd, subargs, options, chdir=True)
                 if code != 0:
-                    return code
-            return code
+                    if not keep_going:
+                        return code
+                    composite_code += code
+            return composite_code
         return self._run_process(
             args,
             chdir=True,

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -283,7 +283,7 @@ class TaskRunner:
                 if code != 0:
                     if not keep_going:
                         return code
-                    composite_code += code
+                    composite_code = code
             return composite_code
         return self._run_process(
             args,

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -619,10 +619,7 @@ def test_composite_keep_going_on_failure(project, pdm, capfd):
         "first": {"cmd": ["python", "-c", "print('First CALLED')"]},
         "fail": "python -c 'raise Exception'",
         "second": "echo 'Second CALLED'",
-        "test": {
-            "composite": ["first", "fail", "second"],
-            "keep_going": True
-        },
+        "test": {"composite": ["first", "fail", "second"], "keep_going": True},
     }
     project.pyproject.write()
     capfd.readouterr()


### PR DESCRIPTION
New option introduced that changes the behavior of composite script to executes all the scripts despite to present errors. Exit code is sum of all the codes.  The name of the option 'keep_going' is inspired/reused from 'GNU make' with similar/same purpose.

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.
