### PR TITLE
fix(zsh): fix completion for `zsh` in when check update is enabled

### DIFF
--- a/news/2838.bugfix.md
+++ b/news/2838.bugfix.md
@@ -1,0 +1,1 @@
+Disable check update in `zsh` completion script.

--- a/src/pdm/cli/completions/pdm.zsh
+++ b/src/pdm/cli/completions/pdm.zsh
@@ -1,5 +1,6 @@
 #compdef pdm
 
+export PDM_CHECK_UPDATE=0
 PDM_PYTHON="%{python_executable}"
 PDM_PIP_INDEXES=($(command ${PDM_PYTHON} -m pdm config pypi.url))
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

This PR is a simpler fix to #2840: only disable update checking in `zsh` completions.

Fixes #2838 
Supersedes and closes #2840