### PR TITLE
fix: excluding non-existing groups for `pdm remove`

### DIFF
--- a/news/3404.bugfix.md
+++ b/news/3404.bugfix.md
@@ -1,0 +1,1 @@
+Intersects translated groups with lockfile groups to exclude the non-existing ones.

--- a/news/3404.bugfix.md
+++ b/news/3404.bugfix.md
@@ -1,1 +1,1 @@
-Intersects translated groups with lockfile groups to exclude the non-existing ones.
+Excluding non-existing groups for `pdm remove`.

--- a/src/pdm/cli/commands/remove.py
+++ b/src/pdm/cli/commands/remove.py
@@ -125,7 +125,7 @@ class Command(BaseCommand):
         if sync:
             do_sync(
                 project,
-                selection=GroupSelection(project, default=False, groups=[group]),
+                selection=GroupSelection(project, default=False, groups=[group], exclude_non_existing=True),
                 clean=True,
                 no_editable=no_editable,
                 no_self=no_self,

--- a/src/pdm/cli/filters.py
+++ b/src/pdm/cli/filters.py
@@ -94,8 +94,6 @@ class GroupSelection:
         if ":all" in groups:
             groups_set.discard(":all")
             groups_set.update(optional_groups)
-            if self.exclude_non_existing and locked_groups:
-                groups_set.intersection_update(locked_groups)
         if default:
             groups_set.add("default")
         groups_set -= {normalize_name(g) for g in self.excluded_groups}

--- a/src/pdm/cli/filters.py
+++ b/src/pdm/cli/filters.py
@@ -89,7 +89,7 @@ class GroupSelection:
                 raise PdmUsageError("--prod is not allowed with dev groups and should be left")
         elif dev:
             groups_set.update(dev_groups)
-            if locked_groups:
+            if self.exclude_non_existing and locked_groups:
                 groups_set.intersection_update(locked_groups)
         if ":all" in groups:
             groups_set.discard(":all")

--- a/src/pdm/cli/filters.py
+++ b/src/pdm/cli/filters.py
@@ -89,7 +89,7 @@ class GroupSelection:
                 raise PdmUsageError("--prod is not allowed with dev groups and should be left")
         elif dev:
             groups_set.update(dev_groups)
-            if self.exclude_non_existing and locked_groups:
+            if locked_groups:
                 groups_set.intersection_update(locked_groups)
         if ":all" in groups:
             groups_set.discard(":all")

--- a/src/pdm/cli/filters.py
+++ b/src/pdm/cli/filters.py
@@ -104,7 +104,7 @@ class GroupSelection:
             )
             groups_set -= invalid_groups
 
-        if self.exclude_non_existing:
+        if self.exclude_non_existing and self.project.lockfile.groups is not None:
             groups_set &= {normalize_name(g) for g in self.project.lockfile.groups}
 
         # Sorts the result in ascending order instead of in random order

--- a/src/pdm/cli/filters.py
+++ b/src/pdm/cli/filters.py
@@ -101,6 +101,10 @@ class GroupSelection:
                 err=True,
             )
             groups_set -= invalid_groups
+
+        # Intersects with the lockfile groups to exclude the non-existing groups
+        groups_set &= {normalize_name(g) for g in self.project.lockfile.groups}
+
         # Sorts the result in ascending order instead of in random order
         # to make this function pure
         result = sorted(groups_set, key=lambda x: (x != "default", x))

--- a/src/pdm/cli/filters.py
+++ b/src/pdm/cli/filters.py
@@ -23,6 +23,7 @@ class GroupSelection:
         groups: Sequence[str] = (),
         group: str | None = None,
         excluded_groups: Sequence[str] = (),
+        exclude_non_existing: bool = False,
     ):
         self.project = project
         self.groups = groups
@@ -30,6 +31,7 @@ class GroupSelection:
         self.default = default
         self.dev = dev
         self.excluded_groups = excluded_groups
+        self.exclude_non_existing = exclude_non_existing
 
     @classmethod
     def from_options(cls, project: Project, options: argparse.Namespace) -> GroupSelection:
@@ -102,8 +104,8 @@ class GroupSelection:
             )
             groups_set -= invalid_groups
 
-        # Intersects with the lockfile groups to exclude the non-existing groups
-        groups_set &= {normalize_name(g) for g in self.project.lockfile.groups}
+        if self.exclude_non_existing:
+            groups_set &= {normalize_name(g) for g in self.project.lockfile.groups}
 
         # Sorts the result in ascending order instead of in random order
         # to make this function pure

--- a/tests/cli/test_remove.py
+++ b/tests/cli/test_remove.py
@@ -105,3 +105,11 @@ def test_remove_group_not_in_lockfile(project, pdm, mocker):
     pdm(["remove", "--group", "tz", "pytz"], obj=project, strict=True)
     assert "optional-dependencies" not in project.pyproject.metadata
     locker.assert_not_called()
+
+@pytest.mark.usefixtures("working_set")
+def test_remove_exclude_non_existing_dev_group_in_lockfile(project, pdm):
+    pdm(["add", "requests"], obj=project, strict=True)
+    project.add_dependencies(["pytz"], to_group="tz", dev=True)
+    assert project.lockfile.groups == ["default"]
+    result = pdm(["remove", "requests"], obj=project)
+    assert result.exit_code == 0

--- a/tests/cli/test_remove.py
+++ b/tests/cli/test_remove.py
@@ -106,6 +106,7 @@ def test_remove_group_not_in_lockfile(project, pdm, mocker):
     assert "optional-dependencies" not in project.pyproject.metadata
     locker.assert_not_called()
 
+
 @pytest.mark.usefixtures("working_set")
 def test_remove_exclude_non_existing_dev_group_in_lockfile(project, pdm):
     pdm(["add", "requests"], obj=project, strict=True)


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Fix #3404 

