### PR TITLE
perf: defer command imports during startup

### DIFF
--- a/news/3673.feature.md
+++ b/news/3673.feature.md
@@ -1,0 +1,1 @@
+Defer startup-time imports for Python and self-management commands.

--- a/src/pdm/cli/commands/python.py
+++ b/src/pdm/cli/commands/python.py
@@ -10,16 +10,14 @@ from typing import TYPE_CHECKING, cast
 
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.options import verbose_option
-from pdm.environments import BareEnvironment
 from pdm.exceptions import InstallationError, PdmArgumentError
-from pdm.models.python import PythonInfo
 from pdm.termui import Verbosity
-from pdm.utils import get_all_installable_python_versions
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace, _SubParsersAction
     from typing import Any
 
+    from pdm.models.python import PythonInfo
     from pdm.project.core import Project
 
 
@@ -116,6 +114,8 @@ class InstallCommand(BaseCommand):
         )
 
     def handle(self, project: Project, options: Namespace) -> None:
+        from pdm.utils import get_all_installable_python_versions
+
         if options.list:
             for version in get_all_installable_python_versions(build_dir=False):
                 project.core.ui.echo(str(version))
@@ -136,7 +136,9 @@ class InstallCommand(BaseCommand):
         from pbs_installer import download, get_download_link, install_file
         from pbs_installer._install import THIS_ARCH
 
+        from pdm.environments import BareEnvironment
         from pdm.misc import sysconfig_patcher
+        from pdm.models.python import PythonInfo
         from pdm.termui import logger
 
         ui = project.core.ui
@@ -204,6 +206,8 @@ class LinkCommand(BaseCommand):
         parser.add_argument("--name", help="The name of the link")
 
     def handle(self, project: Project, options: Namespace) -> None:
+        from pdm.models.python import PythonInfo
+
         python_info = PythonInfo.from_path(options.interpreter)
         if not python_info.valid:
             raise PdmArgumentError("Invalid Python interpreter")

--- a/src/pdm/cli/commands/self_cmd.py
+++ b/src/pdm/cli/commands/self_cmd.py
@@ -5,23 +5,22 @@ import shlex
 import subprocess
 import sys
 from importlib.metadata import Distribution
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pdm import termui
-from pdm.cli.actions import get_latest_pdm_version_from_pypi
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.options import verbose_option
-from pdm.cli.utils import PackageNode, build_dependency_graph
-from pdm.environments import BareEnvironment
-from pdm.models.markers import EnvSpec
-from pdm.models.working_set import WorkingSet
-from pdm.project import Project
-from pdm.utils import is_in_zipapp, normalize_name, parse_version
+from pdm.utils import is_in_zipapp
+
+if TYPE_CHECKING:
+    from pdm.project import Project
 
 PDM_REPO = "https://github.com/pdm-project/pdm"
 
 
 def list_distributions(plugin_only: bool = False) -> list[Distribution]:
+    from pdm.models.working_set import WorkingSet
+
     result: list[Distribution] = []
     working_set = WorkingSet()
     for dist in working_set.values():
