### PR TITLE
fix: editable local packages causes empty urls when pylock is used

### DIFF
--- a/news/3565.bugfix.md
+++ b/news/3565.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug that editable local package URLs are empty when using `pylock.toml`.

--- a/src/pdm/models/repositories/lock.py
+++ b/src/pdm/models/repositories/lock.py
@@ -111,11 +111,10 @@ class LockedRepository(BaseRepository):
                     req_dict["url"] = archive.get("url")
                     req_dict["path"] = archive.get("path")
                     req_dict["subdirectory"] = archive.get("subdirectory")
-                candidate = Candidate(
-                    req=Requirement.from_req_dict(package_name, req_dict),
-                    name=package_name,
-                    version=package.get("version"),
-                )
+                req = Requirement.from_req_dict(package_name, req_dict)
+                if req.is_file_or_url and req.path and not req.url:  # type: ignore[attr-defined]
+                    req.url = root.joinpath(req.path).as_uri()  # type: ignore[attr-defined]
+                candidate = Candidate(req=req, name=package_name, version=package.get("version"))
                 candidate.requires_python = package.get("requires-python", "")
                 for artifact in itertools.chain(
                     package.get("wheels", []), [sdist] if (sdist := package.get("sdist")) else []


### PR DESCRIPTION
Fixes #3565

Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
