### PR TITLE
refactor: move some imports of commands/venv into type checking

### DIFF
--- a/src/pdm/cli/commands/venv/__init__.py
+++ b/src/pdm/cli/commands/venv/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import argparse
+from typing import TYPE_CHECKING
 
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.commands.venv.activate import ActivateCommand
@@ -10,7 +10,11 @@ from pdm.cli.commands.venv.purge import PurgeCommand
 from pdm.cli.commands.venv.remove import RemoveCommand
 from pdm.cli.commands.venv.utils import get_venv_with_name
 from pdm.cli.options import project_option
-from pdm.project import Project
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
+
+    from pdm.project import Project
 
 
 class Command(BaseCommand):
@@ -19,7 +23,7 @@ class Command(BaseCommand):
     name = "venv"
     arguments = (project_option,)
 
-    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+    def add_arguments(self, parser: ArgumentParser) -> None:
         group = parser.add_mutually_exclusive_group()
         group.add_argument("--path", help="Show the path to the given virtualenv")
         group.add_argument("--python", help="Show the python interpreter path for the given virtualenv")
@@ -31,7 +35,7 @@ class Command(BaseCommand):
         PurgeCommand.register_to(subparser, "purge")
         self.parser = parser
 
-    def handle(self, project: Project, options: argparse.Namespace) -> None:
+    def handle(self, project: Project, options: Namespace) -> None:
         if options.path:
             venv = get_venv_with_name(project, options.path)
             project.core.ui.echo(str(venv.root))

--- a/src/pdm/cli/commands/venv/activate.py
+++ b/src/pdm/cli/commands/venv/activate.py
@@ -10,11 +10,11 @@ import shellingham
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.commands.venv.utils import get_venv_with_name
 from pdm.cli.options import verbose_option
+from pdm.models.venv import VirtualEnv
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
 
-    from pdm.models.venv import VirtualEnv
     from pdm.project import Project
 
 

--- a/src/pdm/cli/commands/venv/activate.py
+++ b/src/pdm/cli/commands/venv/activate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import platform
 import shlex
 from pathlib import Path

--- a/src/pdm/cli/commands/venv/activate.py
+++ b/src/pdm/cli/commands/venv/activate.py
@@ -1,15 +1,19 @@
-import argparse
 import platform
 import shlex
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import shellingham
 
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.commands.venv.utils import get_venv_with_name
 from pdm.cli.options import verbose_option
-from pdm.models.venv import VirtualEnv
-from pdm.project import Project
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
+
+    from pdm.models.venv import VirtualEnv
+    from pdm.project import Project
 
 
 class ActivateCommand(BaseCommand):
@@ -17,10 +21,10 @@ class ActivateCommand(BaseCommand):
 
     arguments = (verbose_option,)
 
-    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+    def add_arguments(self, parser: ArgumentParser) -> None:
         parser.add_argument("env", nargs="?", help="The key of the virtualenv")
 
-    def handle(self, project: Project, options: argparse.Namespace) -> None:
+    def handle(self, project: Project, options: Namespace) -> None:
         if options.env:
             venv = get_venv_with_name(project, options.env)
         else:

--- a/src/pdm/cli/commands/venv/backends.py
+++ b/src/pdm/cli/commands/venv/backends.py
@@ -7,13 +7,17 @@ import subprocess
 import sys
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import TYPE_CHECKING, Any
 
 from pdm import termui
 from pdm.cli.commands.venv.utils import get_venv_prefix
 from pdm.exceptions import PdmUsageError, ProjectError
-from pdm.models.python import PythonInfo
-from pdm.project import Project
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+    from pdm.models.python import PythonInfo
+    from pdm.project import Project
 
 
 class VirtualenvCreateError(ProjectError):
@@ -118,10 +122,7 @@ class Backend(abc.ABC):
         with_pip: bool = False,
         venv_name: str | None = None,
     ) -> Path:
