### PR TITLE
perf: defer virtualenv command imports

### DIFF
--- a/news/3673.feature.md
+++ b/news/3673.feature.md
@@ -1,1 +1,1 @@
-Defer startup-time imports for Python and self-management commands.
+Defer startup-time imports for Python, virtualenv, and self-management commands.

--- a/src/pdm/cli/commands/venv/__init__.py
+++ b/src/pdm/cli/commands/venv/__init__.py
@@ -8,7 +8,6 @@ from pdm.cli.commands.venv.create import CreateCommand
 from pdm.cli.commands.venv.list import ListCommand
 from pdm.cli.commands.venv.purge import PurgeCommand
 from pdm.cli.commands.venv.remove import RemoveCommand
-from pdm.cli.commands.venv.utils import get_venv_with_name
 from pdm.cli.options import project_option
 
 if TYPE_CHECKING:
@@ -36,6 +35,8 @@ class Command(BaseCommand):
         self.parser = parser
 
     def handle(self, project: Project, options: Namespace) -> None:
+        from pdm.cli.commands.venv.utils import get_venv_with_name
+
         if options.path:
             venv = get_venv_with_name(project, options.path)
             project.core.ui.echo(str(venv.root))

--- a/src/pdm/cli/commands/venv/activate.py
+++ b/src/pdm/cli/commands/venv/activate.py
@@ -5,16 +5,13 @@ import shlex
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import shellingham
-
 from pdm.cli.commands.base import BaseCommand
-from pdm.cli.commands.venv.utils import get_venv_with_name
 from pdm.cli.options import verbose_option
-from pdm.models.venv import VirtualEnv
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
 
+    from pdm.models.venv import VirtualEnv
     from pdm.project import Project
 
 
@@ -27,6 +24,9 @@ class ActivateCommand(BaseCommand):
         parser.add_argument("env", nargs="?", help="The key of the virtualenv")
 
     def handle(self, project: Project, options: Namespace) -> None:
+        from pdm.cli.commands.venv.utils import get_venv_with_name
+        from pdm.models.venv import VirtualEnv
+
         if options.env:
             venv = get_venv_with_name(project, options.env)
         else:
@@ -48,6 +48,8 @@ class ActivateCommand(BaseCommand):
         project.core.ui.echo(self.get_activate_command(venv))
 
     def get_activate_command(self, venv: VirtualEnv) -> str:  # pragma: no cover
+        import shellingham
+
         try:
             shell, _ = shellingham.detect_shell()
         except shellingham.ShellDetectionFailure:

--- a/src/pdm/cli/commands/venv/create.py
+++ b/src/pdm/cli/commands/venv/create.py
@@ -4,13 +4,15 @@ import argparse
 from typing import TYPE_CHECKING
 
 from pdm.cli.commands.base import BaseCommand
-from pdm.cli.commands.venv.backends import BACKENDS
 from pdm.cli.options import verbose_option
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
 
     from pdm.project import Project
+
+
+BACKEND_CHOICES = ("virtualenv", "venv", "conda", "uv")
 
 
 class CreateCommand(BaseCommand):
@@ -27,7 +29,7 @@ class CreateCommand(BaseCommand):
             "-w",
             "--with",
             dest="backend",
-            choices=BACKENDS.keys(),
+            choices=BACKEND_CHOICES,
             help="Specify the backend to create the virtualenv",
         )
         parser.add_argument(
@@ -50,6 +52,8 @@ class CreateCommand(BaseCommand):
         )
 
     def handle(self, project: Project, options: Namespace) -> None:
+        from pdm.cli.commands.venv.backends import BACKENDS
+
         in_project = project.config["venv.in_project"] and not options.name
         backend: str = options.backend or project.config["venv.backend"]
         venv_backend = BACKENDS[backend](project, options.python)

--- a/src/pdm/cli/commands/venv/list.py
+++ b/src/pdm/cli/commands/venv/list.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pdm.cli.commands.base import BaseCommand
-from pdm.cli.commands.venv.utils import iter_venvs
 from pdm.cli.options import verbose_option
 
 if TYPE_CHECKING:
@@ -19,6 +18,8 @@ class ListCommand(BaseCommand):
     arguments = (verbose_option,)
 
     def handle(self, project: Project, options: Namespace) -> None:
+        from pdm.cli.commands.venv.utils import iter_venvs
+
         project.core.ui.echo("Virtualenvs created with this project:\n")
         saved_python_root = Path(saved_python).parent.parent if (saved_python := project._saved_python) else None
         for ident, venv in iter_venvs(project):

--- a/src/pdm/cli/commands/venv/purge.py
+++ b/src/pdm/cli/commands/venv/purge.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from pdm import termui
 from pdm.cli.commands.base import BaseCommand
