### PR TITLE
fix: proxy environment variables are not recognised by pdm anymore on windows

### DIFF
--- a/news/2788.bugfix.md
+++ b/news/2788.bugfix.md
@@ -1,0 +1,1 @@
+Fix a regression that proxy env vars are not respected.


### PR DESCRIPTION
Fixes #2788

Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
