### PR TITLE
fix: name check for project itself in `pdm outdated`

### DIFF
--- a/news/2785.bugfix.md
+++ b/news/2785.bugfix.md
@@ -1,0 +1,1 @@
+Fix name check for project itself in `pdm outdated`

--- a/src/pdm/cli/commands/outdated.py
+++ b/src/pdm/cli/commands/outdated.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.utils import normalize_pattern
 from pdm.models.requirements import strip_extras
+from pdm.utils import normalize_name
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
@@ -95,7 +96,7 @@ class Command(BaseCommand):
         for name, distribution in installed.items():
             if not self._match_pattern(name, options.patterns):
                 continue
-            if name == project.name:
+            if name == normalize_name(project.name):
                 continue
             constrained_version = resolved.pop(name).version or "" if name in resolved else ""
             collected.append(ListPackage(name, distribution.version or "", constrained_version))

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -340,6 +340,7 @@ def get_rev_from_url(url: str) -> str:
     return ""
 
 
+@functools.lru_cache
 def normalize_name(name: str, lowercase: bool = True) -> str:
     name = re.sub(r"[^A-Za-z0-9]+", "-", name)
     return name.lower() if lowercase else name


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

This should fix #2785

1. Wrap `normalize_name` for `project.name` before name checking.
2. Add `lru_cache` for `normalize_name` function. 

<del>but I am not sure whether this is the best solution.</del>

<del>The cached property `normalized_name` for `Project` is added as the `normalize_name()` need to be triggered for multiple times in the for-loop and there are several other existence of `normalize_name(project.name)` in the repo. If this is OK, a follow up would be change those `normalize_name(project.name)` to `project.normalized_name`.</del>

<del>Other possible options:</del>
<del>1. Use a local variable, e.g., `normalized_project_name`, before the for-loop and use it inside.</del>
<del>3. Add `@lru_cache` for `normalize_name()`. </del>

BTW, I wonder the reason to use the normalized name rather than `distribution.name` directly as the key in `WorkingSet`.