### PR TITLE
fix: add all sources to trusted_hosts if verify_ssl is False

### DIFF
--- a/news/2784.bugfix.md
+++ b/news/2784.bugfix.md
@@ -1,0 +1,1 @@
+Check verify_ssl when trusting each source.

--- a/src/pdm/models/session.py
+++ b/src/pdm/models/session.py
@@ -134,15 +134,18 @@ class PDMPyPIClient(PyPIClient):
         self._trusted_host_ports: set[tuple[str, int | None]] = set()
         transport: httpx.BaseTransport | None = None
         for s in sources:
+            url = None
+            if s.url is not None:
+                url = httpx.URL(s.url)
+                if s.verify_ssl is False:
+                    self._trusted_host_ports.add((url.host, url.port))
             if s.name == "pypi":
                 transport = self._transport_for(s)
                 continue
-            assert s.url is not None
-            url = httpx.URL(s.url)
+            assert url is not None
             mounts[f"{url.scheme}://{url.netloc.decode('ascii')}/"] = hishel.CacheTransport(
                 self._transport_for(s), storage, controller
             )
-            self._trusted_host_ports.add((url.host, url.port))
         mounts.update(kwargs.pop("mounts", None) or {})
 
         httpx.Client.__init__(self, mounts=mounts, follow_redirects=True, transport=transport, **kwargs)

--- a/src/pdm/models/session.py
+++ b/src/pdm/models/session.py
@@ -134,15 +134,13 @@ class PDMPyPIClient(PyPIClient):
         self._trusted_host_ports: set[tuple[str, int | None]] = set()
         transport: httpx.BaseTransport | None = None
         for s in sources:
-            url = None
-            if s.url is not None:
-                url = httpx.URL(s.url)
-                if s.verify_ssl is False:
-                    self._trusted_host_ports.add((url.host, url.port))
+            assert s.url is not None
+            url = httpx.URL(s.url)
+            if s.verify_ssl is False:
+                self._trusted_host_ports.add((url.host, url.port))
             if s.name == "pypi":
                 transport = self._transport_for(s)
                 continue
-            assert url is not None
             mounts[f"{url.scheme}://{url.netloc.decode('ascii')}/"] = hishel.CacheTransport(
                 self._transport_for(s), storage, controller
             )


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
Fix #2784.
- Move the logic to update `session._trusted_host_ports` before checking the `pypi` source so the pypi source can also be trusted if necessary
- Check that `verify_ssl is False` before adding to the trusted host ports which seems in line with how things worked before pdm 2.13.3

I'm not familiar enough with this codebase to know how to properly add unit tests, but I did verify that `pdm sync` works with my custom pypi source after this change.