### PR TITLE
init.py - Add info how to opt-out from using PEP 582

### DIFF
--- a/src/pdm/cli/commands/init.py
+++ b/src/pdm/cli/commands/init.py
@@ -226,6 +226,7 @@ class Command(BaseCommand):
         if python_info.get_venv() is None:
             project.core.ui.info(
                 "You are using the PEP 582 mode, no virtualenv is created.\n"
+                "You can change configuration with `pdm config python.use_venv True`.\n"
                 "For more info, please visit https://peps.python.org/pep-0582/"
             )
         project.python = python_info


### PR DESCRIPTION
refs #3120

When pdm is configured to use PEP 582 instead of default virtualenv, print extra info on how to revert back to the  default behavior. 
