### PR TITLE
fix: pdm 2.20.1 breaks when optional dependency groups contain underscores

### DIFF
--- a/news/3271.bugfix.md
+++ b/news/3271.bugfix.md
@@ -1,0 +1,1 @@
+Fix the name normalization issue for optional dependency groups.

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -400,8 +400,8 @@ class Project:
 
     def get_dependencies(self, group: str | None = None) -> Sequence[Requirement]:
         metadata = self.pyproject.metadata
-        group = group or "default"
-        optional_dependencies = metadata.get("optional-dependencies", {})
+        group = normalize_name(group or "default")
+        optional_dependencies = {normalize_name(k): v for k, v in metadata.get("optional-dependencies", {}).items()}
         dev_dependencies = self.pyproject.dev_dependencies
         in_metadata = group == "default" or group in optional_dependencies
         referred_groups: dict[str, set[str]] = {}


### PR DESCRIPTION
Fixes #3271

Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
