### PR TITLE
Docs and TypedDicts for tool.pdm table and subtables

### DIFF
--- a/docs/_ext/typeddict.py
+++ b/docs/_ext/typeddict.py
@@ -1,0 +1,111 @@
+"""
+griffe extension for documenting typed dicts:
+
+Converts functional-form TypedDicts to class-form.
+Functional TypedDicts may document their fields with comments in place of docstrings.
+
+e.g.
+
+```
+MyDict = TypedDict("MyDict", {
+    "a-field": str,
+    # This is interpreted as a docstring
+    # and it can span multiple lines
+})
+```
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, cast
+
+from griffe import (
+    Attribute,
+    Class,
+    Docstring,
+    ExprCall,
+    ExprDict,
+    ExprName,
+    Extension,
+    GriffeLoader,
+    Module,
+)
+
+
+class TypedDictExtension(Extension):
+    def __init__(self, modules: list[str] | None = None):
+        """
+        Args:
+            modules (list[str]): fully-qualified python module names
+                (e.g. "pdm.mproject.project_file").
+                If present, only transform TypedDicts in these modules.
+        """
+        self.modules = modules
+
+    def on_module(self, *, mod: Module, loader: GriffeLoader, **kwargs: Any) -> None:
+        # need to intercept at the module level because we want to modify the types of its members
+        # (otherwise we can only mutate the member's attributes, but not replace it)
+        if self.modules and mod.module.canonical_path not in self.modules:
+            return
+
+        self._transform_functional_typeddicts(mod)
+
+    def _transform_functional_typeddicts(self, mod: Module) -> Module:
+        """
+        Transform functional typed dicts into class-based typed dicts
+        We only do the minimal work needed here to create the representation in the docs -
+        just grab the field names and annotations, so other metadata will be incomplete.
+        """
+        tds = {
+            k: v
+            for k, v in mod.members.items()
+            if isinstance(v, Attribute)
+            and "module-attribute" in v.labels
+            and isinstance(v.value, ExprCall)
+            and v.value.function.name == "TypedDict"
+        }
+
+        classes = {}
+        for name, td in tds.items():
+            classes[name] = Class(name=name, bases=[ExprName(name="TypedDict", parent=mod, member=name)], parent=mod)
+            classes[name].docstring = td.docstring
+
+            # Convert the keys/values of the dict arg to classlike attributes
+            expression = cast(ExprCall, td.value)
+            fields = cast(ExprDict, expression.arguments[1])
+            attrs = {}
+            for key, val in zip(fields.keys, fields.values):
+                key: str
+                key = key.strip("'")
+                attrs[key] = Attribute(name=key, value=val, annotation=val)
+                attrs[key].parent = classes[name]
+                attrs[key].docstring = self._extract_comment_docstring(key, td)
+
+            classes[name].members = attrs
+
+        mod.members.update(classes)
+        return mod
+
+    def _extract_comment_docstring(self, key: str, td: Attribute) -> Docstring | None:
+        """
+        find comments after this expression to use as docstrings.
+        The ExprName we use to parse the key/annotation doesn't bear the line numbers,
+        so regex is unfortunately the best we can do
+        """
+        expr_line = [idx for idx, line in enumerate(td.lines) if re.match(rf'^\s*[\'"]{key}[\'"]', line)]
+        if not expr_line:
+            return
+        start_line = expr_line[0]
+
+        # find trailing comments, if any
+        docstring_lines = []
+        for line in td.lines[start_line + 1 :]:
+            if not re.match(r"^\s*#", line):
+                break
+            docstring_lines.append(line.strip().lstrip("#").lstrip())
+
+        # join like a naive markdown, not handling line breaks currently
+        docstring = " ".join(docstring_lines)
+        if docstring:
+            return Docstring(value=docstring)

--- a/docs/reference/tool.md
+++ b/docs/reference/tool.md
@@ -33,8 +33,6 @@
       summary:
         attributes: true
 
-(placeholder pending figuring out rendering docs for functional form typeddicts)
-
 ::: pdm.project.project_file.OptionsTable
     options:
       heading: "[tool.pdm.options]"
@@ -60,8 +58,6 @@
       show_if_no_docstring: true
       summary:
         attributes: true
-
-(placeholder pending figuring out rendering docs for functional form typeddicts)
 
 ::: pdm.project.project_file.UserScript
     options:
@@ -101,21 +97,3 @@
       show_if_no_docstring: true
       summary:
         attributes: true
-
-## Functional TypedDicts
-
-::: pdm.project.project_file
-    options:
-      show_root_heading: false
-      show_root_toc_entry: false
-      show_source: false
-      heading_level: 3
-      group_by_category: false
-      show_bases: false
-      show_if_no_docstring: true
-      show_labels: false
-      show_signature_annotations: true
-      signature_crossrefs: true
-      members:
-      - BuildTable
-      - ResolutionTable

--- a/docs/reference/tool.md
+++ b/docs/reference/tool.md
@@ -1,0 +1,121 @@
+# `[tool.pdm]`
+
+<style>
+/* Temporary hack pending guidance to show compact summary tables without double-displaying each attribute */
+.doc-class .doc-children {
+  display: none;
+}
+</style>
+
+::: pdm.project.project_file.ToolPDMTable
+    options:
+      heading: "[tool.pdm]"
+      toc_label: "[tool.pdm]"
+      heading_level: 2
+      show_bases: false
+      show_root_heading: true
+      show_root_toc_entry: true
+      show_source: false
+      show_if_no_docstring: true
+      summary:
+        attributes: true
+
+::: pdm.project.project_file.BuildTable
+    options:
+      heading: "[tool.pdm.build]"
+      toc_label: "[tool.pdm.build]"
+      heading_level: 2
+      show_bases: false
+      show_root_heading: true
+      show_root_toc_entry: true
+      show_source: false
+      show_if_no_docstring: true
+      summary:
+        attributes: true
+
+(placeholder pending figuring out rendering docs for functional form typeddicts)
+
+::: pdm.project.project_file.OptionsTable
+    options:
+      heading: "[tool.pdm.options]"
+      toc_label: "[tool.pdm.options]"
+      heading_level: 2
+      show_bases: false
+      show_root_heading: true
+      show_root_toc_entry: true
+      show_source: false
+      show_if_no_docstring: true
+      summary:
+        attributes: true
+
+::: pdm.project.project_file.ResolutionTable
+    options:
+      heading: "[tool.pdm.resolution]"
+      toc_label: "[tool.pdm.resolution]"
+      heading_level: 2
+      show_bases: false
+      show_root_heading: true
+      show_root_toc_entry: true
+      show_source: false
+      show_if_no_docstring: true
+      summary:
+        attributes: true
+
+(placeholder pending figuring out rendering docs for functional form typeddicts)
+
+::: pdm.project.project_file.UserScript
+    options:
+      heading: "[tool.pdm.scripts]"
+      toc_label: "[tool.pdm.scripts]"
+      heading_level: 2
+      show_bases: false
+      show_root_heading: true
+      show_root_toc_entry: true
+      show_source: false
+      show_if_no_docstring: true
+      summary:
+        attributes: true
+
+::: pdm.project.project_file.SourceTable
+    options:
+      heading: "[[tool.pdm.source]]"
+      toc_label: "[[tool.pdm.source]]"
+      heading_level: 2
+      show_bases: false
+      show_root_heading: true
+      show_root_toc_entry: true
+      show_source: false
+      show_if_no_docstring: true
+      summary:
+        attributes: true
+
+::: pdm.project.project_file.VersionTable
+    options:
+      heading: "[tool.pdm.version]"
+      toc_label: "[tool.pdm.version]"
+      heading_level: 2
+      show_bases: false
+      show_root_heading: true
+      show_root_toc_entry: true
+      show_source: false
+      show_if_no_docstring: true
+      summary:
+        attributes: true
+
+## Functional TypedDicts
+
+::: pdm.project.project_file
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      show_source: false
+      heading_level: 3
+      group_by_category: false
+      show_bases: false
+      show_if_no_docstring: true
+      show_labels: false
+      show_signature_annotations: true
+      signature_crossrefs: true
+      members:
+      - BuildTable
+      - ResolutionTable

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
       - usage/template.md
   - Reference:
       - reference/pep621.md
+      - reference/tool.md
       - reference/configuration.md
       - reference/build.md
       - reference/cli.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,12 +36,16 @@ theme:
   custom_dir: docs/overrides
 
 plugins:
+  - autorefs
   - mkdocstrings:
       enable_inventory: true
       handlers:
         python:
           options:
             docstring_style: google
+            extensions:
+              - docs/_ext/typeddict.py:TypedDictExtension:
+                  modules: ["pdm.project.project_file"]
 
 nav:
   - Usage:

--- a/news/3783.doc.md
+++ b/news/3783.doc.md
@@ -1,0 +1,1 @@
+Add `TypedDicts` and documentation for items within the `[tool.pdm]` table and subtables

--- a/src/pdm/cli/commands/fix/fixers.py
+++ b/src/pdm/cli/commands/fix/fixers.py
@@ -74,7 +74,7 @@ class PackageTypeFixer(BaseFixer):  # pragma: no cover
     identifier = "package-type"
 
     def get_message(self) -> str:
-        package_type = self.project.pyproject.settings["package-type"]
+        package_type = self.project.pyproject.settings["package-type"]  # type: ignore[typeddict-item]
         dist = str(package_type == "library").lower()
         return (
             rf'[success]package-type = "{package_type}"[/] has been renamed to '
@@ -90,7 +90,7 @@ class PackageTypeFixer(BaseFixer):  # pragma: no cover
         settings = self.project.pyproject.settings.copy()
 
         # Pop the package type and convert it to a distribution type
-        package_type = settings.pop("package-type")
+        package_type = settings.pop("package-type")  # type: ignore[typeddict-item]
         dist = package_type == "library"
         settings["distribution"] = dist
 

--- a/src/pdm/core.py
+++ b/src/pdm/core.py
@@ -221,7 +221,7 @@ class Core:
         (pos, command) = self.get_command(args)
         if command and command in config:
             # add args after the command
-            args[pos + 1 : pos + 1] = list(config[command])
+            args[pos + 1 : pos + 1] = list(config[command])  # type: ignore[literal-required]
             return True
         return False
 

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     from pdm.installers.base import BaseSynchronizer
     from pdm.models.caches import CandidateInfoCache, HashCache, WheelCache
     from pdm.models.candidates import Candidate
+    from pdm.project.project_file import UserScript
     from pdm.resolver.base import Resolver
     from pdm.resolver.providers import BaseProvider
     from pdm.resolver.reporters import RichLockReporter
@@ -156,7 +157,7 @@ class Project:
         return collections.ChainMap(self.project_config, self.global_config)
 
     @property
-    def scripts(self) -> dict[str, str | dict[str, str]]:
+    def scripts(self) -> dict[str, str | UserScript]:
         return self.pyproject.settings.get("scripts", {})
 
     @cached_property
@@ -499,8 +500,8 @@ class Project:
 
     def get_sources(self, expand_env: bool = True, include_stored: bool = False) -> list[RepositoryConfig]:
         result: dict[str, RepositoryConfig] = {}
-        for source in self.pyproject.settings.get("source", []):
-            result[source["name"]] = RepositoryConfig(**source, config_prefix="pypi")
+        for project_source in self.pyproject.settings.get("source", []):
+            result[project_source["name"]] = RepositoryConfig(**project_source, config_prefix="pypi")
 
         def merge_sources(other_sources: Iterable[RepositoryConfig]) -> None:
             for source in other_sources:
@@ -962,7 +963,7 @@ class Project:
             return False
         settings = self.pyproject.settings
         if "package-type" in settings:
-            return settings["package-type"] == "library"
+            return settings["package-type"] == "library"  # type: ignore[typeddict-item]
         elif "distribution" in settings:
             return cast(bool, settings["distribution"])
         else:
@@ -975,7 +976,7 @@ class Project:
         Returns `None` if the key does not exists.
         """
         try:
