### PR TITLE
fix: load [tool.pdm.options] from target project when -p/--project is used

### DIFF
--- a/news/3756.bugfix.md
+++ b/news/3756.bugfix.md
@@ -1,0 +1,1 @@
+Fix `[tool.pdm.options]` being loaded from the current working directory instead of the target project when `-p`/`--project` is used.

--- a/src/pdm/core.py
+++ b/src/pdm/core.py
@@ -197,13 +197,18 @@ class Core:
     @staticmethod
     def get_command(args: list[str]) -> tuple[int, str]:
         """Get the command name from the arguments"""
-        options_with_values = ("-c", "--config")
+        options_with_values = ("-c", "--config", "-p", "--project")
         need_value = False
         for i, arg in enumerate(args):
             if arg.startswith("-"):
                 if not arg.startswith(options_with_values):
                     continue
-                if (arg.startswith("-c") and arg != "-c") or arg.startswith("--config="):
+                if (
+                    (arg.startswith("-c") and arg != "-c")
+                    or arg.startswith("--config=")
+                    or (arg.startswith("-p") and arg != "-p")
+                    or arg.startswith("--project=")
+                ):
                     continue
                 need_value = True
             elif need_value:
@@ -213,8 +218,24 @@ class Core:
                 return i, arg
         return -1, ""
 
+    @staticmethod
+    def _get_project_path_from_args(args: list[str]) -> str | None:
+        """Extract the -p/--project path from raw CLI args before full parsing."""
+        for i, arg in enumerate(args):
+            if arg in ("-p", "--project") and i + 1 < len(args):
+                return args[i + 1]
+            if arg.startswith("--project="):
+                return arg[len("--project=") :]
+        return None
+
     def _get_cli_args(self, args: list[str], obj: Project | None) -> list[str]:
-        project = self.create_project(is_global=False) if obj is None else obj
+        if obj is not None:
+            project = obj
+        else:
+            # Respect -p/--project so that [tool.pdm.options] is read from the
+            # target project, not the current working directory.
+            project_path = self._get_project_path_from_args(args)
+            project = self.create_project(root_path=project_path, is_global=False)
         if project.is_global:
             return args
         try:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -373,6 +373,34 @@ def test_invoke_pdm_adding_configured_args(project, pdm, mocker):
     parser.assert_called_with(["--verbose", "add", "--no-isolation", "requests"])
 
 
+def test_invoke_pdm_options_loaded_from_target_project(project, pdm, mocker, tmp_path):
+    """Regression test for https://github.com/pdm-project/pdm/issues/3756.
+
+    When -p/--project is used, [tool.pdm.options] must be read from the
+    target project, not from the current working directory.
+    """
+    import tomlkit
+
+    # Set options on the current (cwd) project — these must NOT be applied.
+    project.pyproject.settings["options"] = {"install": ["--no-editable"]}
+    project.pyproject.write()
+
+    # Build a second project at a tmp location with different options.
+    target_root = tmp_path / "target_project"
+    target_root.mkdir()
+    pyproject = target_root / "pyproject.toml"
+    data = tomlkit.loads("[tool.pdm.options]\ninstall = ['--no-self']\n")
+    pyproject.write_text(tomlkit.dumps(data))
+
+    parser = mocker.patch("argparse.ArgumentParser.parse_args")
+    # Invoke WITHOUT obj= so the real project-path resolution path is exercised.
+    pdm(["-p", str(target_root), "install"])
+    # Should use --no-self from target_project, NOT --no-editable from cwd project.
+    args_used = parser.call_args[0][0]
+    assert "--no-self" in args_used, f"Expected --no-self in {args_used}"
+    assert "--no-editable" not in args_used, f"Unexpected --no-editable in {args_used}"
+
+
 @pytest.fixture()
 def prepare_repository(repository, project):
     repository.add_candidate("foo", "3.0", ">=3.8,<3.13")


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Closes #3756

When using `-p /other/project <command>`, PDM was always loading
`[tool.pdm.options]` from the current working directory instead of the
target project. This meant default options (e.g. `no_sync = true`) in
the target project's `pyproject.toml` were silently ignored.

**Root causes:**

1. `_get_cli_args()` called `create_project(is_global=False)` with no
   path, so it always read options from cwd regardless of `-p`.

2. `get_command()` didn't know that `-p`/`--project` consumes a value
   argument. With `pdm -p /path install`, it would find `/path` as the
   subcommand name and fail to look up `install` in the options table.

**Fix:**

- Added `_get_project_path_from_args()` — a lightweight pre-parse that
  extracts the `-p`/`--project` value from raw args before full
  argument parsing.
- `_get_cli_args()` now passes that path to `create_project()` so
  `[tool.pdm.options]` is loaded from the correct project.
- Added `"-p"` and `"--project"` to `options_with_values` in
  `get_command()` so the subcommand is identified correctly when a
  project path is given.