### PR TITLE
fix/group exclusion

### DIFF
--- a/news/2670.bugfix.md
+++ b/news/2670.bugfix.md
@@ -1,0 +1,1 @@
+Made --without imply --with :all.

--- a/src/pdm/cli/filters.py
+++ b/src/pdm/cli/filters.py
@@ -32,6 +32,8 @@ class GroupSelection:
 
     @classmethod
     def from_options(cls, project: Project, options: argparse.Namespace) -> GroupSelection:
+        if getattr(options, "excluded_groups", None) and not options.groups:
+            options.groups = [":all"]
         if "group" in options:
             return cls(project, group=options.group, dev=options.dev)
         return cls(

--- a/src/pdm/cli/filters.py
+++ b/src/pdm/cli/filters.py
@@ -32,7 +32,7 @@ class GroupSelection:
 
     @classmethod
     def from_options(cls, project: Project, options: argparse.Namespace) -> GroupSelection:
-        if getattr(options, "excluded_groups", None) and not options.groups:
+        if getattr(options, "excluded_groups", None) and not options.groups and options.dev is None:
             options.groups = [":all"]
         if "group" in options:
             return cls(project, group=options.group, dev=options.dev)

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -345,3 +345,23 @@ def test_sync_all_with_excluded_groups(project, working_set, pdm, args):
     assert "urllib3" in working_set
     assert "pytz" not in working_set
     assert "pyopenssl" not in working_set
+
+
+def test_excluded_groups_ignored_if_prod_passed(project, working_set, pdm):
+    project.add_dependencies({"urllib3": parse_requirement("urllib3")}, "url")
+    project.add_dependencies({"pytz": parse_requirement("pytz")}, "tz")
+    project.add_dependencies({"pyopenssl": parse_requirement("pyopenssl")}, "ssl")
+    pdm(["install", "--prod", "--without", "ssl"], obj=project, strict=True)
+    assert "urllib3" not in working_set
+    assert "pytz" not in working_set
+    assert "pyopenssl" not in working_set
+
+
+def test_excluded_groups_ignored_if_dev_passed(project, working_set, pdm):
+    project.add_dependencies({"urllib3": parse_requirement("urllib3")}, "url")
+    project.add_dependencies({"pytz": parse_requirement("pytz")}, "tz")
+    project.add_dependencies({"pyopenssl": parse_requirement("pyopenssl")}, "ssl")
+    pdm(["install", "--dev", "--without", "ssl"], obj=project, strict=True)
+    assert "urllib3" not in working_set
+    assert "pytz" not in working_set
+    assert "pyopenssl" not in working_set

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -314,22 +314,34 @@ def test_fix_package_type_and_update(fixture_project, pdm, working_set):
     assert "test-package-type-fixer" not in working_set
 
 
-def test_install_all_with_excluded_groups(project, working_set, pdm):
+exclusion_cases = [
+    pytest.param(("-G", ":all", "--without", "tz,ssl"), id="-G :all --without tz,ssl"),
+    pytest.param(("-G", ":all", "--without", "tz", "--without", "ssl"), id="-G :all --without tz --without ssl"),
+    pytest.param(("--with", ":all", "--without", "tz,ssl"), id="--with all --without tz,ssl"),
+    pytest.param(("--with", ":all", "--without", "tz", "--without", "ssl"), id="--with all --without tz --without ssl"),
+    pytest.param(("--without", "tz", "--without", "ssl"), id="--without tz --without ssl"),
+    pytest.param(("--without", "tz,ssl"), id="--without tz,ssl"),
+]
+
+
+@pytest.mark.parametrize("args", exclusion_cases)
+def test_install_all_with_excluded_groups(project, working_set, pdm, args):
     project.add_dependencies({"urllib3": parse_requirement("urllib3")}, "url")
     project.add_dependencies({"pytz": parse_requirement("pytz")}, "tz")
     project.add_dependencies({"pyopenssl": parse_requirement("pyopenssl")}, "ssl")
-    pdm(["install", "-G", ":all", "--without", "tz,ssl"], obj=project, strict=True)
+    pdm(["install", *args], obj=project, strict=True)
     assert "urllib3" in working_set
     assert "pytz" not in working_set
     assert "pyopenssl" not in working_set
 
 
-def test_sync_all_with_excluded_groups(project, working_set, pdm):
+@pytest.mark.parametrize("args", exclusion_cases)
+def test_sync_all_with_excluded_groups(project, working_set, pdm, args):
     project.add_dependencies({"urllib3": parse_requirement("urllib3")}, "url")
     project.add_dependencies({"pytz": parse_requirement("pytz")}, "tz")
     project.add_dependencies({"pyopenssl": parse_requirement("pyopenssl")}, "ssl")
     pdm(["lock", "-G:all"], obj=project, strict=True)
-    pdm(["sync", "-G", ":all", "--without", "url,tz"], obj=project, strict=True)
-    assert "urllib3" not in working_set
+    pdm(["sync", *args], obj=project, strict=True)
+    assert "urllib3" in working_set
     assert "pytz" not in working_set
-    assert "pyopenssl" in working_set
+    assert "pyopenssl" not in working_set


### PR DESCRIPTION
## Pull Request Checklist

- [X] A news fragment is added in `news/` describing what is new.
- [X] Test cases added for changed code.

## Describe what you have changed in this PR.

Fixes unintuitive behaviour by making `--without` imply `--with :all` if no explicit groups given.

What should we do in the case of `--with foo --without foo`?  Currently if I read the logic right we silently drop it.
