### PR TITLE
fix: avoid forwarding duplicate SIGINT in pdm run on POSIX

### DIFF
--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -293,13 +293,21 @@ class TaskRunner:
 
         process_env = os.environ.copy()
         process_env.update({"PDM_RUN_CWD": str(Path.cwd())})
-        handle_term = signal.signal(signal.SIGTERM, forward_signal)
-        handle_int = signal.signal(signal.SIGINT, forward_signal)
         process = subprocess.Popen(process_cmd, cwd=cwd, shell=shell, bufsize=0, close_fds=False, env=process_env)
-        retcode = process.wait()
-        signal.signal(signal.SIGTERM, handle_term)
-        signal.signal(signal.SIGINT, handle_int)
-        return retcode
+
+        # On POSIX, an interactive Ctrl-C is delivered by the terminal to every
+        # process in the foreground process group.  The child therefore receives
+        # SIGINT directly.  If PDM also forwards the parent's SIGINT handler to
+        # the child, the child receives two SIGINTs (gh-3732).  Keep forwarding
+        # SIGTERM, which is commonly sent only to the parent process, but avoid
+        # duplicating SIGINT on POSIX.
+        handle_term = signal.signal(signal.SIGTERM, forward_signal)
+        handle_int = signal.signal(signal.SIGINT, signal.SIG_IGN if sys.platform != "win32" else forward_signal)
+        try:
+            return process.wait()
+        finally:
+            signal.signal(signal.SIGTERM, handle_term)
+            signal.signal(signal.SIGINT, handle_int)
 
     def run_task(
         self, task: Task, args: Sequence[str] = (), opts: TaskOptions | None = None, seen: set[str] | None = None

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,6 +1,8 @@
 import json
 import os
+import signal
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -60,6 +62,33 @@ def test_auto_isolate_site_packages(project, pdm):
         strict=True,
     )
     assert not any("site-packages" in path for path in result.stdout.splitlines())
+
+
+def test_run_does_not_forward_posix_sigint(project, monkeypatch):
+    from pdm.cli.commands.run import TaskRunner
+    from pdm.cli.hooks import HookManager
+
+    class DummyProcess:
+        def wait(self):
+            return 0
+
+        def send_signal(self, signum):  # pragma: no cover
+            raise AssertionError("SIGINT should not be forwarded on POSIX")
+
+    signal_calls = []
+
+    def fake_signal(signum, handler):
+        signal_calls.append((signum, handler))
+        return signal.SIG_DFL
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(subprocess, "Popen", lambda *args, **kwargs: DummyProcess())
+    monkeypatch.setattr(signal, "signal", fake_signal)
+
+    runner = TaskRunner(project, HookManager(project, []))
+    assert runner._run_process(["python", "-c", "pass"], chdir=True) == 0
+
+    assert (signal.SIGINT, signal.SIG_IGN) in signal_calls
 
 
 def test_run_with_site_packages(project, pdm):


### PR DESCRIPTION
## Summary

Fixes #3732.

On POSIX terminals, Ctrl-C sends SIGINT to every process in the foreground process group. A child process launched by `pdm run` therefore already receives SIGINT directly from the terminal.

PDM also installed a SIGINT handler that forwarded the parent process's SIGINT to the child. That means an interactive Ctrl-C delivered two SIGINTs to the child:

1. one directly from the terminal
2. one forwarded by PDM

This can interrupt the child process's own `KeyboardInterrupt` handler, matching the issue report where the script prints `interrupted` and then gets interrupted again before printing `done`.

## Fix

- Keep forwarding SIGTERM to the child process, because SIGTERM is commonly delivered only to the parent process.
- On POSIX, set PDM's temporary SIGINT handler to `SIG_IGN` while waiting for the child process, avoiding duplicate SIGINT delivery.
- Preserve existing Windows behavior because console signal delivery semantics differ there.
- Restore both signal handlers in a `finally` block.

## Tests

Added `test_run_does_not_forward_posix_sigint`, which verifies that POSIX `pdm run` installs `SIG_IGN` for SIGINT instead of the forwarding handler.

Local test run:

```
/tmp/pdmvenv/bin/python -m pytest tests/cli/test_run.py -q
74 passed in 6.66s
```