### PR TITLE
fix(venv): ensures that `PDM_IGNORE_ACTIVE_VENV` does not prevent finding an interpreter (fix #2779)

### DIFF
--- a/news/2779.bugfix.md
+++ b/news/2779.bugfix.md
@@ -1,0 +1,1 @@
+Fix PDM unable to find Python interpreters when `PDM_IGNORE_ACTIVE_VENV` is set


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

PDM was unable to find Python interpreters as soon as `PDM_IGNORE_ACTIVE_VENV` was set.
This PR fixes it

Fixes #2779 