### PR TITLE
Uv index strategy respect env var; issue #3410

### DIFF
--- a/news/3410.feature.md
+++ b/news/3410.feature.md
@@ -1,0 +1,3 @@
+When use_uv = True will try to choose index-strategy for uv based on UV_INDEX_STRATEGY environments variable;  
+if this variable isn't set will default to existing strategy which is "unsafe-first-match"   
+if resolution.respect-source-order is set to True in pyproject.toml and "unsafe-best-match" otherwise

--- a/src/pdm/resolver/uv.py
+++ b/src/pdm/resolver/uv.py
@@ -72,7 +72,7 @@ class UvResolver(Resolver):
                 first_index = False
             else:
                 cmd.extend(["--extra-index-url", source.url])
-        if index_strategy:=os.environ.get("UV_INDEX_STRATEGY"):
+        if index_strategy := os.environ.get("UV_INDEX_STRATEGY"):
             if index_strategy not in ALLOWED_INDEX_STRATEGIES:
                 raise ValueError(f"UV_INDEX_STRATEGY should be one of {' '.join(ALLOWED_INDEX_STRATEGIES)}")
         elif self.project.pyproject.settings.get("resolution", {}).get("respect-source-order", False):

--- a/tests/resolver/test_uv_resolver.py
+++ b/tests/resolver/test_uv_resolver.py
@@ -1,11 +1,7 @@
-import os
-
 import pytest
 
 from pdm.models.markers import EnvSpec
 from pdm.models.requirements import parse_requirement
-from tests.test_installer import environment
-
 
 pytestmark = [pytest.mark.network, pytest.mark.uv]
 
@@ -25,7 +21,6 @@ def get_resolver(environment, requirements, target=None):
 
 
 def resolve(environment, requirements, target=None):
-
     reqs = []
     for req in requirements:
         if isinstance(req, str):


### PR DESCRIPTION
## Pull Request Checklist

- [ x] A news fragment is added in `news/` describing what is new.
- [ x] Test cases added for changed code.

## Describe what you have changed in this PR.
When use_uv = True will try to choose index-strategy for uv based on UV_INDEX_STRATEGY environments variable;  
if this variable isn't set will default to existing strategy which is "unsafe-first-match"   
if resolution.respect-source-order is set to True in pyproject.toml and "unsafe-best-match" otherwise