### PR TITLE
fix: properly handle interpreter resolution while importing

### DIFF
--- a/src/pdm/cli/commands/import_cmd.py
+++ b/src/pdm/cli/commands/import_cmd.py
@@ -88,7 +88,8 @@ class Command(BaseCommand):
             pyproject["build-system"] = DEFAULT_BACKEND.build_system()
 
         if "requires-python" not in pyproject["project"]:
-            python_version = f"{project.python.major}.{project.python.minor}"
+            python = project.resolve_interpreter(in_import=True)
+            python_version = f"{python.major}.{python.minor}"
             pyproject["project"]["requires-python"] = f">={python_version}"
             project.core.ui.echo(
                 "The project's [primary]requires-python[/] has been set to [primary]>="

--- a/src/pdm/formats/setup_py.py
+++ b/src/pdm/formats/setup_py.py
@@ -17,7 +17,8 @@ def check_fingerprint(project: Project, filename: Path) -> bool:
 def convert(project: Project, filename: Path, options: Any | None) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
     from pdm.models.in_process import parse_setup_py
 
-    parsed = parse_setup_py(str(project.environment.interpreter.executable), os.path.dirname(filename))
+    python = project.resolve_interpreter(in_import=True)
+    parsed = parse_setup_py(str(python.executable), os.path.dirname(filename))
     metadata: dict[str, Any] = {}
     settings: dict[str, Any] = {}
     for name in [


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Add and use `Project.resolve_interpreter(in_import=True)` which does not memoize the result of resolution that uses a potentially incorrect `requires-python` information and does not create a virtualenv from this (potentially wrong) python version.

Additionally, the quality of informational output from `Project.resolve_interpreter()` is improved, hiding some misleading messages during the first resolution.

Fixes #2608.
