### PR TITLE
fix: pdm lock --update-reuse expands the $PROJECT_ROOT variable when extra dependencies are included

### DIFF
--- a/news/2852.bugfix.md
+++ b/news/2852.bugfix.md
@@ -1,0 +1,1 @@
+Keep the `${PROJECT_ROOT}` variable in dependencies after running `pdm lock --update-reuse`.

--- a/src/pdm/cli/utils.py
+++ b/src/pdm/cli/utils.py
@@ -539,12 +539,14 @@ def format_lockfile(
         deps: list[str] = []
         for r in fetched_dependencies[v.dep_key]:
             # Try to convert to relative paths to make it portable
-            if isinstance(r, FileRequirement) and r.path and r.path.is_absolute():
+            if isinstance(r, FileRequirement) and r.path:
                 try:
-                    r.path = Path(os.path.normpath(r.path)).relative_to(os.path.normpath(project.root))
-                    r.url = backend.relative_path_to_url(r.path.as_posix())
+                    if r.path.is_absolute():
+                        r.path = Path(os.path.normpath(r.path)).relative_to(os.path.normpath(project.root))
                 except ValueError:
                     pass
+                else:
+                    r.url = backend.relative_path_to_url(r.path.as_posix())
             deps.append(r.as_line())
         if len(deps) > 0:
             base.add("dependencies", make_array(sorted(deps), True))

--- a/src/pdm/models/setup.py
+++ b/src/pdm/models/setup.py
@@ -416,7 +416,7 @@ class SetupDistribution(Distribution):
         from pdm.models.markers import get_marker
         from pdm.models.requirements import parse_requirement
 
-        result = self._data.install_requires
+        result = self._data.install_requires[:]
         for extra, reqs in self._data.extras_require.items():
             extra_marker = f"extra == '{extra}'"
             for req in reqs:


### PR DESCRIPTION
Fixes #2852

Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
