### PR TITLE
fix: a bug reusing the python markers from the existing lock when appending result

### DIFF
--- a/news/3089.bugfix.md
+++ b/news/3089.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug that Python markers from the existing locked packages are considered when locking with `--append` option.


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
