### PR TITLE
Docs: Select color scheme based on system preference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,14 +15,14 @@ theme:
       primary: deep purple
       accent: teal
       toggle:
-        icon: material/weather-sunny
+        icon: material/brightness-7
         name: Switch to dark mode
     - scheme: slate
       media: "(prefers-color-scheme: dark)"
       primary: deep purple
       accent: teal
       toggle:
-        icon: material/weather-night
+        icon: material/brightness-4
         name: Switch to system preference
   font:
     text: Open Sans

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,10 @@ edit_uri: edit/main/docs
 theme:
   name: material
   palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
     - scheme: default
       media: "(prefers-color-scheme: light)"
       primary: deep purple
@@ -19,7 +23,7 @@ theme:
       accent: teal
       toggle:
         icon: material/weather-night
-        name: Switch to light mode
+        name: Switch to system preference
   font:
     text: Open Sans
     code: Fira Code


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Added a toggle to select the documentation color scheme based on system preference. Additionally, the icons for light and dark mode were adjusted to match the automatic toggle icon.

Related mkdocs documentation: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#automatic-light-dark-mode