### PR TITLE
refactor: `pdm python install --list` re-use the same implementation …

### DIFF
--- a/news/2977.refactor.md
+++ b/news/2977.refactor.md
@@ -1,1 +1,1 @@
-Refactored `pdm python install --list` to re-use the same implementation as other cli commands that work with Python interpreters from pbs_installer
+Refactored `pdm python install --list` to reuse the same implementation as other cli commands that work with Python interpreters from pbs_installer

--- a/news/2977.refactor.md
+++ b/news/2977.refactor.md
@@ -1,0 +1,1 @@
+Refactored `pdm python install --list` to re-use the same implementation as other cli commands that work with Python interpreters from pbs_installer

--- a/src/pdm/cli/commands/python.py
+++ b/src/pdm/cli/commands/python.py
@@ -11,6 +11,7 @@ from pdm.cli.options import verbose_option
 from pdm.environments import BareEnvironment
 from pdm.exceptions import InstallationError, PdmArgumentError
 from pdm.models.python import PythonInfo
+from pdm.utils import get_all_installable_python_versions
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace, _SubParsersAction
@@ -102,13 +103,9 @@ class InstallCommand(BaseCommand):
         )
 
     def handle(self, project: Project, options: Namespace) -> None:
-        from pbs_installer._install import THIS_ARCH, THIS_PLATFORM
-        from pbs_installer._versions import PYTHON_VERSIONS
-
         if options.list:
-            for version, candidates in PYTHON_VERSIONS.items():
-                if (THIS_PLATFORM, THIS_ARCH, True) in candidates:
-                    project.core.ui.echo(str(version))
+            for version in get_all_installable_python_versions(build_dir=False):
+                project.core.ui.echo(str(version))
             return
         version = options.version
         if version is None:
@@ -136,7 +133,7 @@ class InstallCommand(BaseCommand):
         version, _, arch = version.partition("-")
         arch = "x86" if arch == "32" else (arch or THIS_ARCH)
 
-        ver, python_file = get_download_link(version, implementation=implementation, arch=arch)
+        ver, python_file = get_download_link(version, implementation=implementation, arch=arch, build_dir=False)
         with ui.open_spinner(f"Downloading [success]{ver}[/]") as spinner:
             destination = root / str(ver)
             interpreter = destination / "bin" / "python3" if sys.platform != "win32" else destination / "python.exe"

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Mapping
 
 from packaging.version import Version, _cmpkey
+from pbs_installer import PythonVersion
 
 from pdm.compat import importlib_metadata
 from pdm.exceptions import PDMDeprecationWarning, PdmException
@@ -537,3 +538,20 @@ def convert_to_datetime(value: str) -> datetime:
     if "T" in value:
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
+
+def get_all_installable_python_versions(build_dir: bool = False) -> list[PythonVersion]:
+    """Returns all installable standalone Python interpreter versions from @indygreg
+
+    Installable means:
+        Fitting current platform and arch
+
+    Parameters:
+        build_dir: Whether to include the `build/` directory from indygreg builds (aka 'Full Archive')
+    """
+    from pbs_installer._install import THIS_ARCH, THIS_PLATFORM
+    from pbs_installer._versions import PYTHON_VERSIONS
+
+    arch = "x86" if THIS_ARCH == "32" else THIS_ARCH
+    matches = [v for v, u in PYTHON_VERSIONS.items() if u.get((THIS_PLATFORM, arch, not build_dir))]
+    return matches

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -519,7 +519,7 @@ def test_env_setting_list(
 def test_project_best_match_max(project, mocker):
     expected = PythonVersion("cpython", 3, 10, 13)
     mocker.patch(
-        "pdm.project.core.Project._get_matching_python_versions",
+        "pdm.project.core.get_all_installable_python_versions",
         return_value=get_python_versions(),
     )
     assert project.get_best_matching_cpython_version() == expected
@@ -528,7 +528,7 @@ def test_project_best_match_max(project, mocker):
 def test_project_best_match_min(project, mocker):
     expected = PythonVersion("cpython", 3, 8, 0)
     mocker.patch(
-        "pdm.project.core.Project._get_matching_python_versions",
+        "pdm.project.core.get_all_installable_python_versions",
         return_value=get_python_versions(),
     )
     assert project.get_best_matching_cpython_version(use_minimum=True) == expected


### PR DESCRIPTION
…as other cli commands that work with Python interpreters from pbs_installer

## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Refactored using the same Python interpreter list across commands.
Made `build_dir=False` more verbose everywhere it is used