### PR TITLE
fix: No requires-python in project metadata crashes pdm

### DIFF
--- a/news/3062.bugfix.md
+++ b/news/3062.bugfix.md
@@ -1,0 +1,1 @@
+Fix a crash issue when `requires-python` is absent in the project metadata.

--- a/src/pdm/models/setup.py
+++ b/src/pdm/models/setup.py
@@ -405,10 +405,14 @@ class SetupDistribution(Distribution):
     @property
     def metadata(self) -> dict[str, Any]:  # type: ignore[override]
         return {
-            "Name": self._data.name,
-            "Version": self._data.version,
-            "Summary": self._data.summary,
-            "Requires-Python": self._data.python_requires,
+            k: v
+            for k, v in {
+                "Name": self._data.name,
+                "Version": self._data.version,
+                "Summary": self._data.summary,
+                "Requires-Python": self._data.python_requires,
+            }.items()
+            if v is not None
         }
 
     @property


### PR DESCRIPTION
Fixes #3062

Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
