### PR TITLE
fix(auth): ensures `/` is URL encoded in sources auth environment variables (fix #3169)

### DIFF
--- a/news/3169.bugfix.md
+++ b/news/3169.bugfix.md
@@ -1,0 +1,1 @@
+Ensures that  `/` is URL encoded in sources URL environment variables.

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -244,7 +244,7 @@ def expand_env_vars(credential: str, quote: bool = False, env: Mapping[str, str]
 
     def replace_func(match: Match) -> str:
         rv = env.get(match.group(1), match.group(0))
-        return parse.quote(rv) if quote else rv
+        return parse.quote(rv, "") if quote else rv
 
     return re.sub(r"\$\{(.+?)\}", replace_func, credential)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -217,11 +217,11 @@ def test_expand_env_vars(given, expected, monkeypatch):
         ("https://example.org/path?arg=1", "https://example.org/path?arg=1"),
         (
             "https://${FOO}@example.org/path?arg=1",
-            "https://hello@example.org/path?arg=1",
+            "https://token%3Aoidc%2F1@example.org/path?arg=1",
         ),
         (
             "https://${FOO}:${BAR}@example.org/path?arg=1",
-            "https://hello:wo%3Arld@example.org/path?arg=1",
+            "https://token%3Aoidc%2F1:p%40ssword@example.org/path?arg=1",
         ),
         (
             "https://${FOOBAR}@example.org/path?arg=1",
@@ -230,8 +230,8 @@ def test_expand_env_vars(given, expected, monkeypatch):
     ],
 )
 def test_expand_env_vars_in_auth(given, expected, monkeypatch):
-    monkeypatch.setenv("FOO", "hello")
-    monkeypatch.setenv("BAR", "wo:rld")
+    monkeypatch.setenv("FOO", "token:oidc/1")
+    monkeypatch.setenv("BAR", "p@ssword")
     assert utils.expand_env_vars_in_auth(given) == expected
 
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

`/` was not URL encoded because `urllib.parse.quote` exclude it by default (targeting querystrings).
This PR ensures it is.
(Upstream Python need a PR too as it says it is safe for path by default, which is not, only in querystring)