### PR TITLE
fix: make `--without` respect groups in `dev-dependencies`

### DIFF
--- a/news/2799.bugfix.md
+++ b/news/2799.bugfix.md
@@ -1,0 +1,1 @@
+Make `--without` respect groups in `dev-dependencies`

--- a/src/pdm/cli/filters.py
+++ b/src/pdm/cli/filters.py
@@ -88,8 +88,8 @@ class GroupSelection:
             groups_set.update(dev_groups)
         if ":all" in groups:
             groups_set.discard(":all")
-            optional_groups -= set(self.excluded_groups)
             groups_set.update(optional_groups)
+            groups_set -= set(self.excluded_groups)
 
         invalid_groups = groups_set - set(project.iter_groups())
         if invalid_groups:

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -327,7 +327,7 @@ exclusion_cases = [
 @pytest.mark.parametrize("args", exclusion_cases)
 def test_install_all_with_excluded_groups(project, working_set, pdm, args):
     project.add_dependencies({"urllib3": parse_requirement("urllib3")}, "url")
-    project.add_dependencies({"pytz": parse_requirement("pytz")}, "tz")
+    project.add_dependencies({"pytz": parse_requirement("pytz")}, "tz", True)
     project.add_dependencies({"pyopenssl": parse_requirement("pyopenssl")}, "ssl")
     pdm(["install", *args], obj=project, strict=True)
     assert "urllib3" in working_set
@@ -338,7 +338,7 @@ def test_install_all_with_excluded_groups(project, working_set, pdm, args):
 @pytest.mark.parametrize("args", exclusion_cases)
 def test_sync_all_with_excluded_groups(project, working_set, pdm, args):
     project.add_dependencies({"urllib3": parse_requirement("urllib3")}, "url")
-    project.add_dependencies({"pytz": parse_requirement("pytz")}, "tz")
+    project.add_dependencies({"pytz": parse_requirement("pytz")}, "tz", True)
     project.add_dependencies({"pyopenssl": parse_requirement("pyopenssl")}, "ssl")
     pdm(["lock", "-G:all"], obj=project, strict=True)
     pdm(["sync", *args], obj=project, strict=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -513,7 +513,7 @@ def test_dependency_group_selection(project, args, golden):
     [
         ({"groups": [":all"], "excluded_groups": ["web"]}, ["default", "auth", "test", "doc"]),
         ({"groups": [":all"], "excluded_groups": ["web", "auth"]}, ["default", "test", "doc"]),
-        ({"groups": [":all"], "excluded_groups": ["default", "test"]}, ["default", "web", "auth", "test", "doc"]),
+        ({"groups": [":all"], "excluded_groups": ["default", "test"]}, ["default", "web", "auth", "doc"]),
     ],
 )
 def test_exclude_optional_groups_from_all(project, args, golden):


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Fix #2799

I am not sure this is by design, let me know if I misunderstood anything.