### PR TITLE
fix: pdm export -f requirements exports package twice

### DIFF
--- a/news/3123.bugfix.md
+++ b/news/3123.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug of export command that packages with extras are included twice.

--- a/src/pdm/cli/commands/export.py
+++ b/src/pdm/cli/commands/export.py
@@ -79,7 +79,10 @@ class Command(BaseCommand):
                 raise PdmUsageError(
                     "Can't export a lock file without environment markers, please re-generate the lock file with `inherit_metadata` strategy."
                 )
-            candidates = [entry.candidate for entry in project.get_locked_repository().packages.values()]
+            candidates = sorted(
+                (entry.candidate for entry in project.get_locked_repository().packages.values()),
+                key=lambda c: not c.req.extras,
+            )
             groups = set(selection)
             packages = []
             seen_extras: set[str] = set()


### PR DESCRIPTION
Fixes #3123

Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
