### PR TITLE
fix: Mark two more tests as requiring network (#3487)

### DIFF
--- a/news/3487.bugfix.md
+++ b/news/3487.bugfix.md
@@ -1,0 +1,1 @@
+Mark two more tests are requiring network.

--- a/news/3487.bugfix.md
+++ b/news/3487.bugfix.md
@@ -1,1 +1,2 @@
-Mark two more tests are requiring network.
+Mark one additional test as requiring network, and fix another one
+not to require it anymore.

--- a/tests/models/test_candidates.py
+++ b/tests/models/test_candidates.py
@@ -283,10 +283,9 @@ def test_ignore_invalid_py_version(project):
     _ = next(iter(repo.find_candidates(req)))
 
 
-@pytest.mark.network
 def test_find_candidates_from_find_links(project):
     project.pyproject.settings["source"] = [
-        {"name": "test", "url": "http://fixtures.test/index/demo.html", "verify_ssl": False, "type": "find_links"}
+        {"name": "pypi", "url": "http://fixtures.test/index/demo.html", "verify_ssl": False, "type": "find_links"}
     ]
     project.pyproject.write(False)
     repo = project.get_repository()

--- a/tests/models/test_candidates.py
+++ b/tests/models/test_candidates.py
@@ -283,6 +283,7 @@ def test_ignore_invalid_py_version(project):
     _ = next(iter(repo.find_candidates(req)))
 
 
+@pytest.mark.network
 def test_find_candidates_from_find_links(project):
     project.pyproject.settings["source"] = [
         {"name": "test", "url": "http://fixtures.test/index/demo.html", "verify_ssl": False, "type": "find_links"}

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -443,7 +443,7 @@ def test_preserve_log_file(project, pdm, tmp_path, mocker):
     assert install_log.exists()
 
 
-@pytest.mark.parametrize("use_venv", [True, False])
+@pytest.mark.parametrize("use_venv", [pytest.param(True, marks=pytest.mark.network), False])
 def test_find_interpreters_with_PDM_IGNORE_ACTIVE_VENV(
     pdm: PDMCallable,
     project: Project,


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
Mark two more fails with the `network` marker, as they fail without Internet access, as noted in #3487.