### PR TITLE
docs: add Sponsor CTA badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # PDM
 
+[![Support Frost's Python packaging ecosystem](https://img.shields.io/badge/Sponsor-Python%20packaging%20ecosystem-ea4aaa?logo=githubsponsors&logoColor=white&style=for-the-badge)](https://github.com/sponsors/frostming)
+
 A modern Python package and dependency manager supporting the latest PEP standards.
 [中文版本说明](README_zh.md)
 


### PR DESCRIPTION
Adds a GitHub Sponsors CTA badge directly under the README title.

This uses the shared ecosystem-facing wording and badge style for Frost's Python packaging/toolchain projects, linking to https://github.com/sponsors/frostming.

Scope:
- README-only change
- Places the CTA above existing project/status badges
- Uses the same badge intended for pdm, pdm-backend, and pbs-installer

Validation:
- Reviewed the README diff locally; no code changes or tests needed.