### PR TITLE
feat: emit post_lock after writing pyproject.toml and pdm.lock in add…

### DIFF
--- a/news/3285.feature.md
+++ b/news/3285.feature.md
@@ -1,0 +1,1 @@
+Emit `post_lock` after writing pyproject.toml and pdm.lock in add/update

--- a/src/pdm/cli/commands/add.py
+++ b/src/pdm/cli/commands/add.py
@@ -165,10 +165,10 @@ class Command(BaseCommand):
         # Update dependency specifiers and lockfile hash.
         deps_to_update = group_deps if unconstrained else requirements
         save_version_specifiers(deps_to_update, resolved, save)
-        hooks.try_emit("post_lock", resolution=resolved, dry_run=dry_run)
         if not dry_run:
             project.add_dependencies(deps_to_update, group, selection.dev or False)
             project.write_lockfile(project.lockfile._data, False)
+        hooks.try_emit("post_lock", resolution=resolved, dry_run=dry_run)
         if sync:
             do_sync(
                 project,

--- a/src/pdm/cli/commands/update.py
+++ b/src/pdm/cli/commands/update.py
@@ -187,7 +187,6 @@ class Command(BaseCommand):
                 hooks=hooks,
                 groups=locked_groups,
             )
-        hooks.try_emit("post_lock", resolution=resolved, dry_run=dry_run)
         if unconstrained:
             # Need to update version constraints
             save_version_specifiers(chain.from_iterable(updated_deps.values()), resolved, save)
@@ -196,6 +195,7 @@ class Command(BaseCommand):
                 for group, deps in updated_deps.items():
                     project.add_dependencies(deps, group, selection.dev or False)
             project.write_lockfile(project.lockfile._data, False)
+        hooks.try_emit("post_lock", resolution=resolved, dry_run=dry_run)
         if sync or dry_run:
             do_sync(
                 project,


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

New lockfile is written before post_lock is emitted. Implementation analogous to https://github.com/pdm-project/pdm/pull/1225
Fixes #3285.