### PR TITLE
fix: pass dev selection to sync on pdm add and remove

### DIFF
--- a/news/3404.bugfix.md
+++ b/news/3404.bugfix.md
@@ -1,0 +1,1 @@
+Pass dev selection to sync action on removing.

--- a/news/3404.bugfix.md
+++ b/news/3404.bugfix.md
@@ -1,1 +1,1 @@
-Pass dev selection to sync action on removing.
+Pass dev selection to sync action on adding and removing.

--- a/src/pdm/cli/commands/add.py
+++ b/src/pdm/cli/commands/add.py
@@ -174,7 +174,7 @@ class Command(BaseCommand):
         if sync:
             do_sync(
                 project,
-                selection=GroupSelection(project, groups=[group], default=False),
+                selection=GroupSelection(project, groups=[group], dev=selection.dev, default=False),
                 no_editable=no_editable and tracked_names,
                 no_self=no_self or group != "default",
                 requirements=group_deps,

--- a/src/pdm/cli/commands/remove.py
+++ b/src/pdm/cli/commands/remove.py
@@ -125,7 +125,7 @@ class Command(BaseCommand):
         if sync:
             do_sync(
                 project,
-                selection=GroupSelection(project, default=False, groups=[group]),
+                selection=GroupSelection(project, default=True, dev=selection.dev, groups=[group]),
                 clean=True,
                 no_editable=no_editable,
                 no_self=no_self,

--- a/src/pdm/cli/commands/remove.py
+++ b/src/pdm/cli/commands/remove.py
@@ -125,7 +125,7 @@ class Command(BaseCommand):
         if sync:
             do_sync(
                 project,
-                selection=GroupSelection(project, default=True, dev=selection.dev, groups=[group]),
+                selection=GroupSelection(project, default=False, dev=selection.dev, groups=[group]),
                 clean=True,
                 no_editable=no_editable,
                 no_self=no_self,


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

A trial fix to #3404. 

Actually, I am not sure whether this is the desired approach to fix. Any comments are welcome.