### PR TITLE
fix: If a multiline .python-version is found, it is ignored

### DIFF
--- a/news/3417.bugfix.md
+++ b/news/3417.bugfix.md
@@ -1,0 +1,1 @@
+If a `.python-version` file is found and it contains multiple lines, the file will be ignored. The usage of the `.python-version` file can be disabled, if configuration value `python.use_python_version` (or environment variable `PDM_USE_PYTHON_VERSION`) is `False`.

--- a/src/pdm/cli/commands/use.py
+++ b/src/pdm/cli/commands/use.py
@@ -184,7 +184,7 @@ class Command(BaseCommand):
             f"Using {'[bold]Global[/] ' if project.is_global else ''}Python interpreter: [success]{selected_python.path!s}[/] ({selected_python_identifier})"
         )
         project.python = selected_python
-        if version_file:
+        if version_file and project.config["python.use_python_version"]:
             with project.root.joinpath(".python-version").open("w") as f:
                 f.write(f"{selected_python.major}.{selected_python.minor}\n")
         if project.environment.is_local:

--- a/src/pdm/cli/commands/venv/backends.py
+++ b/src/pdm/cli/commands/venv/backends.py
@@ -43,7 +43,10 @@ class Backend(abc.ABC):
                 py_version.valid and self.project.python_requires.contains(py_version.version, True)
             )
 
-        for py_version in self.project.iter_interpreters(self.python, search_venv=False, filter_func=match_func):
+        respect_version_file = self.project.config["python.use_python_version"]
+        for py_version in self.project.iter_interpreters(
+            self.python, search_venv=False, filter_func=match_func, respect_version_file=respect_version_file
+        ):
             return py_version
 
         python = f" {self.python}" if self.python else ""

--- a/src/pdm/project/config.py
+++ b/src/pdm/project/config.py
@@ -182,6 +182,12 @@ class Config(MutableMapping[str, str]):
         "python.use_venv": ConfigItem(
             "Use virtual environments when available", True, env_var="PDM_USE_VENV", coerce=ensure_boolean
         ),
+        "python.use_python_version": ConfigItem(
+            "Use .python-version file next to pyproject.toml to find python interpreters",
+            True,
+            env_var="PDM_USE_PYTHON_VERSION",
+            coerce=ensure_boolean,
+        ),
         "python.install_root": ConfigItem(
             "The root directory to install python interpreters",
             global_only=True,

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -270,7 +270,9 @@ class Project:
                 return self.python
 
         if self.root.joinpath("__pypackages__").exists() or not config["python.use_venv"] or self.is_global:
-            for py_version in self.iter_interpreters(filter_func=match_version):
+            for py_version in self.iter_interpreters(
+                filter_func=match_version, respect_version_file=config["python.use_python_version"]
+            ):
                 note("[success]__pypackages__[/] is detected, using the PEP 582 mode")
                 self.python = py_version
                 return py_version

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -56,6 +56,20 @@ def test_use_python_write_file(pdm, project):
 
 
 @pytest.mark.integration
+@pytest.mark.skipif(len(PYTHON_VERSIONS) < 2, reason="Need at least 2 Python versions to test")
+def test_use_python_write_no_file(pdm, project):
+    project.project_config["python.use_python_version"] = False
+    pdm(["use", PYTHON_VERSIONS[0]], obj=project, strict=True)
+    assert f"{project.python.major}.{project.python.minor}" == PYTHON_VERSIONS[0]
+    assert not project.root.joinpath(".python-version").exists()
+    project.project_config["python.use_python_version"] = True
+    pdm(["use", PYTHON_VERSIONS[1]], obj=project, strict=True)
+    assert f"{project.python.major}.{project.python.minor}" == PYTHON_VERSIONS[1]
+    assert project.root.joinpath(".python-version").exists()
+    assert project.root.joinpath(".python-version").read_text().strip() == PYTHON_VERSIONS[1]
+
+
+@pytest.mark.integration
 @pytest.mark.parametrize("python_version", PYTHON_VERSIONS)
 @pytest.mark.parametrize("via_env", [True, False])
 def test_init_project_respect_version_file(pdm, project, python_version, via_env, monkeypatch):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -69,6 +69,7 @@ def test_init_project_respect_version_file(pdm, project, python_version, via_env
     pdm(["install"], obj=project, strict=True)
     assert f"{project.python.major}.{project.python.minor}" == python_version
 
+
 @pytest.mark.integration
 @pytest.mark.parametrize("python_version", PYTHON_VERSIONS)
 def test_use_python_write_file_multiple_versions(pdm, project, python_version, monkeypatch):
@@ -79,6 +80,7 @@ def test_use_python_write_file_multiple_versions(pdm, project, python_version, m
     project._environment = None
     pdm(["install"], obj=project, strict=True)
     assert f"{project.python.major}.{project.python.minor}" not in no_versions
+
 
 @pytest.mark.integration
 @pytest.mark.skipif(len(PYTHON_VERSIONS) < 2, reason="Need at least 2 Python versions to test")
@@ -92,6 +94,7 @@ def test_use_python_write_file_with_use_python_version(pdm, project, monkeypatch
     pdm(["install"], obj=project, strict=True)
     assert f"{project.python.major}.{project.python.minor}" == configured_python_version
 
+
 @pytest.mark.integration
 @pytest.mark.skipif(len(PYTHON_VERSIONS) < 2, reason="Need at least 2 Python versions to test")
 def test_use_python_write_file_without_use_python_version(pdm, project):
@@ -102,6 +105,7 @@ def test_use_python_write_file_without_use_python_version(pdm, project):
     project._environment = None
     pdm(["install"], obj=project, strict=True)
     assert f"{project.python.major}.{project.python.minor}" in PYTHON_VERSIONS
+
 
 def test_actual_list_freeze(project, local_finder, pdm):
     pdm(["config", "-l", "install.parallel", "false"], obj=project, strict=True)


### PR DESCRIPTION
## Pull Request Checklist

- [X] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Local .python-version flies with multiple versions will be ignored, as they do not provide a single version to consider. Hence it should not be used and can safely be ignored.

Closes #3417
