### PR TITLE
Allow `exclude-newer` to be defined in `pyproject.toml`

### DIFF
--- a/docs/usage/lockfile.md
+++ b/docs/usage/lockfile.md
@@ -199,6 +199,16 @@ pdm lock --exclude-newer 2024-01-01
 pdm lock --exclude-newer 7d
 ```
 
+!!! tip
+    Added in 2.26.9.
+
+`exclude-newer` may also be set in the `pyproject.toml` file under the `[tool.pdm.resolution]` table:
+
+```toml
+[tool.pdm.resolution]
+exclude-newer = "7d"
+```
+
 !!! note
     The package index must support the `upload-time` field as specified in [PEP 700]. If the field is not present for a given distribution, the distribution will be treated as unavailable.
 

--- a/news/3776.feature.md
+++ b/news/3776.feature.md
@@ -1,0 +1,1 @@
+Support `exclude-newer` in `pyproject.toml` in the `[tool.pdm.resolution]` table

--- a/src/pdm/cli/commands/lock.py
+++ b/src/pdm/cli/commands/lock.py
@@ -104,10 +104,12 @@ class Command(BaseCommand):
         selection = GroupSelection.from_options(project, options)
         strategy = options.update_strategy
         if options.exclude_newer:
+            # cli args override pyproject config if present
+            project.core.state.exclude_newer = options.exclude_newer
+        if project.core.state.exclude_newer:
             strategy = "all"
             if strategy != options.update_strategy:
                 project.core.ui.info("--exclude-newer is set, forcing --update-all")
-        project.core.state.exclude_newer = options.exclude_newer
         env_spec: EnvSpec | None = None
         if any([options.python, options.platform, options.implementation]):
             replace_dict = {}

--- a/src/pdm/core.py
+++ b/src/pdm/core.py
@@ -34,7 +34,7 @@ from pdm.installers import InstallManager
 from pdm.models.repositories import BaseRepository, PyPIRepository
 from pdm.project import Project
 from pdm.project.config import Config
-from pdm.utils import is_in_zipapp
+from pdm.utils import convert_to_datetime, is_in_zipapp
 
 if TYPE_CHECKING:
     from typing import Any, Iterable
@@ -135,6 +135,8 @@ class Core:
                 global_config=options.config or os.getenv("PDM_CONFIG_FILE"),
             )
         self.state.build_isolation = project.config["build_isolation"]
+        if exclude_newer := project.pyproject.resolution.get("exclude-newer"):
+            self.state.exclude_newer = convert_to_datetime(exclude_newer)
         return project
 
     def create_project(

--- a/src/pdm/core.py
+++ b/src/pdm/core.py
@@ -135,8 +135,6 @@ class Core:
                 global_config=options.config or os.getenv("PDM_CONFIG_FILE"),
             )
         self.state.build_isolation = project.config["build_isolation"]
-        if exclude_newer := project.pyproject.resolution.get("exclude-newer"):
-            self.state.exclude_newer = convert_to_datetime(exclude_newer)
         return project
 
     def create_project(
@@ -190,6 +188,9 @@ class Core:
 
         if overrides := getattr(options, "override", None):
             self.state.overrides = overrides
+
+        if exclude_newer := project.pyproject.resolution.get("exclude-newer"):
+            self.state.exclude_newer = convert_to_datetime(exclude_newer)
 
         if command is None:
             self.parser.print_help()

--- a/tests/cli/test_lock.py
+++ b/tests/cli/test_lock.py
@@ -343,18 +343,25 @@ def test_lock_inherit_metadata_strategy(project, pdm, mocker, working_set):
         assert key in working_set
 
 
-def test_lock_exclude_newer(project, pdm):
+@pytest.mark.parametrize("source", ["cli", "pyproject"])
+def test_lock_exclude_newer(project, pdm, source):
     project.pyproject.metadata["requires-python"] = ">=3.9"
     project.project_config["pypi.url"] = "https://my.pypi.org/json"
     project.add_dependencies(["zipp"])
-    pdm(["lock", "--exclude-newer", "2024-01-01"], obj=project, strict=True, cleanup=False)
-    assert project.get_locked_repository().candidates["zipp"].version == "3.6.0"
-
     pdm(["lock"], obj=project, strict=True, cleanup=False)
     assert project.get_locked_repository().candidates["zipp"].version == "3.7.0"
 
+    cmd = ["lock", "--exclude-newer", "2024-01-01"]
+    if source == "pyproject":
+        project.pyproject.settings["resolution"] = {"exclude-newer": "2024-01-01"}
+        cmd = ["lock"]
 
-def test_lock_exclude_newer_accepts_relative_duration(project, pdm, monkeypatch):
+    pdm(cmd, obj=project, strict=True, cleanup=False)
+    assert project.get_locked_repository().candidates["zipp"].version == "3.6.0"
+
+
+@pytest.mark.parametrize("source", ["cli", "pyproject"])
+def test_lock_exclude_newer_accepts_relative_duration(project, pdm, monkeypatch, source):
     from datetime import datetime, timezone
 
     import pdm.utils as pdm_utils
@@ -368,10 +375,16 @@ def test_lock_exclude_newer_accepts_relative_duration(project, pdm, monkeypatch)
             return frozen_now
 
     monkeypatch.setattr(pdm_utils, "datetime", FrozenDateTime)
+
+    cmd = ["lock", "--exclude-newer", "3w"]
+    if source == "pyproject":
+        project.pyproject.settings["resolution"] = {"exclude-newer": "3w"}
+        cmd = ["lock"]
+
     project.pyproject.metadata["requires-python"] = ">=3.9"
     project.project_config["pypi.url"] = "https://my.pypi.org/json"
     project.add_dependencies(["zipp"])
-    pdm(["lock", "--exclude-newer", "3w"], strict=True, obj=project, cleanup=False)
+    pdm(cmd, strict=True, obj=project, cleanup=False)
     assert project.get_locked_repository().candidates["zipp"].version == "3.6.0"
 
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Fix: #3776 - allow setting dependency cooldowns on a projectwide basis from the `pyproject.toml` file. pretty straightforward, i'll comment inline with a few things i wasn't sure about.

There didn't seem to be a single place to add a field to `pyproject.toml`, and looking around at how other things in the `resolution` table made it seem like it was on an as-needed kind of basis since the `PyProject.resolution` prop is just an untyped dict, so i just walked backwards from how the cli flag was handled until i found the setting in the `State` object. I *think* i found the place in `core` to apply settings from pyproject -> state, but lmk if that is too much of a hack/what would be better.