### PR TITLE
fix(docs): fix incorrect link and example

### DIFF
--- a/docs/usage/dependency.md
+++ b/docs/usage/dependency.md
@@ -237,7 +237,7 @@ which is given by `--update-<strategy>` option:
 ### Update packages to the versions that break the version specifiers
 
 One can give `-u/--unconstrained` to tell PDM to ignore the version specifiers in the `pyproject.toml`.
-This works similarly to the `yarn upgrade -L/--latest` command. Besides, [`pdm update`](../reference/cli.md#update) also supports the
+This works similarly to the `yarn upgrade -L/--latest` command. Besides, [`pdm update`](../reference/cli.md#update_2) also supports the
 `--pre/--prerelease` option.
 
 ## Remove existing dependencies

--- a/docs/usage/scripts.md
+++ b/docs/usage/scripts.md
@@ -146,7 +146,7 @@ Besides, you can also define some fixed environment variables in your `pyproject
 ```toml
 [tool.pdm.scripts]
 start.cmd = "flask run -p 54321"
-start.env = {FOO = "bar", FLASK_ENV = "development"}
+start.env = {FOO = "bar", FLASK_DEBUG = "1"}
 ```
 
 Note how we use [TOML's syntax](https://github.com/toml-lang/toml) to define a composite dictionary.


### PR DESCRIPTION
* Fix the incorrect link for API doc
* Update the deprecated env var in the script example
