### PR TITLE
dep: Bump truststore to version 0.10.4

### DIFF
--- a/news/3602.dep.md
+++ b/news/3602.dep.md
@@ -1,0 +1,1 @@
+Bump truststore to version 0.10.4.

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "all", "cookiecutter", "copier", "doc", "keyring", "msgpack", "pytest", "template", "test", "tox", "workflow"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:9f4fbfdede048fa64cabcc13d9f4bc55fa8140119f7510453a3209e039f01424"
+content_hash = "sha256:b557096e04d5aa422a30c5f3c596fd5f62ef3b4c9c02ad2bf92b8d517e1e5802"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -2178,14 +2178,14 @@ files = [
 
 [[package]]
 name = "truststore"
-version = "0.10.1"
+version = "0.10.4"
 requires_python = ">=3.10"
 summary = "Verify certificates using native system trust stores"
 groups = ["default"]
 marker = "python_version >= \"3.10\""
 files = [
-    {file = "truststore-0.10.1-py3-none-any.whl", hash = "sha256:b64e6025a409a43ebdd2807b0c41c8bff49ea7ae6550b5087ac6df6619352d4c"},
-    {file = "truststore-0.10.1.tar.gz", hash = "sha256:eda021616b59021812e800fa0a071e51b266721bef3ce092db8a699e21c63539"},
+    {file = "truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"},
+    {file = "truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "python-dotenv>=0.15",
     "resolvelib>=1.1",
     "installer<0.8,>=0.7",
-    "truststore>=0.9; python_version >= \"3.10\"",
+    "truststore>=0.10.4; python_version >= \"3.10\"",
     "tomli>=1.1.0; python_version < \"3.11\"",
     "importlib-metadata>=3.6; python_version < \"3.10\"",
     "hishel>=0.0.32",


### PR DESCRIPTION
Fix #2940 