### PR TITLE
fix(uv): Universal wheel can't be added as URL dependency as it's mismatched to current platform

### DIFF
--- a/news/3332.bugfix.md
+++ b/news/3332.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug in uv mode that direct URL dependencies can't be installed.

--- a/src/pdm/resolver/uv.py
+++ b/src/pdm/resolver/uv.py
@@ -147,9 +147,8 @@ class UvResolver(Resolver):
                 def hash_maker(item: dict[str, Any]) -> FileHash:
                     return {"file": Link(item["url"]).filename, "hash": item["hash"]}
 
-            if not req.is_file_or_url:
-                for wheel in chain(package.get("wheels", []), [sdist] if (sdist := package.get("sdist")) else []):
-                    candidate.hashes.append(hash_maker(wheel))
+            for wheel in chain(package.get("wheels", []), [sdist] if (sdist := package.get("sdist")) else []):
+                candidate.hashes.append(hash_maker(wheel))
             entry = Package(candidate, [make_requirement(dep) for dep in package.get("dependencies", [])], "")
             packages.append(entry)
             if optional_dependencies := package.get("optional-dependencies"):


### PR DESCRIPTION
Fixes #3332

Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
