### PR TITLE
Stabilize ordering of extras and dependency-groups in pylock output

### DIFF
--- a/news/3543.bugfix.md
+++ b/news/3543.bugfix.md
@@ -1,0 +1,1 @@
+Stabilize order of the `extras` and `dependency-groups` fields in pylock output.

--- a/src/pdm/formats/pylock.py
+++ b/src/pdm/formats/pylock.py
@@ -127,8 +127,8 @@ class PyLockConverter:
                 "lock-version": self.lock_version,
                 "requires-python": str(project.python_requires),
                 "environments": make_array([str(marker) for marker in env_markers], multiline=True),
-                "extras": extras,
-                "dependency-groups": groups,
+                "extras": sorted(extras),
+                "dependency-groups": sorted(groups),
                 "default-groups": ["default"],
                 "created-by": "pdm",
             }


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

As described in #3543, multiple locks of the same project would jitter around the output of `dependency-groups` in the resulting `pylock.toml` file. Looking at the code that produces this, it outputs the result of a number of possible sources, at least one of which (`Project.iter_group()`) using a `set` to collect possible groups. In order to minimize the impact of this change, I opted to sort the output just before it's being output to avoid changing behaviour anywhere else. This could of course be moved further up the stack. 

Currently didn't add any tests, would this change warrant its own test?