### PR TITLE
fix: `add --dev --group test` ignores `dev` if empty group with that name already exists in optional-dependencies

### DIFF
--- a/news/3133.bugfix.md
+++ b/news/3133.bugfix.md
@@ -1,0 +1,1 @@
+Remove empty groups when removing packages with `pdm remove`.

--- a/src/pdm/cli/commands/remove.py
+++ b/src/pdm/cli/commands/remove.py
@@ -118,6 +118,10 @@ class Command(BaseCommand):
         if lock_groups and group not in lock_groups:
             project.core.ui.warn(f"Group [success]{group}[/] isn't in lockfile, skipping lock.")
             return
+        # It may remove the whole group, exclude it from lock groups first
+        project_groups = project.iter_groups()
+        if lock_groups is not None:
+            lock_groups = [g for g in lock_groups if g in project_groups]
         do_lock(project, "reuse", dry_run=dry_run, tracked_names=tracked_names, hooks=hooks, groups=lock_groups)
         if sync:
             do_sync(

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -556,7 +556,10 @@ class Project:
         def update_dev_dependencies(deps: list[str]) -> None:
             from tomlkit.container import OutOfOrderTableProxy
 
-            settings.setdefault("dev-dependencies", {})[group] = deps
+            if deps:
+                settings.setdefault("dev-dependencies", {})[group] = deps
+            else:
+                settings.setdefault("dev-dependencies", {}).pop(group, None)
             if isinstance(self.pyproject._data["tool"], OutOfOrderTableProxy):
                 # In case of a separate table, we have to remove and re-add it to make the write correct.
                 # This may change the order of tables in the TOML file, but it's the best we can do.
@@ -570,7 +573,9 @@ class Project:
         deps_setter = [
             (
                 metadata.get("optional-dependencies", {}),
-                lambda x: metadata.setdefault("optional-dependencies", {}).__setitem__(group, x),
+                lambda x: metadata.setdefault("optional-dependencies", {}).__setitem__(group, x)
+                if x
+                else metadata.setdefault("optional-dependencies", {}).pop(group, None),
             ),
             (settings.get("dev-dependencies", {}), update_dev_dependencies),
         ]

--- a/tests/cli/test_remove.py
+++ b/tests/cli/test_remove.py
@@ -69,7 +69,7 @@ def test_remove_package_exist_in_multi_groups(project, working_set, pdm):
     pdm(["add", "requests"], obj=project, strict=True)
     pdm(["add", "--dev", "urllib3"], obj=project, strict=True)
     pdm(["remove", "--dev", "urllib3"], obj=project, strict=True)
-    assert all("urllib3" not in line for line in project.pyproject.settings["dev-dependencies"]["dev"])
+    assert "dev-dependencies" not in project.pyproject.settings
     assert "urllib3" in working_set
     assert "requests" in working_set
 
@@ -103,5 +103,5 @@ def test_remove_group_not_in_lockfile(project, pdm, mocker):
     assert project.lockfile.groups == ["default"]
     locker = mocker.patch.object(actions, "do_lock")
     pdm(["remove", "--group", "tz", "pytz"], obj=project, strict=True)
-    assert not project.pyproject.metadata["optional-dependencies"].get("tz")
+    assert "optional-dependencies" not in project.pyproject.metadata
     locker.assert_not_called()


### PR DESCRIPTION
Fixes #3133

Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
