### PR TITLE
refactor: disable argparse color instead of falling back to default formatter for Python 3.14

### DIFF
--- a/src/pdm/cli/utils.py
+++ b/src/pdm/cli/utils.py
@@ -125,9 +125,8 @@ class ArgumentParser(argparse.ArgumentParser):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         if sys.version_info >= (3, 14):
-            kwargs["formatter_class"] = argparse.RawDescriptionHelpFormatter
-        else:
-            kwargs["formatter_class"] = PdmFormatter
+            kwargs["color"] = False
+        kwargs["formatter_class"] = PdmFormatter
         kwargs["add_help"] = False
         super().__init__(*args, **kwargs)
         self.add_argument(


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

In Python 3.14, argparse introduced native color support, which caused formatting regressions in PDM's help output. A previous fix in #3683 addressed this by falling back to the default argparse formatter specifically for Python 3.14.

However, since PDM's custom formatter provides more fine-grained layout adjustments and ensures a consistent UI/UX across different Python versions, keeping it is preferable. Given that Python 3.14's argparse allows disabling colors via the color parameter, this PR switches to disabling the native color output while retaining the PDM custom formatter. This approach restores PDM's intended formatting while avoiding conflicts with the new upstream feature.