### PR TITLE
fix: prevent hash clearing when appending to lockfile with env_spec

### DIFF
--- a/news/3610.bugfix.md
+++ b/news/3610.bugfix.md
@@ -1,0 +1,1 @@
+Prevent hash clearing when appending to lockfile with env_spec.

--- a/src/pdm/cli/actions.py
+++ b/src/pdm/cli/actions.py
@@ -63,7 +63,7 @@ def do_lock(
         raise PdmUsageError("Not allowed to change lock strategy when --append is used.")
     locked_repo = project.get_locked_repository()
     candidates = [entry.candidate for entry in locked_repo.packages.values()]
-    if refresh or env_spec is not None:
+    if refresh or (env_spec is not None and not append):
         # Refetch hashes if --platform/--python/--implementation/--refresh is used
         for c in candidates:
             c.hashes.clear()


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

Fix #3610
