### PR TITLE
ensure poetry authors are parsed properly (fixes #2665)

### DIFF
--- a/news/2665.bugfix.md
+++ b/news/2665.bugfix.md
@@ -1,0 +1,2 @@
+Fix errors when parsing poetry format that contains special characters in author name.
+Poetry-specific `parse_name_email` and `NAME_EMAIL_RE` moved from `pdm.formats.base` to `pdm.formats.poetry`.

--- a/src/pdm/formats/base.py
+++ b/src/pdm/formats/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from typing import Any, Callable, Mapping, TypeVar, cast
 
 import tomlkit
@@ -86,9 +85,6 @@ class MetaConverter(metaclass=_MetaConverterMeta):
         return self._data, self.settings
 
 
-NAME_EMAIL_RE = re.compile(r"(?P<name>[^,]+?)\s*(?:<(?P<email>.+)>)?\s*$")
-
-
 def make_inline_table(data: Mapping) -> dict:
     """Create an inline table from the given data."""
     table = cast(dict, tomlkit.inline_table())
@@ -106,16 +102,3 @@ def make_array(data: list, multiline: bool = False) -> list:
 
 def array_of_inline_tables(value: list[Mapping], multiline: bool = True) -> list[str]:
     return make_array([make_inline_table(item) for item in value], multiline)
-
-
-def parse_name_email(name_email: list[str]) -> list[str]:
-    return array_of_inline_tables(
-        [
-            {
-                k: v
-                for k, v in NAME_EMAIL_RE.match(item).groupdict().items()  # type: ignore[union-attr]
-                if v is not None
-            }
-            for item in name_email
-        ]
-    )

--- a/tests/fixtures/pyproject.toml
+++ b/tests/fixtures/pyproject.toml
@@ -3,7 +3,8 @@ name = "poetry"
 version = "1.0.0"
 description = "Python dependency management and packaging made easy."
 authors = [
-    "Sébastien Eustace <sebastien@eustace.io>"
+    "Sébastien Eustace <sebastien@eustace.io>",
+    "Example, Inc. <inc@example.com>"
 ]
 license = "MIT"
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -77,10 +77,16 @@ def test_convert_poetry(project):
     with cd(FIXTURES):
         result, settings = poetry.convert(project, golden_file, ns())
 
-    assert result["authors"][0] == {
-        "name": "Sébastien Eustace",
-        "email": "sebastien@eustace.io",
-    }
+    assert result["authors"] == [
+        {
+            "name": "Sébastien Eustace",
+            "email": "sebastien@eustace.io",
+        },
+        {
+            "name": "Example, Inc.",
+            "email": "inc@example.com",
+        },
+    ]
     assert result["name"] == "poetry"
     assert result["version"] == "1.0.0"
     assert result["license"] == {"text": "MIT"}


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.


* Fix errors when parsing poetry format that contains special characters in author name (fixes #2665)
* Poetry-specific `parse_name_email` and `NAME_EMAIL_RE` moved from `pdm.formats.base` to `pdm.formats.poetry`.
