### PR TITLE
docs: fix Windows install command for a specific version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ Install the prebuilt binary directly with the installer scripts.
     To install a specific version:
 
     ```powershell
-    powershell -ExecutionPolicy ByPass -c "irm https://pdm-project.org/install.ps1 | iex -Args '-v <version>'"
+    powershell -ExecutionPolicy ByPass -c "$env:PDM_VERSION='<version>'; irm https://pdm-project.org/install.ps1 | iex"
     ```
 
 ### Install via Python script

--- a/news/3792.doc.md
+++ b/news/3792.doc.md
@@ -1,0 +1,1 @@
+Fix the Windows installation instructions for a specific version. `Invoke-Expression` (`iex`) does not accept an `-Args` parameter and cannot forward arguments to a piped script, so the documented command failed. Use the `$env:PDM_VERSION` environment variable, which the install script reads, instead.


### PR DESCRIPTION
Fixes #3792

The documented Windows command for installing a specific version pipes the
install script into `iex -Args '-v <version>'`. `Invoke-Expression` has no
`-Args` parameter and cannot forward arguments to a piped script, so the command
errors out (`A parameter cannot be found that matches parameter name 'Args'`).

`install-pdm.ps1` already reads `$env:PDM_VERSION` as the default for `-Version`,
so setting that variable before the existing `irm ... | iex` pipeline is the
minimal, idiomatic fix and keeps the command consistent with the latest-version one.

LinkedIn: https://www.linkedin.com/in/shubham-phapale/