### PR TITLE
Fix hashlib.md5 call for FIPS-enabled builds

### DIFF
--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -164,7 +164,11 @@ class TaskRunner:
         tool_config = metadata.pop("tool", {})
         script_project = self.project.core.create_project()
         script_project.pyproject.set_data({"project": metadata, "tool": tool_config})
-        venv_name = hashlib.md5(os.path.realpath(script_file).encode("utf-8")).hexdigest()
+        md5_kwargs = {}
+        # for python >= 3.9, indicate that md5 is not used in a security context
+        if sys.version_info >= (3, 9):
+            md5_kwargs = {"usedforsecurity": False}
+        venv_name = hashlib.md5(os.path.realpath(script_file).encode("utf-8"), **md5_kwargs).hexdigest()
         venv_backend = BACKENDS[script_project.config["venv.backend"]](script_project, None)
         venv = venv_backend.get_location(None, venv_name)
         if venv.exists() and not self.recreate_env:


### PR DESCRIPTION
FIPS errors with the following message:

```
  File "/usr/lib/python3.11/site-packages/pdm/cli/commands/run.py", line 167, in _get_script_env
    venv_name = hashlib.md5(os.path.realpath(script_file).encode("utf-8")).hexdigest()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_hashlib.UnsupportedDigestmodError: [digital envelope routines] unsupported
```
Since the hash isn't use for cryptographic use we indicate that md5 can be safely used

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
