### PR TITLE
Remove dead code

### DIFF
--- a/news/0.refactor.md
+++ b/news/0.refactor.md
@@ -1,0 +1,1 @@
+Remove unused dead code identified by static analysis.

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -54,9 +54,6 @@ def merge_options(*options: TaskOptions | None) -> TaskOptions:
     )
 
 
-exec_opts = merge_options  # Alias for merge_options
-
-
 RE_ARGS_PLACEHOLDER = re.compile(r"\{args(?::(?P<default>[^}]*))?\}")
 RE_PDM_PLACEHOLDER = re.compile(r"\{pdm\}")
 

--- a/src/pdm/exceptions.py
+++ b/src/pdm/exceptions.py
@@ -61,12 +61,6 @@ class PDMDeprecationWarning(PDMWarning, DeprecationWarning):
 warnings.simplefilter("default", category=PDMDeprecationWarning)
 
 
-class ExtrasWarning(PDMWarning):
-    def __init__(self, project_name: str, extras: list[str]) -> None:
-        super().__init__(f"Extras not found for {project_name}: [{','.join(extras)}]")
-        self.extras = tuple(extras)
-
-
 class ProjectError(PdmUsageError):
     pass
 

--- a/src/pdm/installers/manager.py
+++ b/src/pdm/installers/manager.py
@@ -16,9 +16,6 @@ if TYPE_CHECKING:
 class InstallManager:
     """The manager that performs the installation and uninstallation actions."""
 
-    # The packages below are needed to load paths and thus should not be cached.
-    NO_CACHE_PACKAGES = ("editables",)
-
     def __init__(
         self, environment: BaseEnvironment, *, use_install_cache: bool = False, rename_pth: bool = False
     ) -> None:

--- a/src/pdm/models/project_info.py
+++ b/src/pdm/models/project_info.py
@@ -3,13 +3,10 @@ from __future__ import annotations
 import itertools
 from dataclasses import dataclass, field
 from email.message import Message
-from typing import TYPE_CHECKING, Any, Iterator, cast
+from typing import TYPE_CHECKING, Iterator, cast
 
 if TYPE_CHECKING:
     from pdm.compat import Distribution
-
-
-DYNAMIC = "DYNAMIC"
 
 
 @dataclass
@@ -53,29 +50,6 @@ class ProjectInfo:
             keywords=keywords,
             homepage=metadata.get("Home-page", ""),
             project_urls=[": ".join(parts) for parts in project_urls.items()],
-        )
-
-    @classmethod
-    def from_metadata(cls, metadata: dict[str, Any]) -> ProjectInfo:
-        def get_str(key: str) -> str:
-            if key in metadata.get("dynamic", []):
-                return DYNAMIC
-            return metadata.get(key, "")
-
-        authors = metadata.get("authors", [])
-        author = authors[0]["name"] if authors else ""
-        email = authors[0]["email"] if authors else ""
-
-        return cls(
-            name=metadata["name"],
-            version=get_str("version"),
-            summary=get_str("description"),
-            author=author,
-            email=email,
-            license=metadata.get("license", {}).get("text", ""),
-            requires_python=get_str("requires-python"),
-            keywords=",".join(get_str("keywords")),
-            project_urls=[": ".join(parts) for parts in metadata.get("urls", {}).items()],
         )
 
     def generate_rows(self) -> Iterator[tuple[str, str]]:

--- a/src/pdm/models/specifiers.py
+++ b/src/pdm/models/specifiers.py
@@ -72,7 +72,6 @@ class PySpecSet(SpecifierSet):
     """A custom SpecifierSet that supports merging with logic operators (&, |)."""
 
     PY_MAX_MINOR_VERSION = _read_max_versions()
-    MAX_MAJOR_VERSION = max(PY_MAX_MINOR_VERSION)[:1].bump()
 
     __slots__ = ("_logic", "_prereleases", "_specs")
 

--- a/src/pdm/models/versions.py
+++ b/src/pdm/models/versions.py
@@ -26,6 +26,8 @@ class Version:
     focused on supporting PEP 440 version identifiers, not specifiers.
     """
 
+    MIN: Version
+    MAX: Version
     # Pre-release may follow version with {a|b|rc}N
     # https://docs.python.org/3/faq/general.html#how-does-the-python-version-numbering-scheme-work
     pre: tuple[str, int] | None = None

--- a/src/pdm/models/versions.py
+++ b/src/pdm/models/versions.py
@@ -26,8 +26,6 @@ class Version:
     focused on supporting PEP 440 version identifiers, not specifiers.
     """
 
-    MIN: Version
-    MAX: Version
     # Pre-release may follow version with {a|b|rc}N
     # https://docs.python.org/3/faq/general.html#how-does-the-python-version-numbering-scheme-work
     pre: tuple[str, int] | None = None

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -5,7 +5,6 @@ import hashlib
 import itertools
 import operator
 import os
-import re
 import shutil
 import sys
 from copy import deepcopy

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -70,7 +70,6 @@ class Project:
     """
 
     PYPROJECT_FILENAME = "pyproject.toml"
-    DEPENDENCIES_RE = re.compile(r"(?:(.+?)-)?dependencies")
 
     def __init__(
         self,

--- a/src/pdm/termui.py
+++ b/src/pdm/termui.py
@@ -155,11 +155,6 @@ class DummySpinner:
         pass
 
 
-class SilentSpinner(DummySpinner):
-    def _show(self) -> None:
-        pass
-
-
 class TruncatedIO:
     """A wrapper for IO that truncates output after certain length."""
 


### PR DESCRIPTION
Remove unused dead code identified by static analysis:                                         
                                                                                                 
  - `ProjectInfo.from_metadata()`.. not called (removes `DYNAMIC` constant and `Any` import  too)                                                                                           
  - `ExtrasWarning` .. not raised                                                               
  - `SilentSpinner`.. not instantiated                    
  - `exec_opts` .. not referenced                                                         
  - `InstallManager.NO_CACHE_PACKAGES`.. never read
  - `PySpecSet.MAX_MAJOR_VERSION`.. never read                                                   
  - `Version.MIN` / `Version.MAX` .. declared but not used?                           
  - `Project.DEPENDENCIES_RE`.. never read      
  
No tests needed.. This is only removal of unreachable code and nth else.     

Dead code was identified by using [Skylos](https://github.com/duriantaco/skylos) and confirmed via manual verification.  