@@ -37,6 +36,8 @@ def run_pip(project: Project, args: list[str]) -> subprocess.CompletedProcess[st
             args[(i := args.index("--upgrade-strategy")) : i + 2] = []
         run_args = [*project.core.uv_cmd, "pip", *args, "--python", sys.executable]
     else:
+        from pdm.environments import BareEnvironment
+
         env = BareEnvironment(project)
         project.environment = env
         run_args = [*env.pip_command, *args]
@@ -161,6 +162,11 @@ class RemoveCommand(BaseCommand):
 
     def _resolve_dependencies_to_remove(self, packages: list[str]) -> list[str]:
         """Perform a BFS to find all unneeded dependencies"""
+        from pdm.cli.utils import PackageNode, build_dependency_graph
+        from pdm.models.markers import EnvSpec
+        from pdm.models.working_set import WorkingSet
+        from pdm.utils import normalize_name
+
         result: set[str] = set()
         to_resolve = list(packages)
 
@@ -237,6 +243,8 @@ class UpdateCommand(BaseCommand):
 
     def handle(self, project: Project, options: argparse.Namespace) -> None:
         from pdm.__version__ import __version__, read_version
+        from pdm.cli.actions import get_latest_pdm_version_from_pypi
+        from pdm.utils import parse_version
 
         locked = "[locked]" if options.frozen_deps else ""
 

--- a/src/pdm/cli/commands/use.py
+++ b/src/pdm/cli/commands/use.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from typing import TYPE_CHECKING
 
 from pdm import termui
 from pdm.cli.commands.base import BaseCommand
@@ -8,10 +9,10 @@ from pdm.cli.hooks import HookManager
 from pdm.cli.options import skip_option
 from pdm.exceptions import NoPythonVersion
 from pdm.models.caches import JSONFileCache
-from pdm.models.python import PythonInfo
-from pdm.models.venv import get_venv_python
 from pdm.project import Project
-from pdm.utils import is_conda_base_python, open_for_write_no_symlink
+
+if TYPE_CHECKING:
+    from pdm.models.python import PythonInfo
 
 
 class Command(BaseCommand):
@@ -66,6 +67,7 @@ class Command(BaseCommand):
     ) -> PythonInfo:
         from pdm.cli.commands.python import InstallCommand
         from pdm.cli.commands.venv.utils import get_venv_with_name
+        from pdm.models.python import PythonInfo
 
         def version_matcher(py_version: PythonInfo) -> bool:
             return py_version.valid and (
@@ -151,6 +153,9 @@ class Command(BaseCommand):
         The python can be a version string or interpreter path.
         """
         from pdm.environments import PythonLocalEnvironment
+        from pdm.models.python import PythonInfo
+        from pdm.models.venv import get_venv_python
+        from pdm.utils import is_conda_base_python, open_for_write_no_symlink
 
         selected_python = self.select_python(
             project,

--- a/tests/cli/test_self_command.py
+++ b/tests/cli/test_self_command.py
@@ -26,13 +26,13 @@ def mock_pip(mocker):
 
 @pytest.fixture()
 def mock_all_distributions(mocker):
-    mocker.patch("pdm.cli.commands.self_cmd.WorkingSet", return_value=DISTRIBUTIONS)
+    mocker.patch("pdm.models.working_set.WorkingSet", return_value=DISTRIBUTIONS)
 
 
 @pytest.fixture()
 def mock_latest_pdm_version(mocker):
     return mocker.patch(
-        "pdm.cli.commands.self_cmd.get_latest_pdm_version_from_pypi",
+        "pdm.cli.actions.get_latest_pdm_version_from_pypi",
     )
 
 


### PR DESCRIPTION
## What

Defer imports used only by the `self`, `python`, and `use` command execution paths so they are not loaded while PDM is only starting up and registering CLI commands.

## Why

Refs #3673. PDM currently imports every command module during parser initialization, so top-level imports in rarely used commands contribute to startup cost even for simple invocations such as `pdm --version`.

## How

Move execution-only imports for package working sets, Python discovery/install helpers, environment helpers, and update checks into the functions or handlers that actually need them. The command registration and argument definitions are unchanged.

A local comparison using 7 runs of `python -m pdm --version` with the same virtualenv showed:

- `main`: min 573.50 ms, avg 828.56 ms, max 2294.72 ms
- this branch: min 550.61 ms, avg 572.28 ms, max 613.83 ms

## Testing

- `.\.venv\Scripts\python.exe -m pytest tests\cli\test_self_command.py -q` -> 8 passed
- `.\.venv\Scripts\ruff.exe check src\pdm\cli\commands\self_cmd.py src\pdm\cli\commands\python.py src\pdm\cli\commands\use.py tests\cli\test_self_command.py` -> passed
- `.\.venv\Scripts\python.exe -m compileall src\pdm\cli\commands\self_cmd.py src\pdm\cli\commands\python.py src\pdm\cli\commands\use.py tests\cli\test_self_command.py` -> passed
- `.\.venv\Scripts\pdm.exe --version`, `self --help`, `python --help`, and `use --help` -> passed

I also tried `tests\cli\test_python.py tests\cli\test_use.py`; on my Windows machine they fail before exercising this change because subprocess output from the local Python path under `C:\Users\觉\...` is decoded as UTF-8 while the child process emits the username in the system code page.

## Breaking changes

None.