### PR TITLE
feat: prefer repository config in project config over global config

### DIFF
--- a/news/2645.feature.md
+++ b/news/2645.feature.md
@@ -1,0 +1,1 @@
+Prefer repository config in project config over global config.

--- a/src/pdm/cli/commands/publish/__init__.py
+++ b/src/pdm/cli/commands/publish/__init__.py
@@ -143,10 +143,9 @@ class Command(BaseCommand):
         password = options.password or os.getenv("PDM_PUBLISH_PASSWORD")
         ca_certs = options.ca_certs or os.getenv("PDM_PUBLISH_CA_CERTS")
 
-        config = (
-            project.project_config.get_repository_config(repository, "repository") or
-            project.global_config.get_repository_config(repository, "repository")
-        )
+        config = project.project_config.get_repository_config(
+            repository, "repository"
+        ) or project.global_config.get_repository_config(repository, "repository")
         if config is None:
             raise PdmUsageError(f"Missing repository config of {repository}")
         assert config.url is not None

--- a/src/pdm/cli/commands/publish/__init__.py
+++ b/src/pdm/cli/commands/publish/__init__.py
@@ -143,9 +143,12 @@ class Command(BaseCommand):
         password = options.password or os.getenv("PDM_PUBLISH_PASSWORD")
         ca_certs = options.ca_certs or os.getenv("PDM_PUBLISH_CA_CERTS")
 
-        config = project.global_config.get_repository_config(repository, "repository")
+        config = (
+            project.project_config.get_repository_config(repository, "repository") or
+            project.global_config.get_repository_config(repository, "repository")
+        )
         if config is None:
-            raise PdmUsageError(f"Missing repository config of {repository}")
+                raise PdmUsageError(f"Missing repository config of {repository}")
         assert config.url is not None
         if username is not None:
             config.username = username

--- a/src/pdm/cli/commands/publish/__init__.py
+++ b/src/pdm/cli/commands/publish/__init__.py
@@ -148,7 +148,7 @@ class Command(BaseCommand):
             project.global_config.get_repository_config(repository, "repository")
         )
         if config is None:
-                raise PdmUsageError(f"Missing repository config of {repository}")
+            raise PdmUsageError(f"Missing repository config of {repository}")
         assert config.url is not None
         if username is not None:
             config.username = username

--- a/src/pdm/project/config.py
+++ b/src/pdm/project/config.py
@@ -421,8 +421,6 @@ class Config(MutableMapping[str, str]):
 
     def get_repository_config(self, name_or_url: str, prefix: str) -> RepositoryConfig | None:
         """Get a repository or source by name or url."""
-        if not self.is_global and prefix == REPOSITORY:  # pragma: no cover
-            raise NoConfigError(prefix)
         repositories: dict[str, RepositoryConfig] = {}
         for k, v in self._data.items():
             if not k.startswith(f"{prefix}.") or k in self._config_map:

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -98,6 +98,7 @@ def test_default_repository_setting(project):
     repository = project.global_config.get_repository_config("nonexist", "repository")
     assert repository is None
 
+
 def test_repository_global_config_key_short(project):
     with pytest.raises(PdmUsageError):
         project.global_config["repository.test"] = {"url": "https://example.org/simple"}
@@ -107,6 +108,7 @@ def test_repository_global_config_key_short(project):
 
     with pytest.raises(PdmUsageError):
         del project.global_config["repository"]
+
 
 def test_repository_project_config_key_short(project):
     with pytest.raises(PdmUsageError):
@@ -130,6 +132,7 @@ def test_repository_global_config_overwrite_default(project):
     project.global_config["repository.pypi.url"] = "https://example.pypi.org/legacy/"
     repository = project.global_config.get_repository_config("pypi", "repository")
     assert repository.url == "https://example.pypi.org/legacy/"
+
 
 def test_repository_project_config_overwrite_default(project):
     project.project_config["repository.pypi.username"] = "foo"
@@ -183,6 +186,7 @@ def test_config_get_repository_global_config(project, pdm):
     result = pdm(["config", "repository.pypi.url"], obj=project, strict=True)
     assert result.stdout.strip() == "https://upload.pypi.org/legacy/"
 
+
 def test_config_get_repository_project_config(project, pdm):
     config = project.project_config["repository.pypi"]
     assert config == project.project_config.get_repository_config("pypi", "repository")
@@ -199,6 +203,7 @@ def test_config_get_repository_project_config(project, pdm):
     result = pdm(["config", "repository.pypi.url"], obj=project, strict=True)
     assert result.stdout.strip() == "https://upload.pypi.org/legacy/"
 
+
 def test_config_set_repository_global_config(project):
     project.global_config["repository.pypi.url"] = "https://example.pypi.org/legacy/"
     project.global_config["repository.pypi.username"] = "foo"
@@ -206,6 +211,7 @@ def test_config_set_repository_global_config(project):
     assert project.global_config["repository.pypi.username"] == "foo"
     del project.global_config["repository.pypi.username"]
     assert project.global_config["repository.pypi.username"] is None
+
 
 def test_config_set_repository_project_config(project):
     project.project_config["repository.pypi.url"] = "https://example.pypi.org/legacy/"
@@ -215,12 +221,14 @@ def test_config_set_repository_project_config(project):
     del project.project_config["repository.pypi.username"]
     assert project.project_config["repository.pypi.username"] is None
 
+
 def test_config_del_repository_global_config(project):
     project.global_config["repository.test.url"] = "https://example.org/simple"
     assert project.global_config.get_repository_config("test", "repository") is not None
 
     del project.global_config["repository.test"]
     assert project.global_config.get_repository_config("test", "repository") is None
+
 
 def test_config_del_repository_project_config(project):
     project.project_config["repository.test.url"] = "https://example.org/simple"


### PR DESCRIPTION
## Pull Request Checklist

- [X] A news fragment is added in `news/` describing what is new.
- [X] Test cases added for changed code.

## Describe what you have changed in this PR.

As seen in  #1309 and #2645 users expect to be able to set the repository config in the project config (`pdm.toml`) and use this when using the `pdm publish` command.  
With this PR the project config is preferred over the global config when searching for a repository config.