### PR TITLE
Use id to invoke oidc token generation

### DIFF
--- a/docs/usage/publish.md
+++ b/docs/usage/publish.md
@@ -20,13 +20,14 @@ pdm publish --repository https://test.pypi.org/legacy/
 ## Publish with trusted publishers
 
 You can configure trusted publishers for PyPI so that you don't need to expose the PyPI tokens in the release workflow. To do this, follow
-[the guide](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) to add a publisher and write the GitHub Actions workflow as below:
+[the guide](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) to add a publisher write a action as below:
+
+### GitHub Actions
 
 ```yaml
 on:
   release:
     types: [published]
-
 
 jobs:
   pypi-publish:
@@ -44,6 +45,23 @@ jobs:
 
       - name: Publish package distributions to PyPI
         run: pdm publish
+```
+
+### GitLab CI
+
+```yaml
+image: python:3.12-bookworm
+before_script:
+  - pip install pdm
+
+publish-package:
+  stage: release
+  environment: production
+  id_tokens:
+    PYPI_ID_TOKEN: # for testpypi: TESTPYPI_ID_TOKEN
+      aud: "pypi" # testpypi
+  script:
+    - pdm publish
 ```
 
 ## Build and publish separately

--- a/news/3441.feature.md
+++ b/news/3441.feature.md
@@ -1,0 +1,1 @@
+Support all providers `id` is supporting currently for OIDC trusted publishing

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "all", "cookiecutter", "copier", "doc", "keyring", "pytest", "template", "test", "tox", "workflow"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:de9e1b78b17729c4eea13619aac1d0be4766ebefe354fdba05bba1f3ff9e661c"
+content_hash = "sha256:c01f9550e0e9f04d9bcd5b910568afbbea1e15ca484f29acd43fa986c43edf0e"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -29,7 +29,7 @@ name = "anyio"
 version = "4.3.0"
 requires_python = ">=3.8"
 summary = "High level compatibility layer for multiple asynchronous event loop implementations"
