### PR TITLE
fix: make `pdm venv create --with-pip --with uv` pass correct args to `uv`

### DIFF
--- a/src/pdm/cli/commands/venv/backends.py
+++ b/src/pdm/cli/commands/venv/backends.py
@@ -173,7 +173,7 @@ class VenvBackend(VirtualenvBackend):
 class UvBackend(VirtualenvBackend):
     def pip_args(self, with_pip: bool) -> Iterable[str]:
         if with_pip:
-            return ("--seed", "pip")
+            return ("--seed",)
         return ()
 
     def perform_create(self, location: Path, args: tuple[str, ...], prompt: str | None = None) -> None:


### PR DESCRIPTION
Fixes #3495.

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

The command `uv venv` takes a `--seed` flag with no parameters.