### PR TITLE
fix: pass the `--quiet` option to `pdm sync`

### DIFF
--- a/news/3401.bug.md
+++ b/news/3401.bug.md
@@ -1,0 +1,1 @@
+Pass the `--quiet` option to `pdm sync` command.

--- a/src/pdm/cli/actions.py
+++ b/src/pdm/cli/actions.py
@@ -268,6 +268,7 @@ def do_sync(
     selection: GroupSelection,
     dry_run: bool = False,
     clean: bool = False,
+    quiet: bool = False,
     requirements: list[Requirement] | None = None,
     tracked_names: Collection[str] | None = None,
     no_editable: bool | Collection[str] = False,
@@ -288,7 +289,7 @@ def do_sync(
     packages = list(resolve_from_lockfile(project, requirements, groups=list(selection)))
     if tracked_names and dry_run:
         packages = [p for p in packages if p.candidate.identify() in tracked_names]
-    synchronizer = project.get_synchronizer()(
+    synchronizer = project.get_synchronizer(quiet=quiet)(
         project.environment,
         clean=clean,
         dry_run=dry_run,

--- a/src/pdm/cli/commands/sync.py
+++ b/src/pdm/cli/commands/sync.py
@@ -46,6 +46,7 @@ class Command(BaseCommand):
             selection=selection,
             dry_run=options.dry_run,
             clean=options.clean,
+            quiet=options.verbose == -1,
             no_editable=options.no_editable,
             no_self=options.no_self or "default" not in selection,
             reinstall=options.reinstall,


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

- fix https://github.com/pdm-project/pdm/issues/3401