### PR TITLE
fix(cache): ensure installation and cache works with any environment

### DIFF
--- a/news/2839.bugfix.md
+++ b/news/2839.bugfix.md
@@ -1,0 +1,1 @@
+Fixes cached packages metadata files (`.referrers`) collisions on `sync` when using a `venv` with `symlink` cache method.

--- a/src/pdm/installers/installers.py
+++ b/src/pdm/installers/installers.py
@@ -66,7 +66,7 @@ class PackageWheelSource(WheelSource):
     def iter_files(self) -> Iterable[Path]:
         for root, _, files in os.walk(self.package.path):
             for file in files:
-                if Path(root) == self.package.path and file in (".checksum", ".lock"):
+                if Path(root) == self.package.path and file in CachedPackage.cache_files:
                     continue
                 yield Path(root, file)
 

--- a/src/pdm/models/cached_package.py
+++ b/src/pdm/models/cached_package.py
@@ -4,7 +4,7 @@ import os
 import shutil
 from functools import cached_property
 from pathlib import Path
-from typing import Any, ContextManager
+from typing import Any, ClassVar, ContextManager
 
 from pdm.termui import logger
 
@@ -21,6 +21,9 @@ class CachedPackage:
     Each line of the file is a distribution path that refers to this package.
     *Only wheel installations will be cached*
     """
+
+    cache_files: ClassVar[tuple[str, ...]] = (".lock", ".checksum", ".referrers")
+    """List of files storing cache metadata and not being part of the package"""
 
     def __init__(self, path: str | Path, original_wheel: Path | None = None) -> None:
         self.path = Path(os.path.normcase(os.path.expanduser(path))).resolve()


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Since a few versions I was having a lot of `sync`/`install` failures due to some cache file collisions (especially the `.referrers` file).

This PR ensure installers (with or without cache) are tested against both `PythonEnvironement` (virtualenv) and `PythonLocalEnvironment` (PEP582) because installation and caching might differ between both. (Only the `PythonLocalEnvironment` was tested).

It also tests cached installations across multiple projects with those environments allowing to reproduce my `.referrers` case:
When installing with cache in a virtualenv env, the referrer files was not linked on first install (because created after installation) but it was on the 2nd one.
As a side-effect, when installing 2 already cached packages in the same virtualenv, the 2nd one was failing because the `.referrers` file was already linked (root file), produced the following error:

```python-traceback
pdm.termui: Error occurs:
Traceback (most recent call last):
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/noirbizarre/.local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/installers/synchronizers.py", line 282, in install_candidate
    self.manager.install(can)
  File "/home/noirbizarre/.local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/installers/manager.py", line 32, in install
    dist_info = install_wheel(
                ^^^^^^^^^^^^^^
  File "/home/noirbizarre/.local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/installers/installers.py", line 189, in install_wheel
    dist_info_dir = install(source, destination=destination, additional_metadata=additional_metadata)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/noirbizarre/.local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/installers/installers.py", line 206, in install
    _install(source, destination, additional_metadata=additional_metadata or {})
  File "/home/noirbizarre/.local/pipx/venvs/pdm/lib/python3.11/site-packages/installer/_core.py", line 109, in install
    record = destination.write_file(
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/noirbizarre/.local/pipx/venvs/pdm/lib/python3.11/site-packages/installer/destinations.py", line 207, in write_file
    return self.write_to_fs(scheme, path_, stream, is_executable)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/noirbizarre/.local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/installers/installers.py", line 129, in write_to_fs
    os.symlink(src_path, target_path)
FileExistsError: [Errno 17] File exists: '/home/noirbizarre/.cache/pdm/packages/termcolor-2.4.0-py3-none-any.whl.cache/.referrers' -> '/tmp/pytest-of-noirbizarre/pytest-48/test_apply_fastapi_3_12_0/project/.venv/lib/python3.12/site-packages/.referrers'
pdm.termui: Error occurs
Traceback (most recent call last):
  File "/home/noirbizarre/.local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/termui.py", line 257, in logging
    yield logger
  File "/home/noirbizarre/.local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/cli/actions.py", line 238, in do_sync
    synchronizer.synchronize()
  File "/home/noirbizarre/.local/pipx/venvs/pdm/lib/python3.11/site-packages/pdm/installers/synchronizers.py", line 464, in synchronize
    raise InstallationError("Some package operations are not complete yet")
pdm.exceptions.InstallationError: Some package operations are not complete yet
```

Fixed by storing a list of cache metadata files on the `CachedPackage` class (avoiding to search/know where it is used in the codebase each time a new metadata file is created).