### PR TITLE
fix: Use `sys.executable` in `project_no_init` pytest fixture

### DIFF
--- a/src/pdm/pytest.py
+++ b/src/pdm/pytest.py
@@ -63,7 +63,7 @@ from pdm.models.requirements import (
 from pdm.models.session import PDMPyPIClient
 from pdm.project.config import Config
 from pdm.project.core import Project
-from pdm.utils import find_python_in_path, normalize_name, parse_version
+from pdm.utils import normalize_name, parse_version
 
 if TYPE_CHECKING:
     from typing import Protocol
@@ -407,9 +407,7 @@ def project_no_init(
     tmp_path.joinpath("caches").mkdir(parents=True)
     p.global_config["cache_dir"] = tmp_path.joinpath("caches").as_posix()
     p.global_config["log_dir"] = tmp_path.joinpath("logs").as_posix()
-    python_path = find_python_in_path(sys.base_prefix)
-    if python_path is None:
-        raise ValueError("Unable to find a Python path")
+    python_path = Path(sys.executable)
     p._saved_python = python_path.as_posix()
     monkeypatch.delenv("VIRTUAL_ENV", raising=False)
     monkeypatch.delenv("CONDA_PREFIX", raising=False)


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
Revert part of the changes to `project_no_init` fixture introduced as part of 224663a601548108daac947531442b4af56a9747 that replaced `sys.executable` with `find_python_in_path()` call.  The latter code works correctly only if a single Python version is installed in `sys.base_prefix`.  When more than one version is installed, `find_python_in_path()` can choose an arbitrary Python version, effectively causing a mismatch between the version used by the test suite and the fixture, effectively causing test failures due to mismatched expectations.

Fixes #3486

