### PR TITLE
feat: show download URL in 'pdm python install -v'

### DIFF
--- a/news/3552.feature.md
+++ b/news/3552.feature.md
@@ -1,0 +1,1 @@
+The `pdm python install -v` command now shows the download URL for the Python interpreter.

--- a/src/pdm/cli/commands/python.py
+++ b/src/pdm/cli/commands/python.py
@@ -151,7 +151,7 @@ class InstallCommand(BaseCommand):
         spinner_msg = f"Downloading [success]{ver_str}[/]"
         if ui.verbosity >= Verbosity.DETAIL:
             download_url = python_file[0] if isinstance(python_file, (tuple, list)) else python_file
-            spinner_msg += f" [link]{download_url}[/link]"
+            spinner_msg += f" {download_url}"
 
         with ui.open_spinner(spinner_msg) as spinner:
             destination = root / ver_str

--- a/src/pdm/cli/commands/python.py
+++ b/src/pdm/cli/commands/python.py
@@ -148,7 +148,12 @@ class InstallCommand(BaseCommand):
 
         ver, python_file = get_download_link(version, implementation=implementation, arch=arch, build_dir=False)
         ver_str = str(ver)
-        with ui.open_spinner(f"Downloading [success]{ver_str}[/]") as spinner:
+        spinner_msg = f"Downloading [success]{ver_str}[/]"
+        if ui.verbosity >= Verbosity.DETAIL:
+            download_url = python_file[0] if isinstance(python_file, (tuple, list)) else python_file
+            spinner_msg += f" [link]{download_url}[/link]"
+
+        with ui.open_spinner(spinner_msg) as spinner:
             destination = root / ver_str
             logger.debug("Installing %s to %s", ver_str, destination)
             env = BareEnvironment(project)


### PR DESCRIPTION
Fixes https://github.com/pdm-project/pdm/issues/3552

## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

- `pdm python install -v` command now shows the download URL 

```
STATUS: Downloading cpython@3.13.5 https://github.com/astral-sh/python-build-standalone/releases/download/20250723/cpython-3.13.5%2B20250723-x86_64-pc-windows-msvc-install_only.tar.gz
```
