### PR TITLE
fix: resolve to real path in install-pdm

### DIFF
--- a/install-pdm.py
+++ b/install-pdm.py
@@ -236,7 +236,7 @@ class Installer:
             path = os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
             path = os.path.join(path, "pdm")
 
-        return Path(path)
+        return Path(path).resolve()
 
     def _make_env(self) -> Path:
         venv_path = self._path / "venv"

--- a/install-pdm.py.sha256
+++ b/install-pdm.py.sha256
@@ -1,1 +1,1 @@
-afa46cf5fec76c29e71e40dfd12fa5345c33400757964d397ed2708204aeded1  install-pdm.py
+e1c7f6455fa7ffc50cbc13e4d49c06dfaaf8e9b74d0c9b46287bf767f6a4e4fc  install-pdm.py


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Resolve all paths in `pdm-install` instead of only resolve user-specified path.
Fixes #2317.

It seems that there is a checksum (`.sha256`). Do I have to update it?