### PR TITLE
fix: pbs_installer interface (build_dir) for auto-install best match strategy

### DIFF
--- a/news/2943.bugfix.md
+++ b/news/2943.bugfix.md
@@ -1,0 +1,2 @@
+Fix new interface from pbs_installer regarding `build_dir` and best match auto-install strategy for `pdm use`
+(same as for `pdm python install --list`)

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "all", "doc", "pytest", "test", "tox", "workflow"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.2"
-content_hash = "sha256:edc13388ff5de58d9f0f3b6650d471ac4609dc8e18c9af5be0dab535e85649f5"
+content_hash = "sha256:70dd3dfa99bfaeec6ac6d28335a66a1810812cd215ce47eaf0faae87d8293358"
 
 [[package]]
 name = "anyio"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "importlib-metadata>=3.6; python_version < \"3.10\"",
     "hishel>=0.0.24,<0.1.0",
     "msgpack>=1.0",
-    "pbs-installer",
+    "pbs-installer>=2024.4.18",
     "httpx[socks]<1,>0.20",
     "filelock>=3.13",
 ]

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -793,7 +793,7 @@ class Project:
             for v, u in PYTHON_VERSIONS.items()
             if get_version(v) in self.python_requires
             and v.implementation.lower() == "cpython"
-            and u.get((THIS_PLATFORM, arch))
+            and u.get((THIS_PLATFORM, arch, True))
         ]
         return matches
 


### PR DESCRIPTION
## Pull Request Checklist

- [X] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Fix for new pbs_installer interface regarding `build_dir` and best match auto-install strategy for `pdm-use`. Basically the same fix as for `pdm python install --list` recently.