### PR TITLE
chore: config codespell with pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,8 @@ repos:
     rev: v2.2.6
     hooks:
       - id: codespell  # See pyproject.toml for args
+        additional_dependencies:
+          - tomli
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.9.0


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Currently, codespell in pre-commit will fail as following even though corresponding ignorance is configured in `pyporject.toml`.  According to the documentation [1], to have the configuration in `pyproject.toml` take effect, we need to add `tomli` as `additional_dependencies`.

```shell
codespell................................................................Failed                                                                                                                       - hook id: codespell                                                                                                                                                                                  - exit code: 65

pyproject.toml:218: overriden ==> overridden
pyproject.toml:218: te ==> the, be, we, to
CHANGELOG.md:766: overriden ==> overridden
tests/cli/test_run.py:643: overriden ==> overridden
tests/cli/test_run.py:649: overriden ==> overridden
tests/cli/test_run.py:650: overriden ==> overridden
tests/cli/test_run.py:781: overriden ==> overridden
tests/cli/test_run.py:787: overriden ==> overridden
tests/cli/test_run.py:789: overriden ==> overridden
tests/cli/test_run.py:807: overriden ==> overridden
tests/cli/test_run.py:813: overriden ==> overridden
tests/cli/test_run.py:814: overriden ==> overridden
tests/cli/test_run.py:815: overriden ==> overridden
tests/cli/test_run.py:820: overriden ==> overridden
tests/cli/test_run.py:831: overriden ==> overridden
tests/cli/test_run.py:832: overriden ==> overridden
tests/cli/test_run.py:833: overriden ==> overridden
tests/fixtures/projects/demo-combined-extras/pyproject.toml:16: te ==> the, be, we, to
```

[1] https://github.com/codespell-project/codespell?tab=readme-ov-file#pre-commit-hook
