### PR TITLE
fix: env inherited in nested composite

### DIFF
--- a/news/2849.bugfix.md
+++ b/news/2849.bugfix.md
@@ -1,0 +1,1 @@
+Fix env and other options being inherited in nested composite scripts.

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -277,6 +277,8 @@ class TaskRunner:
             should_interpolate = should_interpolate or any(RE_PDM_PLACEHOLDER.search(script) for script in value)
             composite_code = 0
             keep_going = options.pop("keep_going", False) if options else False
+            if opts:
+                cast(dict, options).update(**exec_opts(options, opts))
             for script in value:
                 if should_interpolate:
                     script, _ = interpolate(script, args)

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -640,7 +640,15 @@ def test_composite_inherit_env(project, pdm, capfd, _echo):
             "cmd": "python echo.py Second VAR",
             "env": {"VAR": "42"},
         },
-        "test": {"composite": ["first", "second"], "env": {"VAR": "overriden"}},
+        "nested": {
+            "composite": ["third"],
+            "env": {"VAR": "42"},
+        },
+        "third": {
+            "cmd": "python echo.py Third VAR",
+            "env": {"VAR": "42"},
+        },
+        "test": {"composite": ["first", "second", "nested"], "env": {"VAR": "overriden"}},
     }
     project.pyproject.write()
     capfd.readouterr()
@@ -648,6 +656,7 @@ def test_composite_inherit_env(project, pdm, capfd, _echo):
     out, _ = capfd.readouterr()
     assert "First CALLED with VAR=overriden" in out
     assert "Second CALLED with VAR=overriden" in out
+    assert "Third CALLED with VAR=overriden" in out
 
 
 def test_composite_fail_on_first_missing_task(project, pdm, capfd, _echo):


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

When running each script in a composite, instead of just forwarding `options` as defined on the current composite `Task`, merge them with input `opts` (from parent composite) using the already existing `exec_opts` helper function.

Fixes #2849