### PR TITLE
Skip resolution for frozen no-sync add

### DIFF
--- a/src/pdm/cli/commands/add.py
+++ b/src/pdm/cli/commands/add.py
@@ -154,6 +154,11 @@ class Command(BaseCommand):
             for req in group_deps:
                 req.specifier = get_specifier("")
 
+        if not sync and not project.enable_write_lockfile:
+            if not dry_run:
+                project.add_dependencies(requirements, group, selection.dev or False)
+            return
+
         reqs = [r for g, deps in all_dependencies.items() for r in deps if lock_groups is None or g in lock_groups]
         with hooks.skipping("post_lock"):
             resolved = do_lock(

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -142,6 +142,15 @@ def test_add_no_install(project, working_set, pdm):
         assert package not in working_set
 
 
+def test_add_no_sync_frozen_lockfile_skips_resolution(project, pdm, mocker):
+    do_lock = mocker.patch("pdm.cli.actions.do_lock")
+    pdm(["add", "--frozen-lockfile", "--no-sync", "requests"], obj=project, strict=True)
+
+    do_lock.assert_not_called()
+    assert project.pyproject.metadata["dependencies"][0] == "requests"
+    assert not project.lockfile.exists()
+
+
 @pytest.mark.usefixtures("repository")
 def test_add_package_save_exact(project, pdm):
     pdm(["add", "--save-exact", "--no-sync", "requests"], obj=project, strict=True)


### PR DESCRIPTION
Fixes #3372.\n\nWhen   0:00:00 🔒 Lock successful.  
Changes are written to pyproject.toml.
Synchronizing working set with resolved packages: 81 to add, 0 to update, 0 to remove

  ✔ Install setuptools 80.9.0 successful
  ✔ Install anysqlite 0.0.5 successful
  ✔ Install distlib 0.4.0 successful
  ✔ Install arpeggio 2.0.3 successful
  ✔ Install blinker 1.9.0 successful
  ✔ Install cachetools 6.2.3 successful
  ✔ Install deepmerge 2.0 successful
  ✔ Install colorama 0.4.6 successful
  ✔ Install dep-logic 0.5.2 successful
  ✔ Install execnet 2.1.2 successful
  ✔ Install attrs 25.4.0 successful
  ✔ Install click 8.1.8 successful
  ✔ Install findpython 0.7.1 successful
  ✔ Install anyio 4.12.0 successful
  ✔ Install certifi 2025.11.12 successful
  ✔ Install chardet 5.2.0 successful
  ✔ Install filelock 3.19.1 successful
  ✔ Install ghp-import 2.1.0 successful
  ✔ Install h11 0.16.0 successful
  ✔ Install id 1.5.0 successful
  ✔ Install httpx 0.28.1 successful
  ✔ Install httpcore 1.0.9 successful
  ✔ Install idna 3.11 successful
  ✔ Install coverage 7.10.7 successful
  ✔ Install hishel 1.1.8 successful
  ✔ Install markdown-it-py 3.0.0 successful
  ✔ Install markdown 3.9 successful
  ✔ Install mdurl 0.1.2 successful
  ✔ Install griffe 1.14.0 successful
  ✔ Install charset-normalizer 3.4.4 successful
  ✔ Install mergedeep 1.3.4 successful
  ✔ Install mkdocs-get-deps 0.2.0 successful
  ✔ Install mkdocs-autorefs 1.4.3 successful
  ✔ Install iniconfig 2.1.0 successful
  ✔ Install mkdocstrings 0.30.1 successful
  ✔ Install markupsafe 3.0.3 successful
  ✔ Install parver 0.5 successful
  ✔ Install packaging 26.0 successful
  ✔ Install mkdocstrings-python 1.18.2 successful
  ✔ Install jinja2 3.1.6 successful
  ✔ Install installer 0.7.0 successful
  ✔ Install pathspec 0.12.1 successful
  ✔ Install pluggy 1.6.0 successful
  ✔ Install pbs-installer 2025.12.5 successful
  ✔ Install platformdirs 4.4.0 successful
  ✔ Install msgpack 1.1.2 successful
  ✔ Install pyproject-api 1.9.1 successful
  ✔ Install pyproject-hooks 1.2.0 successful
  ✔ Install pytest-cov 7.0.0 successful
  ✔ Install pytest-httpserver 1.1.3 successful
  ✔ Install pymdown-extensions 10.19.1 successful
  ✔ Install pytest-httpx 0.35.0 successful
  ✔ Install pytest-mock 3.15.1 successful
  ✔ Install pytest-rerunfailures 16.0.1 successful
  ✔ Install mkdocs 1.6.1 successful
  ✔ Install pytest-xdist 3.8.0 successful
  ✔ Install python-dotenv 1.2.1 successful
  ✔ Install pycomplete 0.4.0 successful
  ✔ Install pytest 8.4.2 successful
  ✔ Install pyyaml-env-tag 1.1 successful
  ✔ Install resolvelib 1.2.1 successful
  ✔ Install pygments 2.19.2 successful
  ✔ Install socksio 1.0.0 successful
  ✔ Install pyyaml 6.0.3 successful
  ✔ Install shellingham 1.5.4 successful
  ✔ Install six 1.17.0 successful
  ✔ Install requests 2.32.5 successful
  ✔ Install tomlkit 0.13.3 successful
  ✔ Install rich 14.2.0 successful
  ✔ Install towncrier 25.8.0 successful
  ✔ Install tox-pdm 0.7.2 successful
  ✔ Install truststore 0.10.4 successful
  ✔ Install unearth 0.18.1 successful
  ✔ Install typing-extensions 4.15.0 successful
  ✔ Install tox 4.30.3 successful
  ✔ Install urllib3 2.6.2 successful
  ✔ Install watchdog 6.0.0 successful
  ✔ Install python-dateutil 2.9.0.post0 successful
  ✔ Install virtualenv 20.35.4 successful
  ✔ Install werkzeug 3.1.4 successful
  ✔ Install zensical 0.0.28 successful
  ✔ Install pdm 2.26.8.dev1+g68906436 successful

  0:00:11 🎉 All complete! 81/81 is run with both  and , the command now skips the resolver entirely and only updates pyproject.toml. This keeps no-sync behavior intact while avoiding an unnecessary lock attempt under a frozen lockfile.