-            return reduce(operator.getitem, key.split("."), self.pyproject.settings)
+            return reduce(operator.getitem, key.split("."), self.pyproject.settings)  # type: ignore[arg-type]
         except KeyError:
             return None
 

--- a/src/pdm/project/project_file.py
+++ b/src/pdm/project/project_file.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
 import tomlkit
 
@@ -10,6 +10,9 @@ from pdm import termui
 from pdm.exceptions import ProjectError
 from pdm.project.toml_file import TOMLFile
 from pdm.utils import normalize_name
+
+if TYPE_CHECKING:
+    from os import PathLike
 
 
 def _remove_empty_tables(doc: dict) -> None:
@@ -91,7 +94,7 @@ class PyProject(TOMLFile):
         return groups
 
     @property
-    def settings(self) -> dict[str, Any]:
+    def settings(self) -> ToolPDMTable:
         return self._data.setdefault("tool", {}).setdefault("pdm", {})
 
     @property
@@ -129,3 +132,170 @@ class PyProject(TOMLFile):
     @property
     def plugins(self) -> list[str]:
         return self.settings.get("plugins", [])
+
+
+class ToolPDMTable(TypedDict, total=False):
+    """
+    Root table for setting pdm options within pyproject.toml
+    """
+
+    distribution: bool
+    plugins: list[str]
+
+    build: BuildTable
+    """Control how pdm-backend builds the package"""
+    options: OptionsTable
+    """Add parameters to every pdm cli call"""
+    resolution: ResolutionTable
+    """Rules governing lockfile resolution"""
+    scripts: dict[str, str | UserScript]
+    """See [pdm-scripts][pdm-scripts]"""
+    source: list[SourceTable]
+    """Repositories where packages may be found"""
+    version: VersionTable
+    """Dynamic Versioning"""
+    # TODO: add dev-dependencies once we figure out how to document functional form typeddicts,
+    # leaving to demo pending guidance.
+
+
+BuildTable = TypedDict(
+    "BuildTable",
+    {
+        "custom-hook": str,
+        "editable-backend": Literal["editables", "path"],
+        "excludes": list[str],
+        "includes": list[str],
+        "is-purelib": bool,
+        "package-dir": str,
+        "run-setuptools": bool,
+        "source-includes": list[str],
+        "wheel-data": dict[
+            Literal["data", "include", "platinclude", "platlib", "purelib", "scripts"],
+            dict[Literal["path", "relative-to"], str],
+        ],
+    },
+)
+"""
+`[tool.pdm.build]`
+
+References:
+    <https://backend.pdm-project.org/build_config/>
+"""
+
+
+class OptionsTable(TypedDict, total=False):
+    """
+    `[tool.pdm.options]`
+
+    References:
+        [Passing constant arguments to every pdm invocation][passing-constant-arguments-to-every-pdm-invocation]
+    """
+
+    add: list[str]
+    build: list[str]
+    cache: list[str]
+    completion: list[str]
+    config: list[str]
+    export: list[str]
+    fix: list[str]
+    info: list[str]
+    init: list[str]
+    install: list[str]
+    list: list[str]
+    lock: list[str]
+    new: list[str]
+    outdated: list[str]
+    publish: list[str]
+    python: list[str]
+    remove: list[str]
+    run: list[str]
+    search: list[str]
+    self: list[str]
+    show: list[str]
+    sync: list[str]
+    update: list[str]
+    use: list[str]
+    venv: list[str]
+
+
+ResolutionTable = TypedDict(
+    "ResolutionTable",
+    {
+        "allow-prereleases": bool,
+        "exclude-newer": str,
+        "no-binary": str | list[str],
+        "only-binary": str | list[str],
+        "overrides": dict[str, str],
+        "prefer-binary": str | list[str],
+    },
+    total=False,
+)
+
+
+class SourceTable(TypedDict, total=False):
+    """
+    A repository where PDM can find packages during lockfile resolution
+
+    References:
+        [Configure the package indexes][configure-the-package-indexes]
+    """
+
+    name: str
+    url: str
+    verify_ssl: bool
+    username: str
+    password: str
+    type: Literal["index", "find_links"]
+    include_packages: list[str]
+    exclude_packages: list[str]
+
+
+class VersionTable(TypedDict, total=False):
+    """
+    Specify how PDM computes dynamic versions.
+
+    References:
+        [Dynamic project version](https://backend.pdm-project.org/metadata/#dynamic-project-version)
+    """
+
+    source: Literal["call", "file", "scm"]
+    getter: str
+    path: PathLike[str]
+    pattern: str
+    fallback_version: str
+    tag_filter: str
+    tag_regex: str
+    version_format: str
+    write_to: str
+    write_template: str
+
+
+class UserScript(TypedDict, total=False):
+    """
+    The value of an item within `[tool.pdm.scripts]` .
+
+    An individual script may be a simple string, or a dictionary of this form.
+
+    Examples:
+
+        [tool.pdm.scripts]
+        list-files = "ls ."
+        start = {cmd = "flask run -p 54321"}
+        mytask.composite = [
+            "echo 'Hello'",
+            "echo 'World'"
+        ]
+        mytask.keep_going = true
+
+    References:
+        [PDM Scripts][pdm-scripts]
+    """
+
+    call: str
+    composite: list[str]
+    cmd: str
+    env: dict[str, str]
+    env_file: str | dict[Literal["override"], str]
+    keep_going: bool
+    shell: str
+    working_dir: str