### Same test case before the changes

```bash
$ pytest -k "test_remove_exclude_non_existing_dev_group_in_lockfile"
================================================================================ test session starts ================================================================================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huxuan/Code/pdm
configfile: pyproject.toml
testpaths: tests/
plugins: anyio-4.3.0, mock-3.14.0, rerunfailures-14.0, pytest_httpserver-1.1.0, cov-5.0.0, xdist-3.6.1
collected 987 items / 986 deselected / 1 selected                                                                                                                                   

tests/cli/test_remove.py F                                                                                                                                                    [100%]

===================================================================================== FAILURES ======================================================================================
______________________________________________________________ test_remove_exclude_non_existing_dev_group_in_lockfile _______________________________________________________________

project = <Project '/tmp/pytest-of-huxuan/pytest-4/test_remove_exclude_non_existi0'>, pdm = <function pdm.<locals>.caller at 0x7dc7251bca60>
mocker = <pytest_mock.plugin.MockerFixture object at 0x7dc7252aa440>

    @pytest.mark.usefixtures("working_set")
    def test_remove_exclude_non_existing_dev_group_in_lockfile(project, pdm, mocker):
        pdm(["add", "requests"], obj=project, strict=True)
        project.add_dependencies(["pytz"], to_group="tz", dev=True)
        assert project.lockfile.groups == ["default"]
        result = pdm(["remove", "requests"], obj=project)
>       assert result.exit_code == 0
E       AssertionError: assert 1 == 0
E        +  where 1 = RunResult(exit_code=1, stdout='Removing packages from default dependencies: requests\nChanges are written to pyproject....\n  0:00:00 🔒 Lock successful.  \n', stderr='[PdmUsageError]: Requested groups not in lockfile: tz\n', exception=None).exit_code

tests/cli/test_remove.py:115: AssertionError
------------------------------------------------------------------------------- Captured stdout setup -------------------------------------------------------------------------------
Changes are written to pyproject.toml.
Changes are written to pyproject.toml.
------------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------------
Changes are written to pyproject.toml.
--------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------
INFO     pdm.termui:reporters.py:23 ======== Start resolving requirements ========
INFO     pdm.termui:reporters.py:117   requests
INFO     pdm.termui:reporters.py:36   Adding requirement python>=3.7
INFO     pdm.termui:reporters.py:36   Adding requirement requests
INFO     pdm.termui:reporters.py:23 ======== Starting round 0 ========
INFO     pdm.termui:reporters.py:146 Adding new pin: python None
INFO     pdm.termui:reporters.py:23 ======== Starting round 1 ========
INFO     pdm.termui:reporters.py:36   Adding requirement certifi>=2017.4.17(from requests 2.19.1)
INFO     pdm.termui:reporters.py:36   Adding requirement chardet<3.1.0,>=3.0.2(from requests 2.19.1)
INFO     pdm.termui:reporters.py:36   Adding requirement idna<2.8,>=2.5(from requests 2.19.1)
INFO     pdm.termui:reporters.py:36   Adding requirement urllib3<1.24,>=1.21.1(from requests 2.19.1)
INFO     pdm.termui:reporters.py:146 Adding new pin: requests 2.19.1
INFO     pdm.termui:reporters.py:23 ======== Starting round 2 ========
INFO     pdm.termui:reporters.py:146 Adding new pin: chardet 3.0.4
INFO     pdm.termui:reporters.py:23 ======== Starting round 3 ========
INFO     pdm.termui:reporters.py:146 Adding new pin: idna 2.7
INFO     pdm.termui:reporters.py:23 ======== Starting round 4 ========
INFO     pdm.termui:reporters.py:146 Adding new pin: urllib3 1.22
INFO     pdm.termui:reporters.py:23 ======== Starting round 5 ========
INFO     pdm.termui:reporters.py:146 Adding new pin: certifi 2018.11.17
INFO     pdm.termui:reporters.py:23 ======== Starting round 6 ========
INFO     pdm.termui:reporters.py:23 ======== Resolution Result ========
INFO     pdm.termui:reporters.py:49     python None
INFO     pdm.termui:reporters.py:49   requests 2.19.1
INFO     pdm.termui:reporters.py:49    chardet 3.0.4
INFO     pdm.termui:reporters.py:49       idna 2.7
INFO     pdm.termui:reporters.py:49    urllib3 1.22
INFO     pdm.termui:reporters.py:49    certifi 2018.11.17
INFO     unearth.preparer:preparer.py:329 The file /tmp/pytest-of-huxuan/pytest-4/test_remove_exclude_non_existi0 is a local directory, use it directly
INFO     pdm.termui:reporters.py:23 ======== Start resolving requirements ========
INFO     pdm.termui:reporters.py:36   Adding requirement python>=3.7
INFO     pdm.termui:reporters.py:23 ======== Starting round 0 ========
INFO     pdm.termui:reporters.py:146 Adding new pin: python None
INFO     pdm.termui:reporters.py:23 ======== Starting round 1 ========
INFO     pdm.termui:reporters.py:23 ======== Resolution Result ========
INFO     pdm.termui:reporters.py:49   python None
============================================================================== short test summary info ==============================================================================
FAILED tests/cli/test_remove.py::test_remove_exclude_non_existing_dev_group_in_lockfile - AssertionError: assert 1 == 0
 +  where 1 = RunResult(exit_code=1, stdout='Removing packages from default dependencies: requests\nChanges are written to pyproject....\n  0:00:00 🔒 Lock successful.  \n', stderr='[PdmUsageError]: Requested groups not in lockfile: tz\n', exception=None).exit_code
========================================================================= 1 failed, 986 deselected in 1.84s =========================================================================
```