### PR TITLE
fix: `publish --skip-existing` for Nexus Repository OSS >= 3.70

### DIFF
--- a/news/3617.bugfix.md
+++ b/news/3617.bugfix.md
@@ -1,0 +1,1 @@
+Fix `publish --skip-existing` for Nexus Repository OSS >= 3.70

--- a/src/pdm/cli/commands/publish/__init__.py
+++ b/src/pdm/cli/commands/publish/__init__.py
@@ -106,7 +106,7 @@ class Command(BaseCommand):
             # PyPI / TestPyPI / GCP Artifact Registry
             or (status == 400 and any("already exist" in x for x in [reason, text]))
             # Nexus Repository OSS (https://www.sonatype.com/nexus-repository-oss)
-            or (status == 400 and any("updating asset" in x for x in [reason, text]))
+            or (status == 400 and any(any(token in x for token in ["updating asset", "cannot be updated"]) for x in [reason, text]))
             # Artifactory (https://jfrog.com/artifactory/)
             or (status == 403 and "overwrite artifact" in text)
             # Gitlab Enterprise Edition (https://about.gitlab.com)

--- a/src/pdm/cli/commands/publish/__init__.py
+++ b/src/pdm/cli/commands/publish/__init__.py
@@ -108,7 +108,7 @@ class Command(BaseCommand):
             # Nexus Repository OSS (https://www.sonatype.com/nexus-repository-oss)
             or (
                 status == 400
-                and any(any(token in x for token in ["updating asset", "cannot be updated"]) for x in [reason, text])
+                and any(token in x for x in [reason, text] for token in ["updating asset", "cannot be updated"])
             )
             # Artifactory (https://jfrog.com/artifactory/)
             or (status == 403 and "overwrite artifact" in text)


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
As described here for twine (https://github.com/pypa/twine/pull/1221), Sonatype changed its error message if packages already exists with version 3.70.x. This PR modifies the recognition for the `--skip-existing` option to support also those versions.
