### PR TITLE
Accept build system extensions from template on matching backend

### DIFF
--- a/news/3766.bugfix.md
+++ b/news/3766.bugfix.md
@@ -1,0 +1,1 @@
+Fix `pdm init <template>` overwriting the template's additions to `build-system.requires` when `build-system.build-backend` matches the user's selection.

--- a/src/pdm/cli/templates/__init__.py
+++ b/src/pdm/cli/templates/__init__.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -133,12 +134,18 @@ class ProjectTemplate:
         except FileNotFoundError:
             template_content = tomlkit.document()
 
+        # repeated calls to merge_dictionary could extend elements in the template build system, get a deep copy now
+        template_build_system = deepcopy(template_content.get("build-system", {}))
         merge_dictionary(content, template_content)
         if "version" in content.get("project", {}).get("dynamic", []):
             metadata["project"].pop("version", None)
         merge_dictionary(content, metadata)
         if "build-system" in metadata:
-            content["build-system"] = metadata["build-system"]
+            build_system = metadata["build-system"]
+            if template_build_system.get("build-backend") == build_system["build-backend"]:
+                # only merge the build system when the selected build backend matches that of the template
+                merge_dictionary(build_system, template_build_system)
+            content["build-system"] = build_system
         else:
             content.pop("build-system", None)
         with open(path, "w", encoding="utf-8") as fp:

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -107,7 +107,11 @@ def test_init_command_library(project_no_init, pdm, mocker):
         assert tomllib.load(fp) == data
 
 
-def test_init_template_build_system(tmp_path, project_no_init, pdm, mocker):
+@pytest.mark.parametrize("backend_choice,merged_backend", [
+    (0, {"build-backend": "pdm.backend", "requires": ["pdm-backend", "example"]}),
+    (1, {"build-backend": "setuptools.build_meta", "requires": ["setuptools>=61"]}),
+])
+def test_init_template_build_system(tmp_path, project_no_init, pdm, mocker, backend_choice, merged_backend):
     template_with_backend = tmp_path / "backend-template"
     template_with_backend.mkdir()
     (template_with_backend / "pyproject.toml").write_text(
@@ -130,7 +134,7 @@ def test_init_template_build_system(tmp_path, project_no_init, pdm, mocker):
     )
     result = pdm(
         ["init", str(template_with_backend)],
-        input="\ntest-project\n\ny\nTest Project\n\n\n\n\n\n",
+        input=f"\ntest-project\n\ny\nTest Project\n{backend_choice}\n\n\n\n\n",
         obj=project_no_init,
     )
     assert result.exit_code == 0
@@ -145,7 +149,7 @@ def test_init_template_build_system(tmp_path, project_no_init, pdm, mocker):
             "requires-python": f">={python_version}",
             "dynamic": ["version"],
         },
-        "build-system": {"build-backend": "pdm.backend", "requires": ["pdm-backend", "example"]},
+        "build-system": merged_backend,
         "tool": {"pdm": {"distribution": True}},
     }
 

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -1,4 +1,5 @@
 import sys
+from textwrap import dedent
 from unittest.mock import ANY
 
 import pytest
@@ -99,6 +100,52 @@ def test_init_command_library(project_no_init, pdm, mocker):
             "version": "0.1.0",
         },
         "build-system": {"build-backend": "setuptools.build_meta", "requires": ["setuptools>=61"]},
+        "tool": {"pdm": {"distribution": True}},
+    }
+
+    with open(project_no_init.root.joinpath("pyproject.toml"), "rb") as fp:
+        assert tomllib.load(fp) == data
+
+
+def test_init_template_build_system(tmp_path, project_no_init, pdm, mocker):
+    template_with_backend = tmp_path / "backend-template"
+    template_with_backend.mkdir()
+    (template_with_backend / "pyproject.toml").write_text(
+        dedent(
+            """
+            [project]
+            dynamic = ["version"]
+            name = "backend-template"
+
+            [build-system]
+            requires = ["pdm-backend", "example"]
+            build-backend = "pdm.backend"
+            """
+        )
+    )
+
+    mocker.patch(
+        "pdm.cli.commands.init.get_user_email_from_git",
+        return_value=("Testing", "me@example.org"),
+    )
+    result = pdm(
+        ["init", str(template_with_backend)],
+        input="\ntest-project\n\ny\nTest Project\n\n\n\n\n\n",
+        obj=project_no_init,
+    )
+    assert result.exit_code == 0
+    python_version = f"{project_no_init.python.major}.{project_no_init.python.minor}"
+    data = {
+        "project": {
+            "authors": [{"email": "me@example.org", "name": "Testing"}],
+            "dependencies": [],
+            "description": "Test Project",
+            "license": {"text": "MIT"},
+            "name": "test-project",
+            "requires-python": f">={python_version}",
+            "dynamic": ["version"],
+        },
+        "build-system": {"build-backend": "pdm.backend", "requires": ["pdm-backend", "example"]},
         "tool": {"pdm": {"distribution": True}},
     }
 

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -107,10 +107,13 @@ def test_init_command_library(project_no_init, pdm, mocker):
         assert tomllib.load(fp) == data
 
 
-@pytest.mark.parametrize("backend_choice,merged_backend", [
-    (0, {"build-backend": "pdm.backend", "requires": ["pdm-backend", "example"]}),
-    (1, {"build-backend": "setuptools.build_meta", "requires": ["setuptools>=61"]}),
-])
+@pytest.mark.parametrize(
+    "backend_choice,merged_backend",
+    [
+        (0, {"build-backend": "pdm.backend", "requires": ["pdm-backend", "example"]}),
+        (1, {"build-backend": "setuptools.build_meta", "requires": ["setuptools>=61"]}),
+    ],
+)
 def test_init_template_build_system(tmp_path, project_no_init, pdm, mocker, backend_choice, merged_backend):
     template_with_backend = tmp_path / "backend-template"
     template_with_backend.mkdir()


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

This PR changes the behaviour of `pdm init <template>` when the template has additions to the `[build-system]` table. When the user's choice of build backend matches that of the template, the template's build system is merged with the user choice. When the user chooses a different build backend, the additions in the template are ignored and the chosen backend is used as it would have previously. This is the expected behaviour as described in #3766.

I'm not happy about having to use a deep copy of the template's `[build-system]` table, but `merge_dictionary` would reuse values from that dict and edit them later, while the changes in this PR would need the original value. This *could* be changed in `merge_dictionary` by using copies there, but I figured the single copy in the template handling would be simpler.

The added test was mostly copied from the test above it, edited to reflect the intentions of the change in this PR.