### PR TITLE
fix: do not trigger recursive script error on multiple invocations

### DIFF
--- a/news/2829.bugfix.md
+++ b/news/2829.bugfix.md
@@ -1,0 +1,1 @@
+Fix recursive script detection on multiple invocations.

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -308,6 +308,7 @@ class TaskRunner:
             if task.kind == "composite":
                 if command in seen:
                     raise PdmUsageError(f"Script {command} is recursive.")
+                seen = seen.copy()
                 seen.add(command)
 
             self.hooks.try_emit("pre_script", script=command, args=args)

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -670,7 +670,8 @@ def test_composite_fails_on_recursive_script(project, pdm):
         "first": {"composite": ["first"]},
         "second": {"composite": ["third"]},
         "third": {"composite": ["second"]},
-        "forth": {"composite": ["python -V", "python -V"]},
+        "fourth": {"composite": ["python -V", "python -V"]},
+        "fifth": {"composite": ["fourth", "fourth"]},
     }
     project.pyproject.write()
     result = pdm(["run", "first"], obj=project)
@@ -681,7 +682,10 @@ def test_composite_fails_on_recursive_script(project, pdm):
     assert result.exit_code == 1
     assert "Script second is recursive" in result.stderr
 
-    result = pdm(["run", "forth"], obj=project)
+    result = pdm(["run", "fourth"], obj=project)
+    assert result.exit_code == 0
+
+    result = pdm(["run", "fifth"], obj=project)
     assert result.exit_code == 0
 
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

For correctly determining script recursion, rather than just multiple invocations of the same task/command e.g. when using different arguments, pass a copy of the `seen` set when recursively calling the next (nested) run task.

Otherwise, when a parent composite recursively runs a child composite, the original `seen` set will get mutated, which means any further invocations of the same child composite in the parent scope will be blocked by the (incorrect) recursion error.

Fixes issue #2829 