### PR TITLE
fix: inherit_metadata would be written in lock file if the file is not pdm.lock even strategy config is true

### DIFF
--- a/news/3232.bugfix.md
+++ b/news/3232.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug that `strategy.inherit_metadata` config is not honored when using `--lockfile` option.

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -202,15 +202,16 @@ class Project:
     @property
     def lockfile(self) -> Lockfile:
         if self._lockfile is None:
-            self._lockfile = Lockfile(self.root / self.LOCKFILE_FILENAME, ui=self.core.ui)
-            if self.config.get("use_uv"):
-                self._lockfile.default_strategies.discard(FLAG_INHERIT_METADATA)
-            if not self.config["strategy.inherit_metadata"]:
-                self._lockfile.default_strategies.discard(FLAG_INHERIT_METADATA)
+            self.set_lockfile(self.root / self.LOCKFILE_FILENAME)
+            assert self._lockfile is not None
         return self._lockfile
 
     def set_lockfile(self, path: str | Path) -> None:
         self._lockfile = Lockfile(path, ui=self.core.ui)
+        if self.config.get("use_uv"):
+            self._lockfile.default_strategies.discard(FLAG_INHERIT_METADATA)
+        if not self.config["strategy.inherit_metadata"]:
+            self._lockfile.default_strategies.discard(FLAG_INHERIT_METADATA)
 
     @cached_property
     def config(self) -> Mapping[str, Any]:


### PR DESCRIPTION
Fixes #3232

Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
