### PR TITLE
Update windows install docs "py" -> "python" (fixes #2860)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ Like Pip, PDM provides an installation script that will install PDM into an isol
 === "Windows"
 
     ```powershell
-    (Invoke-WebRequest -Uri https://pdm-project.org/install-pdm.py -UseBasicParsing).Content | py -
+    (Invoke-WebRequest -Uri https://pdm-project.org/install-pdm.py -UseBasicParsing).Content | python -
     ```
 
 For security reasons, you should verify the checksum of `install-pdm.py`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,8 +44,11 @@ Like Pip, PDM provides an installation script that will install PDM into an isol
 === "Windows"
 
     ```powershell
-    (Invoke-WebRequest -Uri https://pdm-project.org/install-pdm.py -UseBasicParsing).Content | python -
+    (Invoke-WebRequest -Uri https://pdm-project.org/install-pdm.py -UseBasicParsing).Content | py -
     ```
+
+!!! note
+    On Windows, if you do not have the optional ``py`` launcher installed (including if you installed Python through the Microsoft store), replace ``py`` with ``python``.
 
 For security reasons, you should verify the checksum of `install-pdm.py`.
 It can be downloaded from [install-pdm.py.sha256](https://pdm-project.org/install-pdm.py.sha256).


### PR DESCRIPTION
# Summary

This docs-only change updates the windows install instruction from ``| py -``, which is not always available (depending on how exactly you installed python on your system), to ``| python -``, which is always available (unless you don't add python to your ``PATH`` at all, in which case, you probably know what's wrong). See: #2860
