### PR TITLE
doc: add example for install by git+ssh

### DIFF
--- a/docs/usage/dependency.md
+++ b/docs/usage/dependency.md
@@ -101,6 +101,14 @@ pdm add "git+https://github.com/pypa/pip.git@22.0#egg=pip"
 pdm add "git+https://github.com/owner/repo.git@master#egg=pkg&subdirectory=subpackage"
 ```
 
+To use ssh scheme for git, just replace `https://` to `ssh://git@`
+
+Example:
+
+```bash
+pdm add "wheel @ git+ssh://git@github.com/pypa/wheel.git@main"
+```
+
 ### Hide credentials in the URL
 
 You can hide the credentials in the URL by using the `${ENV_VAR}` variable syntax:


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

In my network environment, install package by git+ssh is much faster than git+https

As the document missing this topic, it cost me quick a while to get it work last time.

When searching `pdm add by git+ssh` at internet, it is not easy to get an example.

It will help people who prefer to use ssh, if example added to the document. 