### PR TITLE
Fix incorrect Python version display in pdm use

### DIFF
--- a/news/2776.bugfix.md
+++ b/news/2776.bugfix.md
@@ -1,0 +1,1 @@
+Fix incorrect Python version display in pdm use

--- a/src/pdm/cli/commands/use.py
+++ b/src/pdm/cli/commands/use.py
@@ -124,7 +124,7 @@ class Command(BaseCommand):
             selected_python.get_venv() is None or is_conda_base_python(selected_python.path)
         ):
             venv_path = project._create_virtualenv(str(selected_python.path))
-            selected_python = PythonInfo.from_path(get_venv_python(venv_path))
+            selected_python = PythonInfo.from_path(get_venv_python(venv_path) if venv_path else selected_python.path)
         if not save:
             return selected_python
 


### PR DESCRIPTION
## Pull Request Checklist

- [X] A news fragment is added in `news/` describing what is new.
- [] Test cases added for changed code.

## Describe what you have changed in this PR.
fix: #2776 

# behavior before fix

```
(venv) mrsunglasses@fedora:~/oss/pdm$ pdm use 3.10 -v
STATUS: Downloading cpython@3.10.13
STATUS: Installing cpython@3.10.13
Successfully installed cpython@3.10.13
Version: 3.10.13
Executable: /home/mrsunglasses/.local/share/pdm/python/cpython@3.10.13/bin/python3
Cleaning existing target directory /home/mrsunglasses/oss/pdm/.venv
Run command: ['/home/mrsunglasses/oss/pdm/venv/bin/python', '-m', 'virtualenv', '/home/mrsunglasses/oss/pdm/.venv', '-p', 
'/home/mrsunglasses/.local/share/pdm/python/cpython@3.10.13/bin/python3', '--prompt=pdm-3.10', '--no-pip', '--no-setuptools', 
'--no-wheel']
created virtual environment CPython3.10.13.final.0-64 in 326ms
  creator CPython3Posix(dest=/home/mrsunglasses/oss/pdm/.venv, clear=False, no_vcs_ignore=False, global=False)
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
Virtualenv is created successfully at /home/mrsunglasses/oss/pdm/.venv
Using Python interpreter: /home/mrsunglasses/oss/pdm/.venv/bin/python (3.11)
```

# behavior after fix

```
(venv) mrsunglasses@fedora:~/oss/pdm$ pdm use 3.10 -v
INFO: Using the last selection, add '-i' to ignore it.
Cleaning existing target directory /home/mrsunglasses/oss/pdm/.venv
Run command: ['/home/mrsunglasses/oss/pdm/venv/bin/python', '-m', 'virtualenv', 
'/home/mrsunglasses/oss/pdm/.venv', '-p', 
'/home/mrsunglasses/.local/share/pdm/python/cpython@3.10.13/bin/python3', '--prompt=pdm-3.10', 
'--no-pip', '--no-setuptools', '--no-wheel']
created virtual environment CPython3.10.13.final.0-64 in 28ms
  creator CPython3Posix(dest=/home/mrsunglasses/oss/pdm/.venv, clear=False, no_vcs_ignore=False, global=False)
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
Virtualenv is created successfully at /home/mrsunglasses/oss/pdm/.venv
Using Python interpreter: /home/mrsunglasses/oss/pdm/.venv/bin/python (3.10)
```

