### PR TITLE
fix: respect project path when using cookiecutter template in pdm init command

### DIFF
--- a/news/3721.bugfix.md
+++ b/news/3721.bugfix.md
@@ -1,0 +1,1 @@
+Respect the project path when using cookiecutter template in `pdm init` command.

--- a/src/pdm/cli/commands/init.py
+++ b/src/pdm/cli/commands/init.py
@@ -104,13 +104,10 @@ class Command(BaseCommand):
 
         if not options.template:
             raise PdmUsageError("template argument is required when --cookiecutter is passed")
-        if options.project_path:
-            project.core.ui.warn(
-                "Cookiecutter generator does not respect --project option. "
-                "It will always create a project dir under the current directory",
-            )
         try:
-            cookiecutter.main([options.template, *options.generator_args], standalone_mode=False)
+            cookiecutter.main(
+                [options.template, "--output-dir", str(project.root), *options.generator_args], standalone_mode=False
+            )
         except SystemExit as e:
             raise RuntimeError("Cookiecutter exited with an error") from e
 


### PR DESCRIPTION
Fix #3721

Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
