### PR TITLE
fix: handle Version._key assignment for packaging compatibility

### DIFF
--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -352,17 +352,27 @@ def comparable_version(version: str) -> Version:
         if hasattr(parsed, "__replace__"):  # packaging >= 26
             parsed = parsed.__replace__(local=None)
         else:
+            # packaging < 26 does not have __replace__ method
+            # In this version, we need to manually update _version and recompute _key
+            # Note: In packaging >= 26, _key is a read-only property, but this else branch
+            # only executes on packaging < 26 where _key is a regular attribute that can be
+            # assigned. We use object.__setattr__() instead of direct assignment to satisfy
+            # type checkers that analyze based on the current packaging version.
             from packaging.version import _cmpkey
 
             parsed._version = parsed._version._replace(local=None)
 
-            parsed._key = _cmpkey(
-                parsed._version.epoch,
-                parsed._version.release,
-                parsed._version.pre,
-                parsed._version.post,
-                parsed._version.dev,
-                parsed._version.local,
+            object.__setattr__(
+                parsed,
+                "_key",
+                _cmpkey(
+                    parsed._version.epoch,
+                    parsed._version.release,
+                    parsed._version.pre,
+                    parsed._version.post,
+                    parsed._version.dev,
+                    parsed._version.local,
+                ),
             )
 
     return parsed


### PR DESCRIPTION
## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Problem

The `comparable_version()` function in `src/pdm/utils.py` was causing a mypy error:

```
src/pdm/utils.py:359: error: Property "_key" defined in "Version" is read-only [misc]
```

### Root Cause

In `packaging >= 26`, the `_key` property of the `Version` class is read-only (implemented as a `@property` without a setter). However, the code to handle `packaging < 26` attempted direct assignment to this property, which mypy rejected based on the current packaging version's type stubs.

## Solution

Rather than removing the compatibility code for older versions, we use `object.__setattr__()` to bypass the read-only restriction:
- In `packaging >= 26`: The `if hasattr(parsed, "__replace__")` branch executes, using the modern `__replace__()` method
- In `packaging < 26`: Only the `else` branch executes, where `_key` is a writable attribute

Using `object.__setattr__()` instead of direct assignment satisfies both:
- **mypy**: Not attempting direct property assignment
- **ruff**: Avoiding the B010 warning about using `setattr()` with constant attribute names