### PR TITLE
fix: clear build directory cache in pytest fixture to avoid stale references

### DIFF
--- a/src/pdm/pytest.py
+++ b/src/pdm/pytest.py
@@ -653,6 +653,10 @@ def pdm(core: Core, monkeypatch: pytest.MonkeyPatch) -> PDMCallable:
                 os.environ.update(old_env)
                 if cleanup:
                     core.exit_stack.close()
+                    # Clear the build directory cache to avoid stale references
+                    from pdm.models.candidates import PreparedCandidate
+
+                    PreparedCandidate._build_dir_cache.clear()
 
         result = RunResult(exit_code, stdout.getvalue(), stderr.getvalue(), exception)
 

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -352,17 +352,27 @@ def comparable_version(version: str) -> Version:
         if hasattr(parsed, "__replace__"):  # packaging >= 26
             parsed = parsed.__replace__(local=None)
         else:
+            # packaging < 26 does not have __replace__ method
+            # In this version, we need to manually update _version and recompute _key
+            # Note: In packaging >= 26, _key is a read-only property, but this else branch
+            # only executes on packaging < 26 where _key is a regular attribute that can be
+            # assigned. We use object.__setattr__() instead of direct assignment to satisfy
+            # type checkers that analyze based on the current packaging version.
             from packaging.version import _cmpkey
 
             parsed._version = parsed._version._replace(local=None)
 
-            parsed._key = _cmpkey(
-                parsed._version.epoch,
-                parsed._version.release,
-                parsed._version.pre,
-                parsed._version.post,
-                parsed._version.dev,
-                parsed._version.local,
+            object.__setattr__(
+                parsed,
+                "_key",
+                _cmpkey(
+                    parsed._version.epoch,
+                    parsed._version.release,
+                    parsed._version.pre,
+                    parsed._version.post,
+                    parsed._version.dev,
+                    parsed._version.local,
+                ),
             )
 
     return parsed


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Problem

When executing `pdm run test tests/cli/test_others.py::test_show_package_on_pypi`, the test fails with:

```
FileNotFoundError: [Errno 2] No such file or directory: '/var/folders/.../pdm-build-xxx/requests-2.32.5-py3-none-any.whl'
```

### Root Cause

The issue occurs when multiple PDM commands are executed sequentially in the same test using the same `Core` instance:

1. **Command 1** (`pdm show ipython`):
   - `create_temp_dir()` creates temp directory → stored in `_build_dir_cache`
   - `exit_stack.close()` deletes the temp directory
   - **Cache still holds reference to deleted directory** ❌

2. **Command 2** (`pdm show requests`):
   - Same process, new temp directory created
   - Cache now has reference to two deleted directories

3. **Command 3** (`pdm show --name requests`):
   - Tries to reuse cached directory from Command 1
   - **FileNotFoundError** - directory no longer exists ❌

The root cause is `PreparedCandidate._build_dir_cache` (a `ClassVar[dict]`) persisting across multiple command executions within the same test fixture.

## Solution

Clear the cache in the `pdm` pytest fixture's cleanup phase after `exit_stack.close()`:

```python
if cleanup:
    core.exit_stack.close()
    # Clear the build directory cache to avoid stale references
    from pdm.models.candidates import PreparedCandidate
    PreparedCandidate._build_dir_cache.clear()