### PR TITLE
doc: build docs with Sphinx-style object inventory to support cross referencing from Sphinx documentation projects

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ plugins:
   - "mkdocs-version-annotations":
       version_added_admonition: "tip"
   - mkdocstrings:
+      enable_inventory: true
       handlers:
         python:
           options:

--- a/news/2841.doc.md
+++ b/news/2841.doc.md
@@ -1,0 +1,1 @@
+Build docs with object inventory to support cross references from Sphinx documentation projects.


### PR DESCRIPTION
Build docs with Sphinx-style object inventory to support cross referencing from Sphinx documentation projects.

Addresses #2841.

## Pull Request Checklist

- [Y ] A news fragment is added in `news/` describing what is new.
- [N/A] Test cases added for changed code.

## Describe what you have changed in this PR.

Added a new flag `enable_inventory: true` in the MkDocs YML to allow the docs to be built with a Sphinx-style object inventory to support markup cross references from external Sphinx documentation projects.
