### PR TITLE
feat(run): allow customizing scripts display from settings (fix #3313)

### DIFF
--- a/news/3313.feature.md
+++ b/news/3313.feature.md
@@ -1,0 +1,1 @@
+Allow customizing scripts display with `scripts.show_header` settings.

--- a/src/pdm/project/config.py
+++ b/src/pdm/project/config.py
@@ -217,6 +217,12 @@ class Config(MutableMapping[str, str]):
             env_var="PDM_PYPI_JSON_API",
             coerce=ensure_boolean,
         ),
+        "scripts.show_header": ConfigItem(
+            "Display script name and help before running",
+            default=False,
+            env_var="PDM_SCRIPTS_SHOW_HEADER",
+            coerce=ensure_boolean,
+        ),
         "venv.location": ConfigItem(
             "Parent directory for virtualenvs",
             os.path.join(platformdirs.user_data_dir("pdm"), "venvs"),


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

This PR is a proposal implementation for #3313 introduces a `scripts.show_header` setting allowing to customize scripts display on run.
If set to `True`, running a script will display the help before running, fallback to the command args when no help has been set.

This setting do not have impact on verbose mode, which is still displaying script name and resolved args (and not help as help can be pretty but args are useful, and `verbose` mode is often meant for debug/diagnostic).

## Sample

With the following `tool.pdm.scripts` section:

```toml
[tool.pdm.script]
hello = {cmd = "echo 'hello'", help = "Say hello"}
```

### Default verbosity, default settings

![image](https://github.com/user-attachments/assets/957e505b-982a-4367-8fdb-11ace2772651)

### Default verbosity, `scripts.show_header = true`

![image](https://github.com/user-attachments/assets/5170b7f5-ff7c-45f6-997c-c36f948df117)

#### Without `help` defined

![image](https://github.com/user-attachments/assets/80a931aa-4c99-4208-9626-f714f4ff14cb)

### Verbose

![image](https://github.com/user-attachments/assets/bad56de5-3202-4b87-9f6f-b2ffdec81edb)

## Composite sample

With the following `tool.pdm.scripts` section:

```toml
[tool.pdm.script]
hello = {cmd = "echo 'hello'", help = "Say hello"}
composite = { composite = ["hello", "hello"], help = "Do many things" }
```

### Default verbosity, default settings

![image](https://github.com/user-attachments/assets/7515bd88-4c71-4796-9dca-e06246e8211e)

### Default verbosity, `scripts.show_header = true`

![image](https://github.com/user-attachments/assets/7beff6d0-2ed8-4a82-a2e3-700c0e9eec16)

#### Without `help` defined

![image](https://github.com/user-attachments/assets/aa35356d-0673-4abd-9886-824209c513b0)

### Verbose

![image](https://github.com/user-attachments/assets/3b48eddd-3fa5-4437-8bbd-ff491deebc66)

