### PR TITLE
feat: run pdm sync in post-rewrite stage of pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -24,4 +24,5 @@
   stages:
     - post-checkout
     - post-merge
+    - post-rewrite
   always_run: true

--- a/news/2994.feature.md
+++ b/news/2994.feature.md
@@ -1,0 +1,1 @@
+Run pdm sync in "post-rewrite" stage of pre-commit


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Currently, pdm sync will not be triggered when "git rebase" which is supposed to be the "post-rewrite" stage. 

Let me know if you have any concern on this change.

Reference: https://[pre-commit](https://pre-commit.com/#post-rewrite).com/#post-rewrite