### PR TITLE
Introducing PDM Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A modern Python package and dependency manager supporting the latest PEP standar
 <a href="https://trackgit.com">
 <img src="https://us-central1-trackgit-analytics.cloudfunctions.net/token/ping/l4eztudjnh9bfay668fl" alt="trackgit-views" />
 </a>
+[![](https://img.shields.io/badge/Gurubase-Ask%20PDM%20Guru-006BFF)](https://gurubase.io/g/pdm)
 
 [![asciicast](https://asciinema.org/a/jnifN30pjfXbO9We2KqOdXEhB.svg)](https://asciinema.org/a/jnifN30pjfXbO9We2KqOdXEhB)
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [PDM Guru](https://gurubase.io/g/pdm) to Gurubase. PDM Guru uses the data from this repo and data from the [docs](https://pdm-project.org/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "PDM Guru" badge, which highlights that PDM now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable PDM Guru in Gurubase, just let me know that's totally fine.