### PR TITLE
fix: call make_file_executable with a Path

### DIFF
--- a/src/pdm/installers/installers.py
+++ b/src/pdm/installers/installers.py
@@ -16,6 +16,7 @@ from installer.sources import WheelContentElement, WheelSource
 from installer.sources import WheelFile as _WheelFile
 
 from pdm.models.cached_package import CachedPackage
+from pdm.utils import make_file_executable
 
 if TYPE_CHECKING:
     from typing import Any, BinaryIO, Iterable, Literal
@@ -100,7 +101,7 @@ class InstallDestination(SchemeDictionaryDestination):
 
     def write_to_fs(self, scheme: Scheme, path: str, stream: BinaryIO, is_executable: bool) -> RecordEntry:
         from installer.records import Hash
-        from installer.utils import copyfileobj_with_hashing, make_file_executable
+        from installer.utils import copyfileobj_with_hashing
 
         target_path = os.path.join(self.scheme_dict[scheme], path)
         if os.path.exists(target_path):

--- a/src/pdm/models/caches.py
+++ b/src/pdm/models/caches.py
@@ -17,7 +17,7 @@ from pdm.models.cached_package import CachedPackage
 from pdm.models.candidates import Candidate
 from pdm.models.markers import EnvSpec
 from pdm.termui import logger
-from pdm.utils import atomic_open_for_write, create_tracked_tempdir
+from pdm.utils import atomic_open_for_write, create_tracked_tempdir, make_file_executable
 
 if TYPE_CHECKING:
     from httpx import Client
@@ -277,8 +277,6 @@ class PackageCache:
     def cache_wheel(self, wheel: Path) -> CachedPackage:
         """Create a CachedPackage instance from a wheel file"""
         import zipfile
-
-        from installer.utils import make_file_executable
 
         dest = self.root.joinpath(f"{wheel.name}.cache")
         pkg = CachedPackage(dest, original_wheel=wheel)

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -605,3 +605,9 @@ def hide_url(url: str) -> HiddenText:
     netloc = f"*****@{netloc}"
     redacted = parse.urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
     return HiddenText(url, redacted)
+
+
+def make_file_executable(path: str | Path) -> None:
+    """Make the file at the provided path executable."""
+    path_ = Path(path)
+    path_.chmod(path_.stat().st_mode | 0o111)


### PR DESCRIPTION
The make_file_executable function provided by [pypa/installer](https://github.com/pypa/installer/blob/8b72cf945bfa72295fe4e0e8b9ddc13f8df32964/src/installer/utils.py#L270) only works for Path objects. as it uses it's chmod method directly.

Both uses in pdm are passing an str, thus hitting this code produces tracebacks similar to:
```
Traceback (most recent call last):
  File "/usr/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3/dist-packages/pdm/installers/synchronizers.py", line 50, in update_candidate
    self.manager.overwrite(dist, can)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/pdm/installers/manager.py", line 63, in overwrite
    installed = self.install(candidate)
  File "/usr/lib/python3/dist-packages/pdm/installers/manager.py", line 32, in install
    dist_info = install_wheel(
        prepared.build(),
    ...<4 lines>...
        requested=candidate.requested,
    )
  File "/usr/lib/python3/dist-packages/pdm/installers/installers.py", line 191, in install_wheel
    dist_info_dir = install(source, destination=destination, additional_metadata=additional_metadata)
  File "/usr/lib/python3/dist-packages/pdm/installers/installers.py", line 203, in install
    _install(source, destination, additional_metadata=additional_metadata or {})
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/installer/_core.py", line 89, in install
    record = destination.write_script(
        name=name,
    ...<2 lines>...
        section=section,
    )
  File "/usr/lib/python3/dist-packages/installer/destinations.py", line 235, in write_script
    entry = self.write_to_fs(
        Scheme("scripts"), script_name, stream, is_executable=True
    )
  File "/usr/lib/python3/dist-packages/pdm/installers/installers.py", line 130, in write_to_fs
    make_file_executable(target_path)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/installer/utils.py", line 272, in make_file_executable
    path.chmod(0o777 & ~_current_umask() | 0o111)
    ^^^^^^^^^^
AttributeError: 'str' object has no attribute 'chmod'
```

This can be solved either changing the invocations of make_file_executable in pdm or adding or own version. The updated version of this pr adds the make_file_executable function to pdm.utils.