-from pdm.cli.commands.venv.utils import iter_central_venvs
 from pdm.cli.options import verbose_option
 
 if TYPE_CHECKING:
@@ -35,6 +34,8 @@ class PurgeCommand(BaseCommand):
         )
 
     def handle(self, project: Project, options: Namespace) -> None:
+        from pdm.cli.commands.venv.utils import iter_central_venvs
+
         all_central_venvs = list(iter_central_venvs(project))
         if not all_central_venvs:
             project.core.ui.echo("No virtualenvs to purge, quitting.", style="success")
@@ -64,6 +65,8 @@ class PurgeCommand(BaseCommand):
             project.core.ui.echo("Purged successfully!")
 
     def del_all_venvs(self, project: Project) -> None:
+        from pdm.cli.commands.venv.utils import iter_central_venvs
+
         saved_python = project._saved_python
         for _, venv in iter_central_venvs(project):
             shutil.rmtree(venv)

--- a/src/pdm/cli/commands/venv/remove.py
+++ b/src/pdm/cli/commands/venv/remove.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from pdm import termui
 from pdm.cli.commands.base import BaseCommand
-from pdm.cli.commands.venv.utils import get_venv_with_name
 from pdm.cli.options import verbose_option
 
 if TYPE_CHECKING:
@@ -30,6 +29,8 @@ class RemoveCommand(BaseCommand):
         parser.add_argument("env", help="The key of the virtualenv")
 
     def handle(self, project: Project, options: Namespace) -> None:
+        from pdm.cli.commands.venv.utils import get_venv_with_name
+
         project.core.ui.echo("Virtualenvs created with this project:")
         venv = get_venv_with_name(project, options.env)
         if options.yes or termui.confirm(f"[warning]Will remove: [success]{venv.root}[/], continue?", default=True):

--- a/tests/cli/test_venv.py
+++ b/tests/cli/test_venv.py
@@ -2,7 +2,9 @@ import os
 import platform
 import re
 import shutil
+import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import ANY
 
 import pytest
@@ -28,6 +30,33 @@ def fake_create(monkeypatch):
     monkeypatch.setattr(backends.VirtualenvBackend, "perform_create", fake_create)
     monkeypatch.setattr(backends.VenvBackend, "perform_create", fake_create)
     monkeypatch.setattr(backends.CondaBackend, "perform_create", fake_create)
+
+
+def test_core_registration_does_not_import_venv_runtime_helpers():
+    code = """
+import sys
+from pdm.core import Core
+
+Core()
+lazy_modules = {
+    "pdm.cli.commands.venv.backends",
+    "pdm.cli.commands.venv.utils",
+    "shellingham",
+}
+loaded = sorted(lazy_modules.intersection(sys.modules))
+if loaded:
+    print("\\n".join(loaded))
+    raise SystemExit(1)
+"""
+    env = os.environ.copy()
+    src = Path(__file__).resolve().parents[2] / "src"
+    pythonpath = [str(src)]
+    if env.get("PYTHONPATH"):
+        pythonpath.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath)
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, env=env, text=True)
+
+    assert result.returncode == 0, result.stdout or result.stderr
 
 
 @pytest.mark.usefixtures("fake_create")


### PR DESCRIPTION
## What

Defer virtualenv command runtime imports until the matching `pdm venv` command actually executes.

## Why

Refs #3673. Command registration was still importing virtualenv helpers, backend classes, and shell detection support during startup, even for commands like `pdm --version` that do not need virtualenv functionality.

## How

- Move venv helper/backend imports from module import time into command handlers.
- Keep the `pdm venv create --with` choices available without importing backend implementations during command registration.
- Add a regression test that initializes `Core()` in a clean subprocess and asserts the venv runtime modules are not loaded.

## Testing

- `ruff check src/pdm/cli/commands/venv/__init__.py src/pdm/cli/commands/venv/activate.py src/pdm/cli/commands/venv/create.py src/pdm/cli/commands/venv/list.py src/pdm/cli/commands/venv/purge.py src/pdm/cli/commands/venv/remove.py tests/cli/test_venv.py`
- `python -m compileall -q src/pdm/cli/commands/venv`
- `python -m pytest tests/cli/test_venv.py::test_core_registration_does_not_import_venv_runtime_helpers -q`
- `python -m pdm --version`
- `python -m pdm venv --help`
- `python -m pdm venv create --help`
- `python -m pdm venv activate --help`
- `python -X importtime -m pdm --version` shows no `pdm.cli.commands.venv.utils`, `pdm.cli.commands.venv.backends`, or `shellingham` import-time entries.

Attempted `python -m pytest tests/cli/test_venv.py -q` locally, but this Windows checkout is under a non-ASCII user path and the shared test fixture fails before test assertions with `UnicodeDecodeError` while decoding the interpreter path.

## Breaking changes

None.