--- a/src/pdm/project/project_file.py
+++ b/src/pdm/project/project_file.py
@@ -134,30 +134,6 @@ class PyProject(TOMLFile):
         return self.settings.get("plugins", [])
 
 
-class ToolPDMTable(TypedDict, total=False):
-    """
-    Root table for setting pdm options within pyproject.toml
-    """
-
-    distribution: bool
-    plugins: list[str]
-
-    build: BuildTable
-    """Control how pdm-backend builds the package"""
-    options: OptionsTable
-    """Add parameters to every pdm cli call"""
-    resolution: ResolutionTable
-    """Rules governing lockfile resolution"""
-    scripts: dict[str, str | UserScript]
-    """See [pdm-scripts][pdm-scripts]"""
-    source: list[SourceTable]
-    """Repositories where packages may be found"""
-    version: VersionTable
-    """Dynamic Versioning"""
-    # TODO: add dev-dependencies once we figure out how to document functional form typeddicts,
-    # leaving to demo pending guidance.
-
-
 BuildTable = TypedDict(
     "BuildTable",
     {
@@ -299,3 +275,30 @@ class UserScript(TypedDict, total=False):
     keep_going: bool
     shell: str
     working_dir: str
+
+
+ToolPDMTable = TypedDict(
+    "ToolPDMTable",
+    {
+        "distribution": bool,
+        "plugins": list[str],
+        "build": BuildTable,
+        # Control how pdm-backend builds the package
+        "options": OptionsTable,
+        # Add parameters to every pdm cli call
+        "resolution": ResolutionTable,
+        # Rules governing lockfile resolution
+        "scripts": dict[str, str | UserScript],
+        # See [pdm-scripts][pdm-scripts]
+        "source": list[SourceTable],
+        # Repositories where packages may be found
+        "version": VersionTable,
+        # Dynamic Versioning
+        "dev-dependencies": dict[str, dict[str, str]],
+        # Development-only dependencies
+    },
+    total=False,
+)
+"""
+Root table for setting pdm options within pyproject.toml
+"""

--- a/src/pdm/project/project_file.py
+++ b/src/pdm/project/project_file.py
@@ -102,7 +102,7 @@ class PyProject(TOMLFile):
         return self._data.get("build-system", {})
 
     @property
-    def resolution(self) -> dict[str, Any]:
+    def resolution(self) -> ResolutionTable:
         """A compatible getter method for the resolution overrides
         in the pyproject.toml file.
         """
@@ -294,7 +294,7 @@ ToolPDMTable = TypedDict(
         # Repositories where packages may be found
         "version": VersionTable,
         # Dynamic Versioning
-        "dev-dependencies": dict[str, dict[str, str]],
+        "dev-dependencies": dict[str, list[str]],
         # Development-only dependencies
     },
     total=False,

--- a/src/pdm/project/project_file.py
+++ b/src/pdm/project/project_file.py
@@ -199,6 +199,7 @@ ResolutionTable = TypedDict(
     {
         "allow-prereleases": bool,
         "exclude-newer": str,
+        "excludes": list[str],
         "no-binary": str | list[str],
         "only-binary": str | list[str],
         "overrides": dict[str, str],
@@ -281,6 +282,7 @@ ToolPDMTable = TypedDict(
     "ToolPDMTable",
     {
         "distribution": bool,
+        "ignore_package_warnings": list[str],
         "plugins": list[str],
         "build": BuildTable,
         # Control how pdm-backend builds the package

--- a/src/pdm/project/project_file.py
+++ b/src/pdm/project/project_file.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union, cast
 
 import tomlkit
 
@@ -200,10 +200,10 @@ ResolutionTable = TypedDict(
         "allow-prereleases": bool,
         "exclude-newer": str,
         "excludes": list[str],
-        "no-binary": str | list[str],
-        "only-binary": str | list[str],
+        "no-binary": Union[str, list[str]],
+        "only-binary": Union[str, list[str]],
         "overrides": dict[str, str],
-        "prefer-binary": str | list[str],
+        "prefer-binary": Union[str, list[str]],
     },
     total=False,
 )
@@ -290,7 +290,7 @@ ToolPDMTable = TypedDict(
         # Add parameters to every pdm cli call
         "resolution": ResolutionTable,
         # Rules governing lockfile resolution
-        "scripts": dict[str, str | UserScript],
+        "scripts": dict[str, Union[str, UserScript]],
         # See [pdm-scripts][pdm-scripts]
         "source": list[SourceTable],
         # Repositories where packages may be found


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code - none needed, as far as i'm aware

## Describe what you have changed in this PR.

Fix: #3783 

(raising this as a draft but i have to run right now and can't do a full rundown just yet, wanted to open to see if you approved of the general approach)

So i figured out how to get mkdocs to do a summary-table style like what is done in the other refrence docs pages, but it is a bit of a hack. the big thing that is missing here is that functional typeddicts get rendered like garbage, so i think i'll need to write a small extension for that, if you would accept that ( opened a discussion: https://github.com/mkdocstrings/python/discussions/329 ) 

<img width="1268" height="911" alt="Screenshot 2026-05-08 at 7 07 29 PM" src="https://github.com/user-attachments/assets/800b3a60-5449-480e-be10-566f531f1ec6" />

Getting that summary form with the correct TOC headings also required doing manual autodoc invocations for each class, which isn't so bad, but it does risk getting stale if there are a bunch of new tables, but not that bad.

I went through the docs and source to find all mentions of `[tool.pdm]` entries i could find, and added some docstrings as examples, but if we generally like this approach then i can go through and fill those in more completely (or you can do that, no preference).

Feel free to edit anything, if i've gotten something wrong, if you don't like my working, etc. i'm not precious - these are your docs, just trying to help out!

will be back later for more complete comment and to figure out an approach for the functional typed dicts.

## todo

- python 3.9 compat - use `Union`
- extension to document functional typed dicts
- ... will fill in later

