### PR TITLE
fix: ensure dev-dependencies are added to the correct group

### DIFF
--- a/news/3392.bugfix.md
+++ b/news/3392.bugfix.md
@@ -1,0 +1,1 @@
+Ensure dev-dependencies are added to the correct group when the `tool.pdm.dev-dependencies` table has groups.

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -670,8 +670,8 @@ class Project:
         if group == "default":
             return metadata.get("dependencies", tomlkit.array()), lambda x: metadata.__setitem__("dependencies", x)
         dev_dependencies = self.pyproject._data.get("dependency-groups", {})
-        for group, items in self.pyproject.settings.get("dev-dependencies", {}).items():
-            dev_dependencies.setdefault(group, []).extend(items)
+        for dev_group, items in self.pyproject.settings.get("dev-dependencies", {}).items():
+            dev_dependencies.setdefault(dev_group, []).extend(items)
         deps_setter = [
             (
                 metadata.get("optional-dependencies", {}),

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import sys
+from copy import deepcopy
 from functools import cached_property, reduce
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, Sequence, cast
@@ -669,7 +670,7 @@ class Project:
         metadata, settings = self.pyproject.metadata, self.pyproject.settings
         if group == "default":
             return metadata.get("dependencies", tomlkit.array()), lambda x: metadata.__setitem__("dependencies", x)
-        dev_dependencies = self.pyproject._data.get("dependency-groups", {})
+        dev_dependencies = deepcopy(self.pyproject._data.get("dependency-groups", {}))
         for dev_group, items in self.pyproject.settings.get("dev-dependencies", {}).items():
             dev_dependencies.setdefault(dev_group, []).extend(items)
         deps_setter = [

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -108,6 +108,25 @@ def test_add_editable_normal_dev_dependency(project, pdm):
     assert pep735_group == ["urllib3>=1.22", "idna>=2.7"]
 
 
+@pytest.mark.usefixtures("working_set", "vcs")
+def test_add_dev_dependency_with_existing_editables_group(project, pdm):
+    project.environment.python_requires = PySpecSet(">=3.6")
+    url = "git+https://github.com/test-root/demo.git#egg=demo"
+    pdm(["add", "-dG", "editables", "-e", url], obj=project, strict=True)
+    pdm(["add", "-d", "urllib3"], obj=project, strict=True)
+    pdm(["add", "-dG", "named", "idna"], obj=project, strict=True)
+    assert "editables" in project.pyproject.settings["dev-dependencies"]
+    assert "dev" in project.pyproject.dependency_groups
+    assert "named" in project.pyproject.dependency_groups
+    editables_group = project.pyproject.settings["dev-dependencies"]["editables"]
+    pep735_group = project.pyproject.dependency_groups["dev"]
+    pep735_named_group = project.pyproject.dependency_groups["named"]
+    assert editables_group == ["-e git+https://github.com/test-root/demo.git#egg=demo"]
+    assert "editables" not in project.pyproject.dependency_groups
+    assert pep735_group == ["urllib3>=1.22"]
+    assert pep735_named_group == ["idna>=2.7"]
+
+
 @pytest.mark.usefixtures("working_set")
 def test_add_remote_package_url(project, dev_option, pdm):
     project.environment.python_requires = PySpecSet(">=3.6")


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Before this change, the `group` variable containing the group the user requested was being overridden with the last group processed from the `tool.pdm.dev-dependencies` table, making PDM add dev-dependencies to the wrong group.

~This is a draft PR since #3392 also mentions the duplication of groups between `tool.pdm.dev-dependencies` and `dependency-groups`. I'll be adding the news fragment and test cases in another commit once I finish setting up the dev environment.~ Finished!

Fixes #3392.