-        if in_project:
-            location = self.project.root / ".venv"
-        else:
-            location = self.get_location(name, venv_name)
+        location = (self.project.root / ".venv") if in_project else self.get_location(name, venv_name)
         args = (*self.pip_args(with_pip), *args)
         if prompt is not None:
             prompt = prompt.format(

--- a/src/pdm/cli/commands/venv/create.py
+++ b/src/pdm/cli/commands/venv/create.py
@@ -1,9 +1,14 @@
 import argparse
+from typing import TYPE_CHECKING
 
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.commands.venv.backends import BACKENDS
 from pdm.cli.options import verbose_option
-from pdm.project import Project
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
+
+    from pdm.project import Project
 
 
 class CreateCommand(BaseCommand):
@@ -15,7 +20,7 @@ class CreateCommand(BaseCommand):
     description = "Create a virtualenv"
     arguments = (verbose_option,)
 
-    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+    def add_arguments(self, parser: ArgumentParser) -> None:
         parser.add_argument(
             "-w",
             "--with",
@@ -42,7 +47,7 @@ class CreateCommand(BaseCommand):
             help="Additional arguments that will be passed to the backend",
         )
 
-    def handle(self, project: Project, options: argparse.Namespace) -> None:
+    def handle(self, project: Project, options: Namespace) -> None:
         in_project = project.config["venv.in_project"] and not options.name
         backend: str = options.backend or project.config["venv.backend"]
         venv_backend = BACKENDS[backend](project, options.python)

--- a/src/pdm/cli/commands/venv/create.py
+++ b/src/pdm/cli/commands/venv/create.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 from typing import TYPE_CHECKING
 

--- a/src/pdm/cli/commands/venv/list.py
+++ b/src/pdm/cli/commands/venv/list.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 

--- a/src/pdm/cli/commands/venv/list.py
+++ b/src/pdm/cli/commands/venv/list.py
@@ -20,7 +20,7 @@ class ListCommand(BaseCommand):
 
     def handle(self, project: Project, options: Namespace) -> None:
         project.core.ui.echo("Virtualenvs created with this project:\n")
-        saved_python = project._saved_python
+        saved_python_root = Path(saved_python).parent.parent if (saved_python := project._saved_python) else None
         for ident, venv in iter_venvs(project):
-            mark = "*" if saved_python and Path(saved_python).parent.parent == venv.root else "-"
+            mark = "*" if saved_python_root and saved_python_root == venv.root else "-"
             project.core.ui.echo(f"{mark}  [success]{ident}[/]: {venv.root}")

--- a/src/pdm/cli/commands/venv/list.py
+++ b/src/pdm/cli/commands/venv/list.py
@@ -1,10 +1,14 @@
-import argparse
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.commands.venv.utils import iter_venvs
 from pdm.cli.options import verbose_option
-from pdm.project import Project
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+
+    from pdm.project import Project
 
 
 class ListCommand(BaseCommand):
@@ -12,12 +16,9 @@ class ListCommand(BaseCommand):
 
     arguments = (verbose_option,)
 
-    def handle(self, project: Project, options: argparse.Namespace) -> None:
+    def handle(self, project: Project, options: Namespace) -> None:
         project.core.ui.echo("Virtualenvs created with this project:\n")
+        saved_python = project._saved_python
         for ident, venv in iter_venvs(project):
-            saved_python = project._saved_python
-            if saved_python and Path(saved_python).parent.parent == venv.root:
-                mark = "*"
-            else:
-                mark = "-"
+            mark = "*" if saved_python and Path(saved_python).parent.parent == venv.root else "-"
             project.core.ui.echo(f"{mark}  [success]{ident}[/]: {venv.root}")

--- a/src/pdm/cli/commands/venv/purge.py
+++ b/src/pdm/cli/commands/venv/purge.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -43,9 +45,8 @@ class PurgeCommand(BaseCommand):
             for i, venv in enumerate(all_central_venvs):
                 project.core.ui.echo(f"{i}. [success]{venv[0]}[/]")
 
-        if not options.interactive:
-            if options.force or termui.confirm("continue?", default=True):
-                return self.del_all_venvs(project)
+        if not options.interactive and (options.force or termui.confirm("continue?", default=True)):
+            return self.del_all_venvs(project)
 
         selection = termui.ask(
             "Please select",

--- a/src/pdm/cli/commands/venv/purge.py
+++ b/src/pdm/cli/commands/venv/purge.py
@@ -1,12 +1,16 @@
-import argparse
 import shutil
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pdm import termui
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.commands.venv.utils import iter_central_venvs
 from pdm.cli.options import verbose_option
-from pdm.project import Project
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
+
+    from pdm.project import Project
 
 
 class PurgeCommand(BaseCommand):
@@ -14,7 +18,7 @@ class PurgeCommand(BaseCommand):
 
     arguments = (verbose_option,)
 
-    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+    def add_arguments(self, parser: ArgumentParser) -> None:
         parser.add_argument(
             "-f",
             "--force",
@@ -28,7 +32,7 @@ class PurgeCommand(BaseCommand):
             help="Interactively purge selected Virtualenvs",
         )
 
-    def handle(self, project: Project, options: argparse.Namespace) -> None:
+    def handle(self, project: Project, options: Namespace) -> None:
         all_central_venvs = list(iter_central_venvs(project))
         if not all_central_venvs:
             project.core.ui.echo("No virtualenvs to purge, quitting.", style="success")

--- a/src/pdm/cli/commands/venv/remove.py
+++ b/src/pdm/cli/commands/venv/remove.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING

--- a/src/pdm/cli/commands/venv/remove.py
+++ b/src/pdm/cli/commands/venv/remove.py
@@ -1,12 +1,16 @@
-import argparse
 import shutil
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pdm import termui
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.commands.venv.utils import get_venv_with_name
 from pdm.cli.options import verbose_option
-from pdm.project import Project
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
+
+    from pdm.project import Project
 
 
 class RemoveCommand(BaseCommand):
@@ -14,7 +18,7 @@ class RemoveCommand(BaseCommand):
 
     arguments = (verbose_option,)
 
-    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+    def add_arguments(self, parser: ArgumentParser) -> None:
         parser.add_argument(
             "-y",
             "--yes",
@@ -23,7 +27,7 @@ class RemoveCommand(BaseCommand):
         )
         parser.add_argument("env", help="The key of the virtualenv")
 
-    def handle(self, project: Project, options: argparse.Namespace) -> None:
+    def handle(self, project: Project, options: Namespace) -> None:
         project.core.ui.echo("Virtualenvs created with this project:")
         venv = get_venv_with_name(project, options.env)
         if options.yes or termui.confirm(f"[warning]Will remove: [success]{venv.root}[/], continue?", default=True):

--- a/src/pdm/cli/commands/venv/utils.py
+++ b/src/pdm/cli/commands/venv/utils.py
@@ -2,14 +2,24 @@ from __future__ import annotations
 
 import base64
 import hashlib
-import typing as t
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from findpython import BaseProvider, PythonVersion
 
 from pdm.exceptions import PdmUsageError
-from pdm.models.venv import VirtualEnv
-from pdm.project import Project
+
+if TYPE_CHECKING:
+    import sys
+    from collections.abc import Iterable
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
+
+    from pdm.models.venv import VirtualEnv
+    from pdm.project import Project
 
 
 def hash_path(path: str) -> str:
@@ -33,7 +43,7 @@ def get_venv_prefix(project: Project) -> str:
     return f"{path.name}-{name_hash}-"
 
 
-def iter_venvs(project: Project) -> t.Iterable[tuple[str, VirtualEnv]]:
+def iter_venvs(project: Project) -> Iterable[tuple[str, VirtualEnv]]:
     """Return an iterable of venv paths associated with the project"""
     in_project_venv = get_in_project_venv(project.root)
     if in_project_venv is not None:
@@ -47,7 +57,7 @@ def iter_venvs(project: Project) -> t.Iterable[tuple[str, VirtualEnv]]:
             yield ident, venv
 
 
-def iter_central_venvs(project: Project) -> t.Iterable[tuple[str, Path]]:
+def iter_central_venvs(project: Project) -> Iterable[tuple[str, Path]]:
     """Return an iterable of all managed venvs and their paths."""
     venv_parent = Path(project.config["venv.location"])
     for venv in venv_parent.glob("*"):
@@ -62,10 +72,10 @@ class VenvProvider(BaseProvider):
         self.project = project
 
     @classmethod
-    def create(cls) -> t.Self | None:
+    def create(cls) -> Self | None:
         return None
 
-    def find_pythons(self) -> t.Iterable[PythonVersion]:
+    def find_pythons(self) -> Iterable[PythonVersion]:
         for _, venv in iter_venvs(self.project):
             yield PythonVersion(venv.interpreter, _interpreter=venv.interpreter, keep_symlink=True)
 

--- a/src/pdm/cli/commands/venv/utils.py
+++ b/src/pdm/cli/commands/venv/utils.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from findpython import BaseProvider, PythonVersion
 
 from pdm.exceptions import PdmUsageError
+from pdm.models.venv import VirtualEnv
 
 if TYPE_CHECKING:
     import sys
@@ -18,7 +19,6 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import Self
 
-    from pdm.models.venv import VirtualEnv
     from pdm.project import Project
 
 


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
1. Move some imports of `cli/commands/venv/*.py` into `TYPE_CHECKING` in order to improve startup speed
2. Fix some issues that complaint by `ruff check --extend-select=SIM src/pdm/cli/commands/venv`