### PR TITLE
Also use csh venv activation for tcsh

### DIFF
--- a/news/3366.bugfix.md
+++ b/news/3366.bugfix.md
@@ -1,0 +1,1 @@
+`shellingham.detect_shell()` returns `('tcsh', '/bin/tcsh')` for tcsh on FreeBSD, so the current code tries to use the Bash venv activation script and fails due to syntax error. This change fixes the issue.

--- a/src/pdm/cli/commands/venv/activate.py
+++ b/src/pdm/cli/commands/venv/activate.py
@@ -48,7 +48,7 @@ class ActivateCommand(BaseCommand):
             shell = ""
         if shell == "fish":
             command, filename = "source", "activate.fish"
-        elif shell == "csh":
+        elif shell in ["csh", "tcsh"]:
             command, filename = "source", "activate.csh"
         elif shell in ["powershell", "pwsh"]:
             command, filename = ".", "Activate.ps1"

--- a/tests/cli/test_venv.py
+++ b/tests/cli/test_venv.py
@@ -142,6 +142,19 @@ def test_venv_activate(pdm, mocker, project):
 
 
 @pytest.mark.usefixtures("venv_backends")
+def test_venv_activate_tcsh(pdm, mocker, project):
+    project.project_config["venv.in_project"] = False
+    result = pdm(["venv", "create"], obj=project)
+    assert result.exit_code == 0, result.stderr
+    venv_path = re.match(r"Virtualenv (.+) is created successfully", result.output).group(1)
+    key = os.path.basename(venv_path)[len(get_venv_prefix(project)) :]
+
+    mocker.patch("shellingham.detect_shell", return_value=("tcsh", None))
+    result = pdm(["venv", "activate", key], obj=project)
+    assert result.output.startswith("source") and result.output.strip("'\"\n").endswith("activate.csh")
+
+
+@pytest.mark.usefixtures("venv_backends")
 def test_venv_activate_custom_prompt(pdm, mocker, project):
     project.project_config["venv.in_project"] = False
     creator = mocker.patch("pdm.cli.commands.venv.backends.Backend.create")


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

`shellingham.detect_shell()` returns `('tcsh', '/bin/tcsh')` for tcsh on FreeBSD, so the current code tries to use the Bash venv activation script and fails due to syntax error. This change fixes the issue.
