### PR TITLE
fix: correct test_use_python_write_file_multiple_versions logic

### DIFF
--- a/news/3660.bugfix.md
+++ b/news/3660.bugfix.md
@@ -1,0 +1,1 @@
+Fix test_use_python_write_file_multiple_versions to match PDM's actual behavior.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -91,11 +91,20 @@ def test_init_project_respect_version_file(pdm, project, python_version, via_env
 def test_use_python_write_file_multiple_versions(pdm, project, python_version, monkeypatch):
     no_versions = [p for p in DEFAULT_PYTHON_VERSIONS if p not in PYTHON_VERSIONS]
     project.project_config["python.use_venv"] = True
-    project.root.joinpath(".python-version").write_text("\n".join(no_versions))
+
+    if no_versions and PYTHON_VERSIONS:
+        version_content = f"{no_versions[0]}\n{PYTHON_VERSIONS[0]}"
+    elif no_versions:
+        version_content = "\n".join(no_versions)
+    else:
+        version_content = "\n".join(PYTHON_VERSIONS[:2])
+
+    project.root.joinpath(".python-version").write_text(version_content)
     project._saved_python = None
     project._environment = None
     pdm(["install"], obj=project, strict=True)
-    assert f"{project.python.major}.{project.python.minor}" not in no_versions
+
+    assert f"{project.python.major}.{project.python.minor}" in PYTHON_VERSIONS
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Pull Request Checklist
- [X] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
Fix `test_use_python_write_file_multiple_versions` test by correcting its logic to match PDM's actual behavior regarding .python-version file handling.

## Related ticket
- Closes #3660 