### PR TITLE
feat: Allow pypi.verify_ssl to be configured via environmental variable

### DIFF
--- a/news/3081.feature.md
+++ b/news/3081.feature.md
@@ -1,0 +1,1 @@
+Allow pypi.verify_ssl to be configured via PDM_PYPI_VERIFY_SSL environmental variable.

--- a/src/pdm/project/config.py
+++ b/src/pdm/project/config.py
@@ -187,7 +187,8 @@ class Config(MutableMapping[str, str]):
         ),
         "pypi.verify_ssl": ConfigItem(
             "Verify SSL certificate when query PyPI",
-            True, env_var="PDM_PYPI_VERIFY_SSL",
+            True,
+            env_var="PDM_PYPI_VERIFY_SSL",
             coerce=ensure_boolean,
         ),
         "pypi.username": ConfigItem("The username to access PyPI", env_var="PDM_PYPI_USERNAME"),

--- a/src/pdm/project/config.py
+++ b/src/pdm/project/config.py
@@ -185,7 +185,11 @@ class Config(MutableMapping[str, str]):
             DEFAULT_PYPI_INDEX,
             env_var="PDM_PYPI_URL",
         ),
-        "pypi.verify_ssl": ConfigItem("Verify SSL certificate when query PyPI", True, coerce=ensure_boolean),
+        "pypi.verify_ssl": ConfigItem(
+            "Verify SSL certificate when query PyPI",
+            True, env_var="PDM_PYPI_VERIFY_SSL",
+            coerce=ensure_boolean,
+        ),
         "pypi.username": ConfigItem("The username to access PyPI", env_var="PDM_PYPI_USERNAME"),
         "pypi.password": ConfigItem("The password to access PyPI", env_var="PDM_PYPI_PASSWORD"),
         "pypi.ca_certs": ConfigItem(


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
Adresses issue #3082 
 
This PR allows `pypi.verify_ssl` to be configured via `PDM_PYPI_VERIFY_SSL` environmental variable.

Test case not added (as I couldn't find any tests for `pypi.username` nor `pypi.password`), but I'll work on it if it's mandatory.