### PR TITLE
fix: zsh completion syntax error

### DIFF
--- a/news/3031.zshcompletion.md
+++ b/news/3031.zshcompletion.md
@@ -1,0 +1,1 @@
+Fix zsh completions

--- a/src/pdm/cli/completions/pdm.zsh
+++ b/src/pdm/cli/completions/pdm.zsh
@@ -51,7 +51,7 @@ _pdm() {
     {-I,--ignore-python}'[Ignore the Python path saved in .pdm-python]' \
     '--no-cache:Disable the cache for the current command. [env var: PDM_NO_CACHE]' \
     '--pep582:Print the command line to be eval by the shell for PEP 582:shell:(zsh bash fish tcsh csh)' \
-    {-n,--non-interactive}"[Don't show interactive prompts but use defaults. \[env var: PDM_NON_INTERACTIVE\]]"
+    {-n,--non-interactive}"[Don't show interactive prompts but use defaults. \[env var: PDM_NON_INTERACTIVE\]]" \
     '*:: :->_subcmds' \
     && return 0
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
zsh completions were broken. Fixed the syntax error

## Testing
Tested against my oh-my-zsh setup.

1. Install system pdm 2.17.0
2. `pdm completion zsh > $ZSH_CUSTOM/plugins/pdm/_pdm`
3. Type `pdm sync --` then tab. Error is reproduced
```bash
$ pdm sync --zsh: command not found: *:: :->_subcmds
zsh: command not found: *:: :->_subcmds
zsh: command not found: *:: :->_subcmds
zsh: command not found: *:: :->_subcmds
zsh: command not found: *:: :->_subcmds
zsh: command not found: *:: :->_subcmds
```
4. From within pdm fork: `pdm sync && pdm run pdm completion zsh > $ZSH_CUSTOM/plugins/pdm/_pdm`
5. Type `pdm sync --` then tab. See expected completions.

Closes #3031 