### PR TITLE
fix: update minimal .gitignore to ignore all *.py[codz] files

### DIFF
--- a/src/pdm/cli/templates/minimal/.gitignore
+++ b/src/pdm/cli/templates/minimal/.gitignore
@@ -1,4 +1,4 @@
-.py[cod]
+*.py[codz]
 __pycache__/
 .mypy_cache/
 .pytest_cache/


### PR DESCRIPTION
## Pull Request Checklist
- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.
Previously, `.py[cod]` was incorrect -- it wouldn't ignore all compiled classes -- for that, we need to do `*.py[cod]`. I noticed this bug locally when building `pdm init` with minimal.

I updated that specific ignore line to match [`/default/.gitignore`](https://github.com/pdm-project/pdm/blob/main/src/pdm/cli/templates/default/.gitignore#L3) which resolves any ignore issues.

`news/` and test cases seem unnecessary for this, but I can add if requested!