-groups = ["default"]
+groups = ["default", "test"]
 dependencies = [
     "exceptiongroup>=1.0.2; python_version < \"3.11\"",
     "idna>=2.8",
@@ -124,7 +124,7 @@ name = "blinker"
 version = "1.8.2"
 requires_python = ">=3.8"
 summary = "Fast, simple object-to-object and broadcast signaling"
-groups = ["default"]
+groups = ["default", "test"]
 files = [
     {file = "blinker-1.8.2-py3-none-any.whl", hash = "sha256:1779309f71bf239144b9399d06ae925637cf6634cf6bd131104184531bf67c01"},
     {file = "blinker-1.8.2.tar.gz", hash = "sha256:8f77b09d3bf7c795e969e9486f39c2c5e9c39d4ee07424be2bc594ece9642d83"},
@@ -146,7 +146,7 @@ name = "certifi"
 version = "2024.8.30"
 requires_python = ">=3.6"
 summary = "Python package for providing Mozilla's CA Bundle."
-groups = ["default", "all", "cookiecutter", "doc", "template"]
+groups = ["default", "all", "cookiecutter", "doc", "template", "test"]
 files = [
     {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
     {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
@@ -213,7 +213,7 @@ name = "charset-normalizer"
 version = "3.3.2"
 requires_python = ">=3.7.0"
 summary = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-groups = ["all", "cookiecutter", "doc", "template"]
+groups = ["default", "all", "cookiecutter", "doc", "template", "test"]
 files = [
     {file = "charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"},
     {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3"},
@@ -491,7 +491,7 @@ name = "dep-logic"
 version = "0.4.11"
 requires_python = ">=3.8"
 summary = "Python dependency specifications supporting logical operations"
-groups = ["default"]
+groups = ["default", "test"]
 dependencies = [
     "packaging>=22",
 ]
@@ -504,7 +504,7 @@ files = [
 name = "distlib"
 version = "0.3.8"
 summary = "Distribution utilities"
-groups = ["default", "tox"]
+groups = ["default", "test", "tox"]
 files = [
     {file = "distlib-0.3.8-py2.py3-none-any.whl", hash = "sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784"},
     {file = "distlib-0.3.8.tar.gz", hash = "sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64"},
@@ -565,7 +565,7 @@ name = "filelock"
 version = "3.16.1"
 requires_python = ">=3.8"
 summary = "A platform independent file lock."
-groups = ["default", "tox"]
+groups = ["default", "test", "tox"]
 files = [
     {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
     {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
@@ -576,7 +576,7 @@ name = "findpython"
 version = "0.6.3"
 requires_python = ">=3.8"
 summary = "A utility to find python versions on your system"
-groups = ["default"]
+groups = ["default", "test"]
 dependencies = [
     "packaging>=20",
 ]
@@ -628,7 +628,7 @@ name = "h11"
 version = "0.14.0"
 requires_python = ">=3.7"
 summary = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
-groups = ["default"]
+groups = ["default", "test"]
 dependencies = [
     "typing-extensions; python_version < \"3.8\"",
 ]
@@ -642,7 +642,7 @@ name = "hishel"
 version = "0.0.33"
 requires_python = ">=3.8"
 summary = "Persistent cache implementation for httpx and httpcore"
-groups = ["default"]
+groups = ["default", "test"]
 dependencies = [
     "httpx>=0.22.0",
     "typing-extensions>=4.8.0",
@@ -657,7 +657,7 @@ name = "httpcore"
 version = "1.0.6"
 requires_python = ">=3.8"
 summary = "A minimal low-level HTTP client."
-groups = ["default"]
+groups = ["default", "test"]
 dependencies = [
     "certifi",
     "h11<0.15,>=0.13",
@@ -672,7 +672,7 @@ name = "httpx"
 version = "0.27.2"
 requires_python = ">=3.8"
 summary = "The next generation HTTP client."
-groups = ["default"]
+groups = ["default", "test"]
 dependencies = [
     "anyio",
     "certifi",
@@ -691,7 +691,7 @@ version = "0.27.2"
 extras = ["socks"]
 requires_python = ">=3.8"
 summary = "The next generation HTTP client."
-groups = ["default"]
+groups = ["default", "test"]
 dependencies = [
     "httpx==0.27.2",
     "socksio==1.*",
@@ -702,11 +702,25 @@ files = [
 ]
 
 [[package]]
+name = "id"
+version = "1.5.0"
+requires_python = ">=3.8"
+summary = "A tool for generating OIDC identities"
+groups = ["default", "test"]
+dependencies = [
+    "requests",
+]
+files = [
+    {file = "id-1.5.0-py3-none-any.whl", hash = "sha256:f1434e1cef91f2cbb8a4ec64663d5a23b9ed43ef44c4c957d02583d61714c658"},
+    {file = "id-1.5.0.tar.gz", hash = "sha256:292cb8a49eacbbdbce97244f47a97b4c62540169c976552e497fd57df0734c1d"},
+]
+
+[[package]]
 name = "idna"
 version = "3.6"
 requires_python = ">=3.5"
 summary = "Internationalized Domain Names in Applications (IDNA)"
-groups = ["default", "all", "cookiecutter", "doc", "template"]
+groups = ["default", "all", "cookiecutter", "doc", "template", "test"]
 files = [
     {file = "idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"},
     {file = "idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"},
@@ -717,7 +731,7 @@ name = "importlib-metadata"
 version = "8.5.0"
 requires_python = ">=3.8"
 summary = "Read metadata from Python packages"
-groups = ["default", "all", "doc", "keyring", "workflow"]
+groups = ["default", "all", "doc", "keyring", "test", "workflow"]
 marker = "python_version < \"3.12\""
 dependencies = [
     "typing-extensions>=3.6.4; python_version < \"3.8\"",
@@ -759,7 +773,7 @@ name = "installer"
 version = "0.7.0"
 requires_python = ">=3.7"
 summary = "A library for installing Python wheels."
-groups = ["default"]
+groups = ["default", "test"]
 files = [
     {file = "installer-0.7.0-py3-none-any.whl", hash = "sha256:05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53"},
     {file = "installer-0.7.0.tar.gz", hash = "sha256:a26d3e3116289bb08216e0d0f7d925fcef0b0194eedfa0c944bcaaa106c4b631"},
@@ -901,7 +915,7 @@ name = "markdown-it-py"
 version = "3.0.0"
 requires_python = ">=3.8"
 summary = "Python port of markdown-it. Markdown parsing, done right!"
-groups = ["default", "all", "cookiecutter", "template"]
+groups = ["default", "all", "cookiecutter", "template", "test"]
 dependencies = [
     "mdurl~=0.1",
 ]
@@ -965,7 +979,7 @@ name = "mdurl"
 version = "0.1.2"
 requires_python = ">=3.7"
 summary = "Markdown URL utilities"
-groups = ["default", "all", "cookiecutter", "template"]
+groups = ["default", "all", "cookiecutter", "template", "test"]
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
@@ -1172,7 +1186,7 @@ name = "msgpack"
 version = "1.1.0"
 requires_python = ">=3.8"
 summary = "MessagePack serializer"
-groups = ["default"]
+groups = ["default", "test"]
 files = [
     {file = "msgpack-1.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7ad442d527a7e358a469faf43fda45aaf4ac3249c8310a82f0ccff9164e5dccd"},
     {file = "msgpack-1.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:74bed8f63f8f14d75eec75cf3d04ad581da6b914001b474a5d3cd3372c8cc27d"},
@@ -1284,7 +1298,7 @@ name = "pbs-installer"
 version = "2025.2.12"
 requires_python = ">=3.8"
 summary = "Installer for Python Build Standalone"
-groups = ["default"]
+groups = ["default", "test"]
 files = [
     {file = "pbs_installer-2025.2.12-py3-none-any.whl", hash = "sha256:3d9034047945b2d5f169cd9bb324f1f28c37d0ec120d6110ddb10aa07016fb79"},
     {file = "pbs_installer-2025.2.12.tar.gz", hash = "sha256:c6815165babf312c90d27ccd16afe598de641d616860f88e1855f183b0253b39"},
@@ -1295,7 +1309,7 @@ name = "platformdirs"
 version = "4.3.6"
 requires_python = ">=3.8"
 summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
-groups = ["default", "doc", "tox"]
+groups = ["default", "doc", "test", "tox"]
 files = [
     {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
     {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
@@ -1474,7 +1488,7 @@ name = "pygments"
 version = "2.17.2"
 requires_python = ">=3.7"
 summary = "Pygments is a syntax highlighting package written in Python."
-groups = ["default", "all", "cookiecutter", "copier", "doc", "template"]
+groups = ["default", "all", "cookiecutter", "copier", "doc", "template", "test"]
 files = [
     {file = "pygments-2.17.2-py3-none-any.whl", hash = "sha256:b27c2826c47d0f3219f29554824c30c5e8945175d888647acd804ddd04af846c"},
     {file = "pygments-2.17.2.tar.gz", hash = "sha256:da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367"},
@@ -1515,7 +1529,7 @@ name = "pyproject-hooks"
 version = "1.2.0"
 requires_python = ">=3.7"
 summary = "Wrappers to call pyproject.toml-based build backend hooks."
-groups = ["default"]
+groups = ["default", "test"]
 files = [
     {file = "pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"},
     {file = "pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8"},
@@ -1567,6 +1581,21 @@ dependencies = [
 files = [
     {file = "pytest_httpserver-1.1.0-py3-none-any.whl", hash = "sha256:7ef88be8ed3354b6784daa3daa75a422370327c634053cefb124903fa8d73a41"},
     {file = "pytest_httpserver-1.1.0.tar.gz", hash = "sha256:6b1cb0199e2ed551b1b94d43f096863bbf6ae5bcd7c75c2c06845e5ce2dc8701"},
+]
+
+[[package]]
+name = "pytest-httpx"
+version = "0.34.0"
+requires_python = ">=3.9"
+summary = "Send responses to httpx."
+groups = ["test"]
+dependencies = [
+    "httpx==0.27.*",
+    "pytest==8.*",
+]
+files = [
+    {file = "pytest_httpx-0.34.0-py3-none-any.whl", hash = "sha256:42cf0a66f7b71b9111db2897e8b38a903abd33a27b11c48aff4a3c7650313af2"},
+    {file = "pytest_httpx-0.34.0.tar.gz", hash = "sha256:3ca4b0975c0f93b985f17df19e76430c1086b5b0cce32b1af082d8901296a735"},
 ]
 
 [[package]]
@@ -1632,7 +1661,7 @@ name = "python-dotenv"
 version = "1.0.1"
 requires_python = ">=3.8"
 summary = "Read key-value pairs from a .env file and set them as environment variables"
-groups = ["default"]
+groups = ["default", "test"]
 files = [
     {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
     {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
@@ -1829,7 +1858,7 @@ name = "requests"
 version = "2.31.0"
 requires_python = ">=3.7"
 summary = "Python HTTP for Humans."
-groups = ["all", "cookiecutter", "doc", "template"]
+groups = ["default", "all", "cookiecutter", "doc", "template", "test"]
 dependencies = [
     "certifi>=2017.4.17",
     "charset-normalizer<4,>=2",
@@ -1846,7 +1875,7 @@ name = "resolvelib"
 version = "1.1.0"
 requires_python = ">=3.7"
 summary = "Resolve abstract dependencies into concrete ones"
-groups = ["default"]
+groups = ["default", "test"]
 files = [
     {file = "resolvelib-1.1.0-py2.py3-none-any.whl", hash = "sha256:f80de38ae744bcf4e918e27a681a5c6cb63a08d9a926c0989c0730bcdd089049"},
     {file = "resolvelib-1.1.0.tar.gz", hash = "sha256:b68591ef748f58c1e2a2ac28d0961b3586ae8b25f60b0ba9a5e4f3d87c1d6a79"},
@@ -1857,7 +1886,7 @@ name = "rich"
 version = "13.9.2"
 requires_python = ">=3.8.0"
 summary = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
-groups = ["default", "all", "cookiecutter", "template"]
+groups = ["default", "all", "cookiecutter", "template", "test"]
 dependencies = [
     "markdown-it-py>=2.2.0",
     "pygments<3.0.0,>=2.13.0",
@@ -1900,7 +1929,7 @@ name = "shellingham"
 version = "1.5.4"
 requires_python = ">=3.7"
 summary = "Tool to Detect Surrounding Shell"
-groups = ["default"]
+groups = ["default", "test"]
 files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
@@ -1922,7 +1951,7 @@ name = "sniffio"
 version = "1.3.1"
 requires_python = ">=3.7"
 summary = "Sniff out which async library your code is running under"
-groups = ["default"]
+groups = ["default", "test"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
@@ -1933,7 +1962,7 @@ name = "socksio"
 version = "1.0.0"
 requires_python = ">=3.6"
 summary = "Sans-I/O implementation of SOCKS4, SOCKS4A, and SOCKS5."
-groups = ["default"]
+groups = ["default", "test"]
 files = [
     {file = "socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3"},
     {file = "socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac"},
@@ -1966,7 +1995,7 @@ name = "tomlkit"
 version = "0.13.2"
 requires_python = ">=3.8"
 summary = "Style preserving TOML library"
-groups = ["default"]
+groups = ["default", "test"]
 files = [
     {file = "tomlkit-0.13.2-py3-none-any.whl", hash = "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde"},
     {file = "tomlkit-0.13.2.tar.gz", hash = "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79"},
@@ -2034,7 +2063,7 @@ name = "truststore"
 version = "0.9.2"
 requires_python = ">=3.10"
 summary = "Verify certificates using native system trust stores"
-groups = ["default"]
+groups = ["default", "test"]
 marker = "python_version >= \"3.10\""
 files = [
     {file = "truststore-0.9.2-py3-none-any.whl", hash = "sha256:04559916f8810cc1a5ecc41f215eddc988746067b754fc0995da7a2ceaf54735"},
@@ -2046,7 +2075,7 @@ name = "typing-extensions"
 version = "4.12.2"
 requires_python = ">=3.8"
 summary = "Backported and Experimental Type Hints for Python 3.8+"
-groups = ["default", "all", "cookiecutter", "copier", "doc", "template", "tox", "workflow"]
+groups = ["default", "all", "cookiecutter", "copier", "doc", "template", "test", "tox", "workflow"]
 files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
@@ -2057,7 +2086,7 @@ name = "unearth"
 version = "0.17.2"
 requires_python = ">=3.8"
 summary = "A utility to fetch and download python packages"
-groups = ["default"]
+groups = ["default", "test"]
 dependencies = [
     "httpx<1,>=0.27.0",
     "packaging>=20",
@@ -2072,7 +2101,7 @@ name = "urllib3"
 version = "2.2.1"
 requires_python = ">=3.8"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
-groups = ["all", "cookiecutter", "doc", "template"]
+groups = ["default", "all", "cookiecutter", "doc", "template", "test"]
 files = [
     {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
     {file = "urllib3-2.2.1.tar.gz", hash = "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"},
@@ -2083,7 +2112,7 @@ name = "virtualenv"
 version = "20.27.0"
 requires_python = ">=3.8"
 summary = "Virtual Python Environment builder"
-groups = ["default", "tox"]
+groups = ["default", "test", "tox"]
 dependencies = [
     "distlib<1,>=0.3.7",
     "filelock<4,>=3.12.2",
@@ -2161,7 +2190,7 @@ name = "zipp"
 version = "3.20.2"
 requires_python = ">=3.8"
 summary = "Backport of pathlib-compatible object wrapper for zip files"
-groups = ["default", "all", "doc", "keyring", "workflow"]
+groups = ["default", "all", "doc", "keyring", "test", "workflow"]
 marker = "python_version < \"3.12\""
 files = [
     {file = "zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "filelock>=3.13",
     "httpcore>=1.0.6",
     "certifi>=2024.8.30",
+    "id>=1.5.0"
 ]
 readme = "README.md"
 keywords = ["packaging", "dependency", "workflow"]
@@ -75,37 +76,6 @@ all = [
 [project.scripts]
 pdm = "pdm.core:main"
 
-[tool.pdm.version]
-source = "scm"
-write_to = "pdm/VERSION"
-
-[tool.pdm.build]
-excludes = ["./**/.git"]
-package-dir = "src"
-includes = ["src/pdm"]
-source-includes = ["tests", "typings", "CHANGELOG.md", "LICENSE", "README.md", "tox.ini"]
-# editables backend doesn't work well with namespace packages
-editable-backend = "path"
-locked = true
-locked-groups = ["default", "all"]
-
-[tool.pdm.scripts]
-pre_release = "python tasks/max_versions.py"
-release = "python tasks/release.py"
-test = "pytest"
-coverage = {shell = """\
-                    python -m pytest \
-                              --verbosity=3 \
-                              --cov=src/pdm \
-                              --cov-branch \
-                              --cov-report term-missing \
-                              tests/
-                    """}
-tox = "tox"
-doc = {cmd = "mkdocs serve", help = "Start the dev server for docs preview"}
-lint = "pre-commit run --all-files"
-complete = {call = "tasks.complete:main", help = "Create autocomplete files for bash and fish"}
-
 [dependency-groups]
 test = [
     "pdm[pytest]",
@@ -113,6 +83,7 @@ test = [
     "pytest-xdist>=1.31.0",
     "pytest-rerunfailures>=10.2",
     "pytest-httpserver>=1.0.6",
+    "pytest-httpx>=0.34.0",
 ]
 tox = [
     "tox",
@@ -258,3 +229,35 @@ exclude = "pdm/(pep582/|models/in_process/.+\\.py)"
 namespace_packages = true
 mypy_path = "src"
 explicit_package_bases = true
+
+[tool.pdm.version]
+source = "scm"
+write_to = "pdm/VERSION"
+
+[tool.pdm.build]
+excludes = ["./**/.git"]
+package-dir = "src"
+includes = ["src/pdm"]
+source-includes = ["tests", "typings", "CHANGELOG.md", "LICENSE", "README.md", "tox.ini"]
+# editables backend doesn't work well with namespace packages
+editable-backend = "path"
+locked = true
+locked-groups = ["default", "all"]
+
+[tool.pdm.scripts]
+pre_release = "python tasks/max_versions.py"
+release = "python tasks/release.py"
+test = "pytest"
+coverage = {shell = """\
+                    python -m pytest \
+                              --verbosity=3 \
+                              --cov=src/pdm \
+                              --cov-branch \
+                              --cov-report term-missing \
+                              tests/
+                    """}
+tox = "tox"
+doc = {cmd = "mkdocs serve", help = "Start the dev server for docs preview"}
+lint = "pre-commit run --all-files"
+complete = {call = "tasks.complete:main", help = "Create autocomplete files for bash and fish"}
+


### PR DESCRIPTION
`id` implements detection of different providers, like Github, Gitlab etc. With that pdm does not need to take care of all supported providers and can stand of the shoulder of that library that twine uses as well.
- removed pdm's implementation of generating a token
- add `id` dependency and use it
- add test dependency to mock httpx requests
- add test for oidc auth of Repository

## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

Closes: #3441 