### PR TITLE
fix: PYTHONPATH values set in host can break `pdm run`

### DIFF
--- a/news/3743.bugfix.md
+++ b/news/3743.bugfix.md
@@ -1,0 +1,1 @@
+Clear build directory cache in pytest fixture to avoid stale references.

--- a/news/3744.bugfix.md
+++ b/news/3744.bugfix.md
@@ -1,0 +1,1 @@
+Handle `Version._key` assignment for packaging compatibility.

--- a/news/3746.bugfix.md
+++ b/news/3746.bugfix.md
@@ -1,0 +1,1 @@
+Don't inherit `PYTHONPATH` environment variable from parent process when running `pdm run`.

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -243,6 +243,7 @@ class TaskRunner:
             check_project_file(project)
             project_env = project.environment
         this_path = project_env.get_paths()["scripts"]
+        os.environ.pop("PYTHONPATH", None)  # Don't inherit PYTHONPATH from the parent process
         os.environ.update(project_env.process_env)
         if env_file is not None:
             if isinstance(env_file, str):

--- a/src/pdm/environments/local.py
+++ b/src/pdm/environments/local.py
@@ -85,10 +85,10 @@ class PythonLocalEnvironment(BaseEnvironment):
         from pdm.cli.utils import get_pep582_path
 
         env = super().process_env
-        pythonpath = os.getenv("PYTHONPATH", "").split(os.pathsep)
-        pythonpath = [get_pep582_path(self.project)] + [p for p in pythonpath if "/pep582" not in p.replace("\\", "/")]
-        env["PYTHONPATH"] = os.pathsep.join(pythonpath)
-        env["PEP582_PACKAGES"] = str(self.packages_path)
+        env.update(
+            PYTHONPATH=get_pep582_path(self.project),
+            PEP582_PACKAGES=str(self.packages_path),
+        )
         return env
 
     @cached_property

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -546,26 +546,23 @@ def test_run_with_another_project_root(project, pdm, capfd, explicit_python):
             assert out.strip() == "1"
 
 
-def test_import_another_sitecustomize(project, pdm, capfd):
-    project.pyproject.metadata["requires-python"] = ">=2.7"
-    project.pyproject.write()
-    # a script for checking another sitecustomize is imported
-    project.root.joinpath("foo.py").write_text("import os;print(os.getenv('FOO'))")
-    # ensure there have at least one sitecustomize can be imported
-    # there may have more than one sitecustomize.py in sys.path
-    project.root.joinpath("sitecustomize.py").write_text("import os;os.environ['FOO'] = 'foo'")
-    env = os.environ.copy()
-    paths = env.get("PYTHONPATH")
-    this_path = str(project.root)
-    new_paths = [this_path] if not paths else [this_path, paths]
-    env["PYTHONPATH"] = os.pathsep.join(new_paths)
-    project._environment = None
+def test_run_does_not_inherit_parent_pythonpath(project, pdm, capfd):
+    inherited_path = project.root / "inherited-pythonpath"
+    inherited_path.mkdir()
+    inherited_path.joinpath("sitecustomize.py").write_text("import os;os.environ['PDM_RUN_PYTHONPATH_MARKER'] = '1'")
+    check_cmd = "import os;print(os.getenv('PDM_RUN_PYTHONPATH_MARKER'));print(os.getenv('PYTHONPATH'))"
     capfd.readouterr()
-    with cd(project.root):
-        result = pdm(["run", "python", "foo.py"], env=env)
+    result = pdm(
+        ["run", "python", "-c", check_cmd],
+        obj=project,
+        env={"PYTHONPATH": str(inherited_path)},
+    )
     assert result.exit_code == 0, result.stderr
     out, _ = capfd.readouterr()
-    assert out.strip() == "foo"
+    marker, pythonpath = out.strip().splitlines()
+    assert marker == "None"
+    assert pythonpath == get_pep582_path(project)
+    assert str(inherited_path) not in pythonpath
 
 
 def test_run_with_patched_sysconfig(project, pdm, capfd):


### PR DESCRIPTION
Fixes #3742

Signed-off-by: Frost Ming <me@frostming.com>

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
