### PR TITLE
fix: remove _saved_python when purging venv

### DIFF
--- a/news/3137.bugfix.md
+++ b/news/3137.bugfix.md
@@ -1,0 +1,1 @@
+When running `pdm venv purge`, if the current project's python version had been referencing the removed venv then clear it out.

--- a/src/pdm/cli/commands/venv/purge.py
+++ b/src/pdm/cli/commands/venv/purge.py
@@ -58,6 +58,9 @@ class PurgeCommand(BaseCommand):
             project.core.ui.echo("Purged successfully!")
 
     def del_all_venvs(self, project: Project) -> None:
+        saved_python = project._saved_python
         for _, venv in iter_central_venvs(project):
             shutil.rmtree(venv)
+            if saved_python and Path(saved_python).parent.parent == venv:
+                project._saved_python = None
         project.core.ui.echo("Purged successfully!")

--- a/src/pdm/cli/commands/venv/purge.py
+++ b/src/pdm/cli/commands/venv/purge.py
@@ -1,5 +1,6 @@
 import argparse
 import shutil
+from pathlib import Path
 
 from pdm import termui
 from pdm.cli.commands.base import BaseCommand


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

The command `pdm venv remove in-project --yes` will remove the `.pdm-python` file if target of the python path is in the removed venv folder, but the `pdm venv purge` command does not.  This updates the `pdm venv purge` command to match the behavior of the former.