### PR TITLE
feat(scripts): add {run_cwd} placeholder for cross-platform scripts

### DIFF
--- a/docs/usage/scripts.md
+++ b/docs/usage/scripts.md
@@ -402,15 +402,15 @@ PDM, version 2.8.0 was called as <snip>/venvs/pdm2-8/bin/python -m pdm -V
 !!! note
     While the above example uses PDM 2.8, this functionality was introduced in the 2.10 series and only backported for the showcase.
 
-### `{PDM_RUN_CWD}` placeholder
+### `{pdm_run_cwd}` placeholder
 
-To make scripts referencing the current working directory cross-platform, you can use the `{PDM_RUN_CWD}` placeholder.
+To make scripts referencing the current working directory cross-platform, you can use the `{pdm_run_cwd}` placeholder.
 It expands to the absolute path of the directory from which `pdm run` was invoked, the same value that is exposed
 via the `PDM_RUN_CWD` environment variable.
 
 ```toml
 [tool.pdm.scripts]
-create-symlinks = { shell = "python tools/create_symlinks.py {PDM_RUN_CWD}" }
+create-symlinks = { shell = "python tools/create_symlinks.py {pdm_run_cwd}" }
 ```
 
 ## Show the List of Scripts

--- a/docs/usage/scripts.md
+++ b/docs/usage/scripts.md
@@ -402,15 +402,15 @@ PDM, version 2.8.0 was called as <snip>/venvs/pdm2-8/bin/python -m pdm -V
 !!! note
     While the above example uses PDM 2.8, this functionality was introduced in the 2.10 series and only backported for the showcase.
 
-### `{pdm_run_cwd}` placeholder
+### `{run_cwd}` placeholder
 
-To make scripts referencing the current working directory cross-platform, you can use the `{pdm_run_cwd}` placeholder.
+To make scripts referencing the current working directory cross-platform, you can use the `{run_cwd}` placeholder.
 It expands to the absolute path of the directory from which `pdm run` was invoked, the same value that is exposed
 via the `PDM_RUN_CWD` environment variable.
 
 ```toml
 [tool.pdm.scripts]
-create-symlinks = { shell = "python tools/create_symlinks.py {pdm_run_cwd}" }
+create-symlinks = { shell = "python tools/create_symlinks.py {run_cwd}" }
 ```
 
 ## Show the List of Scripts

--- a/docs/usage/scripts.md
+++ b/docs/usage/scripts.md
@@ -402,6 +402,17 @@ PDM, version 2.8.0 was called as <snip>/venvs/pdm2-8/bin/python -m pdm -V
 !!! note
     While the above example uses PDM 2.8, this functionality was introduced in the 2.10 series and only backported for the showcase.
 
+### `{PDM_RUN_CWD}` placeholder
+
+To make scripts referencing the current working directory cross-platform, you can use the `{PDM_RUN_CWD}` placeholder.
+It expands to the absolute path of the directory from which `pdm run` was invoked, the same value that is exposed
+via the `PDM_RUN_CWD` environment variable.
+
+```toml
+[tool.pdm.scripts]
+create-symlinks = { shell = "python tools/create_symlinks.py {PDM_RUN_CWD}" }
+```
+
 ## Show the List of Scripts
 
 Use `pdm run --list/-l` to show the list of available script shortcuts:

--- a/news/3734.feature.md
+++ b/news/3734.feature.md
@@ -1,1 +1,1 @@
-Add `{PDM_RUN_CWD}` placeholder for scripts to reference the original working directory.
+Add `{pdm_run_cwd}` placeholder for scripts to reference the original working directory.

--- a/news/3734.feature.md
+++ b/news/3734.feature.md
@@ -1,1 +1,1 @@
-Add `{pdm_run_cwd}` placeholder for scripts to reference the original working directory.
+Add `{run_cwd}` placeholder for scripts to reference the original working directory.

--- a/news/3734.feature.md
+++ b/news/3734.feature.md
@@ -1,0 +1,1 @@
+Add `{PDM_RUN_CWD}` placeholder for scripts to reference the original working directory.

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -97,7 +97,7 @@ def _interpolate_cwd(script: str, for_shell: bool = False) -> tuple[str, bool]:
     else:
         cwd = shlex.quote(path)
 
-    interpolated, count = RE_CWD_PLACEHOLDER.subn(cwd, script)
+    interpolated, count = RE_CWD_PLACEHOLDER.subn(lambda _: cwd, script)
     return interpolated, count > 0
 
 

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -58,7 +58,7 @@ def merge_options(*options: TaskOptions | None) -> TaskOptions:
 
 RE_ARGS_PLACEHOLDER = re.compile(r"\{args(?::(?P<default>[^}]*))?\}")
 RE_PDM_PLACEHOLDER = re.compile(r"\{pdm\}")
-RE_CWD_PLACEHOLDER = re.compile(r"\{PDM_RUN_CWD\}")
+RE_CWD_PLACEHOLDER = re.compile(r"\{pdm_run_cwd\}")
 
 
 def _interpolate_args(script: str, args: Sequence[str]) -> tuple[str, bool]:
@@ -105,7 +105,7 @@ def _quote_cwd_for_cmd_exe(path: str) -> str:
 
 
 def _interpolate_cwd(script: str, for_shell: bool = False) -> tuple[str, bool]:
-    """Interpolate the `{PDM_RUN_CWD}` placeholder in a string.
+    """Interpolate the `{pdm_run_cwd}` placeholder in a string.
 
     When ``for_shell`` is true the result is handed directly to the OS shell, so
     on Windows it must be escaped the way ``cmd.exe`` understands (caret-escaped
@@ -124,7 +124,7 @@ def _interpolate_cwd(script: str, for_shell: bool = False) -> tuple[str, bool]:
 
 
 def interpolate(script: str, args: Sequence[str], for_shell: bool = False) -> tuple[str, bool]:
-    """Interpolate the `{args:[defaults]}`, `{pdm}` and `{PDM_RUN_CWD}` placeholders in a string."""
+    """Interpolate the `{args:[defaults]}`, `{pdm}` and `{pdm_run_cwd}` placeholders in a string."""
 
     script, args_interpolated = _interpolate_args(script, args)
     script = _interpolate_pdm(script)

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import itertools
 import os
 import re
 import shlex
@@ -26,7 +25,6 @@ from pdm.signals import pdm_signals
 from pdm.utils import deprecation_warning, expand_env_vars, is_path_relative_to
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
     from types import FrameType
     from typing import Any, TypedDict
 
@@ -56,30 +54,7 @@ def merge_options(*options: TaskOptions | None) -> TaskOptions:
     )
 
 
-RE_ARGS_PLACEHOLDER = re.compile(r"\{args(?::(?P<default>[^}]*))?\}")
-RE_PDM_PLACEHOLDER = re.compile(r"\{pdm\}")
-RE_CWD_PLACEHOLDER = re.compile(r"\{pdm_run_cwd\}")
-
-
-def _interpolate_args(script: str, args: Sequence[str]) -> tuple[str, bool]:
-    """Interpolate the `{args:[defaults]} placeholder in a string"""
-    import shlex
-
-    def replace(m: re.Match[str]) -> str:
-        default = m.group("default") or ""
-        return shlex.join(args) if args else default
-
-    interpolated, count = RE_ARGS_PLACEHOLDER.subn(replace, script)
-    return interpolated, count > 0
-
-
-def _interpolate_pdm(script: str) -> str:
-    """Interpolate the `{pdm} placeholder in a string"""
-    executable_path = Path(sys.executable)
-    pdm_executable = shlex.join([executable_path.as_posix(), "-m", "pdm"])
-
-    interpolated = RE_PDM_PLACEHOLDER.sub(pdm_executable, script)
-    return interpolated
+RE_PLACEHOLDER = re.compile(r"\{(?P<name>[^}:]+)(?::(?P<default>[^}]*))?\}")
 
 
 #: Operators that cmd.exe's own command-line parser treats specially, e.g. `&`
@@ -104,32 +79,35 @@ def _quote_cwd_for_cmd_exe(path: str) -> str:
     return _CMD_EXE_METACHARS.sub(lambda m: "^" + m.group(), path)
 
 
-def _interpolate_cwd(script: str, for_shell: bool = False) -> tuple[str, bool]:
-    """Interpolate the `{pdm_run_cwd}` placeholder in a string.
+def interpolate(script: str, args: Sequence[str], for_shell: bool = False) -> tuple[str, bool]:
+    """Interpolate placeholders in a script.
 
-    When ``for_shell`` is true the result is handed directly to the OS shell, so
-    on Windows it must be escaped the way ``cmd.exe`` understands (caret-escaped
-    metacharacters) rather than with POSIX-only ``shlex.quote``. For the other
-    kinds the string is re-parsed with ``shlex.split`` before use, so POSIX
-    quoting is the correct format on every platform.
+    ``run_cwd`` needs shell-specific quoting on Windows. Other script kinds
+    are re-parsed with ``shlex.split``, so POSIX quoting is used for them on all
+    platforms.
     """
+    pdm = shlex.join([Path(sys.executable).as_posix(), "-m", "pdm"])
     path = str(Path.cwd())
     if for_shell and sys.platform == "win32":
         cwd = _quote_cwd_for_cmd_exe(path)
     else:
         cwd = shlex.quote(path)
+    replacements = {
+        "args": shlex.join(args),
+        "pdm": pdm,
+        "run_cwd": cwd,
+    }
+    interpolated: set[str] = set()
 
-    interpolated, count = RE_CWD_PLACEHOLDER.subn(lambda _: cwd, script)
-    return interpolated, count > 0
+    def replace(match: re.Match[str]) -> str:
+        name = match.group("name")
+        if name not in replacements:
+            return match.group()
+        interpolated.add(name)
+        return replacements[name] or match.group("default") or ""
 
-
-def interpolate(script: str, args: Sequence[str], for_shell: bool = False) -> tuple[str, bool]:
-    """Interpolate the `{args:[defaults]}`, `{pdm}` and `{pdm_run_cwd}` placeholders in a string."""
-
-    script, args_interpolated = _interpolate_args(script, args)
-    script = _interpolate_pdm(script)
-    script, cwd_interpolated = _interpolate_cwd(script, for_shell=for_shell)
-    return script, args_interpolated or cwd_interpolated
+    script = RE_PLACEHOLDER.sub(replace, script)
+    return script, "args" in interpolated
 
 
 _METADATA_REGEX = r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$"
@@ -367,22 +345,21 @@ class TaskRunner:
         shell = False
         if kind == "cmd":
             if isinstance(value, str):
-                cmd, interpolated = interpolate(value, args)
+                cmd, args_interpolated = interpolate(value, args)
                 value = shlex.split(cmd)
             else:
-                agg = [interpolate(part, args) for part in value]
-                interpolated = any(row[1] for row in agg)
-                # In case of multiple default, we need to split the resulting string.
-                parts: Iterator[list[str]] = (
-                    shlex.split(part) if interpolated else [part] for part, interpolated in agg
-                )
-                # We flatten the nested list to obtain a list of arguments
-                value = list(itertools.chain(*parts))
-            args = value if interpolated else [*value, *args]
+                expanded = []
+                args_interpolated = False
+                for part in value:
+                    result, part_args_interpolated = interpolate(part, args)
+                    args_interpolated = args_interpolated or part_args_interpolated
+                    expanded.extend(shlex.split(result) if result != part else [part])
+                value = expanded
+            args = value if args_interpolated else [*value, *args]
         elif kind == "shell":
             assert isinstance(value, str)
-            script, interpolated = interpolate(value, args, for_shell=True)
-            args = script if interpolated else " ".join([script, *args])
+            script, args_interpolated = interpolate(value, args, for_shell=True)
+            args = script if args_interpolated or not args else f"{script} {shlex.join(args)}"
             shell = True
         elif kind == "call":
             assert isinstance(value, str)
@@ -400,17 +377,14 @@ class TaskRunner:
 
         if kind == "composite":
             args = list(args)
-            should_interpolate = any(RE_ARGS_PLACEHOLDER.search(script) for script in value)
-            should_interpolate = should_interpolate or any(RE_PDM_PLACEHOLDER.search(script) for script in value)
-            should_interpolate = should_interpolate or any(RE_CWD_PLACEHOLDER.search(script) for script in value)
+            interpolated_scripts = [interpolate(script, args) for script in value]
+            args_interpolated = any(row[1] for row in interpolated_scripts)
             composite_code = 0
             keep_going = options.pop("keep_going", False) if options else False
-            for script in value:
-                if should_interpolate:
-                    script, _ = interpolate(script, args)
+            for script, _ in interpolated_scripts:
                 split = shlex.split(script)
                 cmd = split[0]
-                subargs = split[1:] + ([] if should_interpolate else args)
+                subargs = split[1:] + ([] if args_interpolated else args)
                 code = self.run(cmd, subargs, merge_options(options, opts), chdir=True, seen=seen)
                 if code != 0:
                     if not keep_going:

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -82,18 +82,40 @@ def _interpolate_pdm(script: str) -> str:
     return interpolated
 
 
+#: Operators that cmd.exe's own command-line parser treats specially, e.g. `&`
+#: for command chaining or `|` for piping. `subprocess.list2cmdline` does not
+#: escape any of these: it only implements the MSVCRT argv-quoting convention
+#: (double quotes understood by a spawned program's argument parser), which is
+#: not the same grammar cmd.exe itself uses when it tokenizes the command line
+#: it was handed. `%` is left alone here since its escaping (doubling) is a
+#: batch-file convention that does not apply to a plain `cmd.exe /c` line.
+_CMD_EXE_METACHARS = re.compile(r"[\^&|<>()]")
+
+
+def _quote_cwd_for_cmd_exe(path: str) -> str:
+    """Escape cmd.exe metacharacters in ``path`` with carets.
+
+    The `^` itself is escaped first so a caret inserted while escaping a later
+    character is never re-escaped. Whitespace is left untouched: cmd.exe's
+    builtin `echo` does not tokenize its argument on spaces (it prints the
+    remainder of the line verbatim) and, unlike quoting, does not print the
+    escaping caret either, so this is safe for both spaced and unspaced paths.
+    """
+    return _CMD_EXE_METACHARS.sub(lambda m: "^" + m.group(), path)
+
+
 def _interpolate_cwd(script: str, for_shell: bool = False) -> tuple[str, bool]:
     """Interpolate the `{PDM_RUN_CWD}` placeholder in a string.
 
     When ``for_shell`` is true the result is handed directly to the OS shell, so
-    on Windows the path must be quoted the way ``cmd.exe`` understands (double
-    quotes) rather than with POSIX-only ``shlex.quote``. For the other kinds the
-    string is re-parsed with ``shlex.split`` before use, so POSIX quoting is the
-    correct format on every platform.
+    on Windows it must be escaped the way ``cmd.exe`` understands (caret-escaped
+    metacharacters) rather than with POSIX-only ``shlex.quote``. For the other
+    kinds the string is re-parsed with ``shlex.split`` before use, so POSIX
+    quoting is the correct format on every platform.
     """
     path = str(Path.cwd())
     if for_shell and sys.platform == "win32":
-        cwd = subprocess.list2cmdline([path])
+        cwd = _quote_cwd_for_cmd_exe(path)
     else:
         cwd = shlex.quote(path)
 

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -58,6 +58,7 @@ def merge_options(*options: TaskOptions | None) -> TaskOptions:
 
 RE_ARGS_PLACEHOLDER = re.compile(r"\{args(?::(?P<default>[^}]*))?\}")
 RE_PDM_PLACEHOLDER = re.compile(r"\{pdm\}")
+RE_CWD_PLACEHOLDER = re.compile(r"\{PDM_RUN_CWD\}")
 
 
 def _interpolate_args(script: str, args: Sequence[str]) -> tuple[str, bool]:
@@ -81,11 +82,20 @@ def _interpolate_pdm(script: str) -> str:
     return interpolated
 
 
+def _interpolate_cwd(script: str) -> str:
+    """Interpolate the `{PDM_RUN_CWD} placeholder in a string"""
+    cwd = shlex.quote(str(Path.cwd()))
+
+    interpolated = RE_CWD_PLACEHOLDER.sub(cwd, script)
+    return interpolated
+
+
 def interpolate(script: str, args: Sequence[str]) -> tuple[str, bool]:
     """Interpolate the `{args:[defaults]} placeholder in a string"""
 
     script, args_interpolated = _interpolate_args(script, args)
     script = _interpolate_pdm(script)
+    script = _interpolate_cwd(script)
     return script, args_interpolated
 
 
@@ -359,6 +369,7 @@ class TaskRunner:
             args = list(args)
             should_interpolate = any(RE_ARGS_PLACEHOLDER.search(script) for script in value)
             should_interpolate = should_interpolate or any(RE_PDM_PLACEHOLDER.search(script) for script in value)
+            should_interpolate = should_interpolate or any(RE_CWD_PLACEHOLDER.search(script) for script in value)
             composite_code = 0
             keep_going = options.pop("keep_going", False) if options else False
             for script in value:

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -82,20 +82,31 @@ def _interpolate_pdm(script: str) -> str:
     return interpolated
 
 
-def _interpolate_cwd(script: str) -> tuple[str, bool]:
-    """Interpolate the `{PDM_RUN_CWD}` placeholder in a string"""
-    cwd = shlex.quote(str(Path.cwd()))
+def _interpolate_cwd(script: str, for_shell: bool = False) -> tuple[str, bool]:
+    """Interpolate the `{PDM_RUN_CWD}` placeholder in a string.
+
+    When ``for_shell`` is true the result is handed directly to the OS shell, so
+    on Windows the path must be quoted the way ``cmd.exe`` understands (double
+    quotes) rather than with POSIX-only ``shlex.quote``. For the other kinds the
+    string is re-parsed with ``shlex.split`` before use, so POSIX quoting is the
+    correct format on every platform.
+    """
+    path = str(Path.cwd())
+    if for_shell and sys.platform == "win32":
+        cwd = subprocess.list2cmdline([path])
+    else:
+        cwd = shlex.quote(path)
 
     interpolated, count = RE_CWD_PLACEHOLDER.subn(cwd, script)
     return interpolated, count > 0
 
 
-def interpolate(script: str, args: Sequence[str]) -> tuple[str, bool]:
+def interpolate(script: str, args: Sequence[str], for_shell: bool = False) -> tuple[str, bool]:
     """Interpolate the `{args:[defaults]}`, `{pdm}` and `{PDM_RUN_CWD}` placeholders in a string."""
 
     script, args_interpolated = _interpolate_args(script, args)
     script = _interpolate_pdm(script)
-    script, cwd_interpolated = _interpolate_cwd(script)
+    script, cwd_interpolated = _interpolate_cwd(script, for_shell=for_shell)
     return script, args_interpolated or cwd_interpolated
 
 
@@ -348,7 +359,7 @@ class TaskRunner:
             args = value if interpolated else [*value, *args]
         elif kind == "shell":
             assert isinstance(value, str)
-            script, interpolated = interpolate(value, args)
+            script, interpolated = interpolate(value, args, for_shell=True)
             args = script if interpolated else " ".join([script, *args])
             shell = True
         elif kind == "call":

--- a/src/pdm/cli/commands/run.py
+++ b/src/pdm/cli/commands/run.py
@@ -82,21 +82,21 @@ def _interpolate_pdm(script: str) -> str:
     return interpolated
 
 
-def _interpolate_cwd(script: str) -> str:
-    """Interpolate the `{PDM_RUN_CWD} placeholder in a string"""
+def _interpolate_cwd(script: str) -> tuple[str, bool]:
+    """Interpolate the `{PDM_RUN_CWD}` placeholder in a string"""
     cwd = shlex.quote(str(Path.cwd()))
 
-    interpolated = RE_CWD_PLACEHOLDER.sub(cwd, script)
-    return interpolated
+    interpolated, count = RE_CWD_PLACEHOLDER.subn(cwd, script)
+    return interpolated, count > 0
 
 
 def interpolate(script: str, args: Sequence[str]) -> tuple[str, bool]:
-    """Interpolate the `{args:[defaults]} placeholder in a string"""
+    """Interpolate the `{args:[defaults]}`, `{pdm}` and `{PDM_RUN_CWD}` placeholders in a string."""
 
     script, args_interpolated = _interpolate_args(script, args)
     script = _interpolate_pdm(script)
-    script = _interpolate_cwd(script)
-    return script, args_interpolated
+    script, cwd_interpolated = _interpolate_cwd(script)
+    return script, args_interpolated or cwd_interpolated
 
 
 _METADATA_REGEX = r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$"

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -453,6 +453,15 @@ def test_interpolate_cwd_placeholder_shell_quoting_on_windows(monkeypatch, tmp_p
     assert shlex.split(cmd_result)[1] == str(spaced_dir)
 
 
+def test_interpolate_cwd_with_backslash_u_in_path(monkeypatch):
+    from pdm.cli.commands.run import _interpolate_cwd
+
+    monkeypatch.setattr(Path, "cwd", staticmethod(lambda: Path(r"C:\Users\pdm")))
+    interpolated, replaced = _interpolate_cwd("echo {PDM_RUN_CWD}")
+    assert replaced
+    assert r"C:\Users\pdm" in interpolated
+
+
 def test_run_expand_env_vars(project, pdm, capfd, monkeypatch):
     (project.root / "test_script.py").write_text("import os; print(os.getenv('FOO'))")
     project.pyproject.settings["scripts"] = {

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -378,6 +378,52 @@ def test_run_cmd_script_with_cwd_placeholder(project, pdm, capfd):
     assert out.strip() == str(project.root)
 
 
+def test_run_shell_script_with_cwd_placeholder_and_spaces_in_path(project, pdm):
+    project.pyproject.settings["scripts"] = {
+        "test_script": {
+            "shell": "echo {PDM_RUN_CWD} > output.txt",
+            "help": "test cwd placeholder with spaces in path",
+        }
+    }
+    project.pyproject.write()
+    spaced_dir = project.root / "sub dir"
+    spaced_dir.mkdir()
+    with cd(spaced_dir):
+        result = pdm(["run", "test_script"], obj=project)
+    assert result.exit_code == 0
+    assert (project.root / "output.txt").read_text().strip() == str(spaced_dir)
+
+
+def test_run_cmd_script_with_cwd_placeholder_and_spaces_in_path(project, pdm, capfd):
+    project.pyproject.settings["scripts"] = {
+        "test_script": ["python", "-c", "import sys; print(sys.argv[1])", "{PDM_RUN_CWD}"],
+    }
+    project.pyproject.write()
+    spaced_dir = project.root / "sub dir"
+    spaced_dir.mkdir()
+    capfd.readouterr()
+    with cd(spaced_dir):
+        result = pdm(["run", "test_script"], obj=project)
+    assert result.exit_code == 0
+    out, _ = capfd.readouterr()
+    assert out.strip() == str(spaced_dir)
+
+
+def test_run_composite_script_with_cwd_placeholder_and_spaces_in_path(project, pdm, capfd):
+    project.pyproject.settings["scripts"] = {
+        "test_script": {"composite": ["echo {PDM_RUN_CWD}"]},
+    }
+    project.pyproject.write()
+    spaced_dir = project.root / "sub dir"
+    spaced_dir.mkdir()
+    capfd.readouterr()
+    with cd(spaced_dir):
+        result = pdm(["run", "test_script"], obj=project)
+    assert result.exit_code == 0
+    out, _ = capfd.readouterr()
+    assert out.strip() == str(spaced_dir)
+
+
 def test_run_expand_env_vars(project, pdm, capfd, monkeypatch):
     (project.root / "test_script.py").write_text("import os; print(os.getenv('FOO'))")
     project.pyproject.settings["scripts"] = {

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -424,6 +424,35 @@ def test_run_composite_script_with_cwd_placeholder_and_spaces_in_path(project, p
     assert out.strip() == str(spaced_dir)
 
 
+def test_interpolate_cwd_placeholder_shell_quoting_on_windows(monkeypatch, tmp_path):
+    """Shell scripts are handed straight to cmd.exe on Windows, so a cwd with
+    spaces must be quoted the way cmd.exe understands (double quotes) instead of
+    with POSIX ``shlex.quote`` (single quotes), which cmd.exe does not parse.
+    CI runs on Linux and cannot spawn a real cmd.exe, so assert on the
+    interpolated string directly."""
+    from pdm.cli.commands import run as run_module
+
+    spaced_dir = tmp_path / "Jane Doe" / "Project"
+    spaced_dir.mkdir(parents=True)
+    monkeypatch.chdir(spaced_dir)
+    monkeypatch.setattr(run_module.sys, "platform", "win32")
+
+    # for_shell=True targets cmd.exe -> must use double-quote quoting.
+    shell_result, interpolated = run_module.interpolate("echo {PDM_RUN_CWD}", [], for_shell=True)
+    assert interpolated
+    assert shell_result == f"echo {subprocess.list2cmdline([str(spaced_dir)])}"
+    assert shell_result == f'echo "{spaced_dir}"'
+    assert "'" not in shell_result
+
+    # cmd/composite parts are re-parsed with shlex.split, so POSIX quoting stays
+    # correct even when simulating Windows.
+    cmd_result, _ = run_module.interpolate("echo {PDM_RUN_CWD}", [])
+    import shlex
+
+    assert cmd_result == f"echo {shlex.quote(str(spaced_dir))}"
+    assert shlex.split(cmd_result)[1] == str(spaced_dir)
+
+
 def test_run_expand_env_vars(project, pdm, capfd, monkeypatch):
     (project.root / "test_script.py").write_text("import os; print(os.getenv('FOO'))")
     project.pyproject.settings["scripts"] = {

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -354,7 +354,7 @@ def test_run_shell_script_with_pdm_placeholder(project, pdm):
 def test_run_shell_script_with_cwd_placeholder(project, pdm):
     project.pyproject.settings["scripts"] = {
         "test_script": {
-            "shell": "echo {PDM_RUN_CWD} > output.txt",
+            "shell": "echo {pdm_run_cwd} > output.txt",
             "help": "test it won't fail",
         }
     }
@@ -367,7 +367,7 @@ def test_run_shell_script_with_cwd_placeholder(project, pdm):
 
 def test_run_cmd_script_with_cwd_placeholder(project, pdm, capfd):
     project.pyproject.settings["scripts"] = {
-        "test_script": ["python", "-c", "import sys; print(sys.argv[1])", "{PDM_RUN_CWD}"],
+        "test_script": ["python", "-c", "import sys; print(sys.argv[1])", "{pdm_run_cwd}"],
     }
     project.pyproject.write()
     capfd.readouterr()
@@ -381,7 +381,7 @@ def test_run_cmd_script_with_cwd_placeholder(project, pdm, capfd):
 def test_run_shell_script_with_cwd_placeholder_and_spaces_in_path(project, pdm):
     project.pyproject.settings["scripts"] = {
         "test_script": {
-            "shell": "echo {PDM_RUN_CWD} > output.txt",
+            "shell": "echo {pdm_run_cwd} > output.txt",
             "help": "test cwd placeholder with spaces in path",
         }
     }
@@ -396,7 +396,7 @@ def test_run_shell_script_with_cwd_placeholder_and_spaces_in_path(project, pdm):
 
 def test_run_cmd_script_with_cwd_placeholder_and_spaces_in_path(project, pdm, capfd):
     project.pyproject.settings["scripts"] = {
-        "test_script": ["python", "-c", "import sys; print(sys.argv[1])", "{PDM_RUN_CWD}"],
+        "test_script": ["python", "-c", "import sys; print(sys.argv[1])", "{pdm_run_cwd}"],
     }
     project.pyproject.write()
     spaced_dir = project.root / "sub dir"
@@ -411,7 +411,7 @@ def test_run_cmd_script_with_cwd_placeholder_and_spaces_in_path(project, pdm, ca
 
 def test_run_composite_script_with_cwd_placeholder_and_spaces_in_path(project, pdm, capfd):
     project.pyproject.settings["scripts"] = {
-        "test_script": {"composite": ["echo {PDM_RUN_CWD}"]},
+        "test_script": {"composite": ["echo {pdm_run_cwd}"]},
     }
     project.pyproject.write()
     spaced_dir = project.root / "sub dir"
@@ -441,7 +441,7 @@ def test_interpolate_cwd_placeholder_shell_quoting_on_windows(monkeypatch, tmp_p
 
     # for_shell=True targets cmd.exe -> spaces pass through unescaped since
     # cmd.exe builtins like echo do not tokenize their argument on whitespace.
-    shell_result, interpolated = run_module.interpolate("echo {PDM_RUN_CWD}", [], for_shell=True)
+    shell_result, interpolated = run_module.interpolate("echo {pdm_run_cwd}", [], for_shell=True)
     assert interpolated
     assert shell_result == f"echo {spaced_dir}"
     assert "'" not in shell_result
@@ -449,7 +449,7 @@ def test_interpolate_cwd_placeholder_shell_quoting_on_windows(monkeypatch, tmp_p
 
     # cmd/composite parts are re-parsed with shlex.split, so POSIX quoting stays
     # correct even when simulating Windows.
-    cmd_result, _ = run_module.interpolate("echo {PDM_RUN_CWD}", [])
+    cmd_result, _ = run_module.interpolate("echo {pdm_run_cwd}", [])
     import shlex
 
     assert cmd_result == f"echo {shlex.quote(str(spaced_dir))}"
@@ -469,7 +469,7 @@ def test_interpolate_cwd_placeholder_escapes_cmd_exe_metacharacters_on_windows(m
     monkeypatch.setattr(run_module.sys, "platform", "win32")
     monkeypatch.setattr(run_module.Path, "cwd", staticmethod(lambda: run_module.Path(r"C:\repo&ver")))
 
-    result, interpolated = run_module.interpolate("echo {PDM_RUN_CWD}", [], for_shell=True)
+    result, interpolated = run_module.interpolate("echo {pdm_run_cwd}", [], for_shell=True)
     assert interpolated
     assert result == r"echo C:\repo^&ver"
     # An unescaped & would be split into two cmd.exe commands.
@@ -484,7 +484,7 @@ def test_interpolate_cwd_placeholder_escapes_all_cmd_exe_operators(monkeypatch, 
     monkeypatch.setattr(run_module.sys, "platform", "win32")
     monkeypatch.setattr(run_module.Path, "cwd", staticmethod(lambda: run_module.Path(path)))
 
-    result, _ = run_module.interpolate("echo {PDM_RUN_CWD}", [], for_shell=True)
+    result, _ = run_module.interpolate("echo {pdm_run_cwd}", [], for_shell=True)
     assert result == f"echo C:\\repo^{metachar}ver"
 
 
@@ -492,7 +492,7 @@ def test_interpolate_cwd_with_backslash_u_in_path(monkeypatch):
     from pdm.cli.commands.run import _interpolate_cwd
 
     monkeypatch.setattr(Path, "cwd", staticmethod(lambda: Path(r"C:\Users\pdm")))
-    interpolated, replaced = _interpolate_cwd("echo {PDM_RUN_CWD}")
+    interpolated, replaced = _interpolate_cwd("echo {pdm_run_cwd}")
     assert replaced
     assert r"C:\Users\pdm" in interpolated
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -354,7 +354,7 @@ def test_run_shell_script_with_pdm_placeholder(project, pdm):
 def test_run_shell_script_with_cwd_placeholder(project, pdm):
     project.pyproject.settings["scripts"] = {
         "test_script": {
-            "shell": "echo {pdm_run_cwd} > output.txt",
+            "shell": "echo {run_cwd} > output.txt",
             "help": "test it won't fail",
         }
     }
@@ -367,7 +367,7 @@ def test_run_shell_script_with_cwd_placeholder(project, pdm):
 
 def test_run_cmd_script_with_cwd_placeholder(project, pdm, capfd):
     project.pyproject.settings["scripts"] = {
-        "test_script": ["python", "-c", "import sys; print(sys.argv[1])", "{pdm_run_cwd}"],
+        "test_script": ["python", "-c", "import sys; print(sys.argv[1])", "{run_cwd}"],
     }
     project.pyproject.write()
     capfd.readouterr()
@@ -381,7 +381,7 @@ def test_run_cmd_script_with_cwd_placeholder(project, pdm, capfd):
 def test_run_shell_script_with_cwd_placeholder_and_spaces_in_path(project, pdm):
     project.pyproject.settings["scripts"] = {
         "test_script": {
-            "shell": "echo {pdm_run_cwd} > output.txt",
+            "shell": "echo {run_cwd} > output.txt",
             "help": "test cwd placeholder with spaces in path",
         }
     }
@@ -389,39 +389,39 @@ def test_run_shell_script_with_cwd_placeholder_and_spaces_in_path(project, pdm):
     spaced_dir = project.root / "sub dir"
     spaced_dir.mkdir()
     with cd(spaced_dir):
-        result = pdm(["run", "test_script"], obj=project)
+        result = pdm(["run", "test_script", "extra arg"], obj=project)
     assert result.exit_code == 0
-    assert (project.root / "output.txt").read_text().strip() == str(spaced_dir)
+    assert (project.root / "output.txt").read_text().strip() == f"{spaced_dir} extra arg"
 
 
 def test_run_cmd_script_with_cwd_placeholder_and_spaces_in_path(project, pdm, capfd):
     project.pyproject.settings["scripts"] = {
-        "test_script": ["python", "-c", "import sys; print(sys.argv[1])", "{pdm_run_cwd}"],
+        "test_script": ["python", "-c", "import sys; print(*sys.argv[1:], sep='|')", "{run_cwd}"],
     }
     project.pyproject.write()
     spaced_dir = project.root / "sub dir"
     spaced_dir.mkdir()
     capfd.readouterr()
     with cd(spaced_dir):
-        result = pdm(["run", "test_script"], obj=project)
+        result = pdm(["run", "test_script", "extra arg"], obj=project)
     assert result.exit_code == 0
     out, _ = capfd.readouterr()
-    assert out.strip() == str(spaced_dir)
+    assert out.strip() == f"{spaced_dir}|extra arg"
 
 
 def test_run_composite_script_with_cwd_placeholder_and_spaces_in_path(project, pdm, capfd):
     project.pyproject.settings["scripts"] = {
-        "test_script": {"composite": ["echo {pdm_run_cwd}"]},
+        "test_script": {"composite": ["echo {run_cwd}"]},
     }
     project.pyproject.write()
     spaced_dir = project.root / "sub dir"
     spaced_dir.mkdir()
     capfd.readouterr()
     with cd(spaced_dir):
-        result = pdm(["run", "test_script"], obj=project)
+        result = pdm(["run", "test_script", "extra arg"], obj=project)
     assert result.exit_code == 0
     out, _ = capfd.readouterr()
-    assert out.strip() == str(spaced_dir)
+    assert out.strip() == f"{spaced_dir} extra arg"
 
 
 def test_interpolate_cwd_placeholder_shell_quoting_on_windows(monkeypatch, tmp_path):
@@ -441,15 +441,15 @@ def test_interpolate_cwd_placeholder_shell_quoting_on_windows(monkeypatch, tmp_p
 
     # for_shell=True targets cmd.exe -> spaces pass through unescaped since
     # cmd.exe builtins like echo do not tokenize their argument on whitespace.
-    shell_result, interpolated = run_module.interpolate("echo {pdm_run_cwd}", [], for_shell=True)
-    assert interpolated
+    shell_result, args_interpolated = run_module.interpolate("echo {run_cwd}", [], for_shell=True)
+    assert not args_interpolated
     assert shell_result == f"echo {spaced_dir}"
     assert "'" not in shell_result
     assert '"' not in shell_result
 
     # cmd/composite parts are re-parsed with shlex.split, so POSIX quoting stays
     # correct even when simulating Windows.
-    cmd_result, _ = run_module.interpolate("echo {pdm_run_cwd}", [])
+    cmd_result, _ = run_module.interpolate("echo {run_cwd}", [])
     import shlex
 
     assert cmd_result == f"echo {shlex.quote(str(spaced_dir))}"
@@ -469,8 +469,8 @@ def test_interpolate_cwd_placeholder_escapes_cmd_exe_metacharacters_on_windows(m
     monkeypatch.setattr(run_module.sys, "platform", "win32")
     monkeypatch.setattr(run_module.Path, "cwd", staticmethod(lambda: run_module.Path(r"C:\repo&ver")))
 
-    result, interpolated = run_module.interpolate("echo {pdm_run_cwd}", [], for_shell=True)
-    assert interpolated
+    result, args_interpolated = run_module.interpolate("echo {run_cwd}", [], for_shell=True)
+    assert not args_interpolated
     assert result == r"echo C:\repo^&ver"
     # An unescaped & would be split into two cmd.exe commands.
     assert "&" not in result.replace("^&", "")
@@ -484,17 +484,24 @@ def test_interpolate_cwd_placeholder_escapes_all_cmd_exe_operators(monkeypatch, 
     monkeypatch.setattr(run_module.sys, "platform", "win32")
     monkeypatch.setattr(run_module.Path, "cwd", staticmethod(lambda: run_module.Path(path)))
 
-    result, _ = run_module.interpolate("echo {pdm_run_cwd}", [], for_shell=True)
+    result, _ = run_module.interpolate("echo {run_cwd}", [], for_shell=True)
     assert result == f"echo C:\\repo^{metachar}ver"
 
 
 def test_interpolate_cwd_with_backslash_u_in_path(monkeypatch):
-    from pdm.cli.commands.run import _interpolate_cwd
+    from pdm.cli.commands.run import interpolate
 
     monkeypatch.setattr(Path, "cwd", staticmethod(lambda: Path(r"C:\Users\pdm")))
-    interpolated, replaced = _interpolate_cwd("echo {pdm_run_cwd}")
-    assert replaced
+    interpolated, args_interpolated = interpolate("echo {run_cwd}", [])
+    assert not args_interpolated
     assert r"C:\Users\pdm" in interpolated
+
+
+def test_interpolate_unknown_placeholder():
+    from pdm.cli.commands.run import interpolate
+
+    script = "echo {unknown:default}"
+    assert interpolate(script, []) == (script, False)
 
 
 def test_run_expand_env_vars(project, pdm, capfd, monkeypatch):
@@ -937,6 +944,18 @@ def test_composite_can_pass_parameters(project, pdm, capfd, _args):
     assert "Second CALLED with param=second" in out
     assert "Post-Second CALLED" in out
     assert "Post-Test CALLED" in out
+
+
+def test_composite_preserves_unknown_placeholder(project, pdm, capfd, _args):
+    project.pyproject.settings["scripts"] = {
+        "test": {"composite": ["first {unknown:default}"]},
+        "first": "python args.py First",
+    }
+    project.pyproject.write()
+    capfd.readouterr()
+    pdm(["run", "test", "param=value"], strict=True, obj=project)
+    out, _ = capfd.readouterr()
+    assert "First CALLED with {unknown:default}, param=value" in out
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -389,9 +389,9 @@ def test_run_shell_script_with_cwd_placeholder_and_spaces_in_path(project, pdm):
     spaced_dir = project.root / "sub dir"
     spaced_dir.mkdir()
     with cd(spaced_dir):
-        result = pdm(["run", "test_script", "extra arg"], obj=project)
+        result = pdm(["run", "test_script"], obj=project)
     assert result.exit_code == 0
-    assert (project.root / "output.txt").read_text().strip() == f"{spaced_dir} extra arg"
+    assert (project.root / "output.txt").read_text().strip() == str(spaced_dir)
 
 
 def test_run_cmd_script_with_cwd_placeholder_and_spaces_in_path(project, pdm, capfd):

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -425,9 +425,11 @@ def test_run_composite_script_with_cwd_placeholder_and_spaces_in_path(project, p
 
 
 def test_interpolate_cwd_placeholder_shell_quoting_on_windows(monkeypatch, tmp_path):
-    """Shell scripts are handed straight to cmd.exe on Windows, so a cwd with
-    spaces must be quoted the way cmd.exe understands (double quotes) instead of
-    with POSIX ``shlex.quote`` (single quotes), which cmd.exe does not parse.
+    """Shell scripts are handed straight to cmd.exe on Windows, so a cwd must be
+    escaped the way cmd.exe's own command-line parser understands (caret-escaped
+    metacharacters) instead of with POSIX ``shlex.quote`` (single quotes), which
+    cmd.exe does not parse, or double quotes, which builtins like `echo` print
+    literally instead of stripping.
     CI runs on Linux and cannot spawn a real cmd.exe, so assert on the
     interpolated string directly."""
     from pdm.cli.commands import run as run_module
@@ -437,12 +439,13 @@ def test_interpolate_cwd_placeholder_shell_quoting_on_windows(monkeypatch, tmp_p
     monkeypatch.chdir(spaced_dir)
     monkeypatch.setattr(run_module.sys, "platform", "win32")
 
-    # for_shell=True targets cmd.exe -> must use double-quote quoting.
+    # for_shell=True targets cmd.exe -> spaces pass through unescaped since
+    # cmd.exe builtins like echo do not tokenize their argument on whitespace.
     shell_result, interpolated = run_module.interpolate("echo {PDM_RUN_CWD}", [], for_shell=True)
     assert interpolated
-    assert shell_result == f"echo {subprocess.list2cmdline([str(spaced_dir)])}"
-    assert shell_result == f'echo "{spaced_dir}"'
+    assert shell_result == f"echo {spaced_dir}"
     assert "'" not in shell_result
+    assert '"' not in shell_result
 
     # cmd/composite parts are re-parsed with shlex.split, so POSIX quoting stays
     # correct even when simulating Windows.
@@ -451,6 +454,38 @@ def test_interpolate_cwd_placeholder_shell_quoting_on_windows(monkeypatch, tmp_p
 
     assert cmd_result == f"echo {shlex.quote(str(spaced_dir))}"
     assert shlex.split(cmd_result)[1] == str(spaced_dir)
+
+
+def test_interpolate_cwd_placeholder_escapes_cmd_exe_metacharacters_on_windows(monkeypatch):
+    """A cwd containing a cmd.exe metacharacter such as `&` must not be handed
+    to cmd.exe unescaped, even without any whitespace in the path: cmd.exe
+    parses `&` as a command separator regardless of quoting via
+    ``subprocess.list2cmdline`` (which only understands MSVCRT argv-quoting,
+    a different grammar from cmd.exe's own command-line parsing), so
+    `echo C:\\repo&ver` would run `echo C:\\repo` followed by a second
+    command `ver`. Caret-escaping is what cmd.exe itself defines for this."""
+    from pdm.cli.commands import run as run_module
+
+    monkeypatch.setattr(run_module.sys, "platform", "win32")
+    monkeypatch.setattr(run_module.Path, "cwd", staticmethod(lambda: run_module.Path(r"C:\repo&ver")))
+
+    result, interpolated = run_module.interpolate("echo {PDM_RUN_CWD}", [], for_shell=True)
+    assert interpolated
+    assert result == r"echo C:\repo^&ver"
+    # An unescaped & would be split into two cmd.exe commands.
+    assert "&" not in result.replace("^&", "")
+
+
+@pytest.mark.parametrize("metachar", ["&", "|", "<", ">", "^", "(", ")"])
+def test_interpolate_cwd_placeholder_escapes_all_cmd_exe_operators(monkeypatch, metachar):
+    from pdm.cli.commands import run as run_module
+
+    path = rf"C:\repo{metachar}ver"
+    monkeypatch.setattr(run_module.sys, "platform", "win32")
+    monkeypatch.setattr(run_module.Path, "cwd", staticmethod(lambda: run_module.Path(path)))
+
+    result, _ = run_module.interpolate("echo {PDM_RUN_CWD}", [], for_shell=True)
+    assert result == f"echo C:\\repo^{metachar}ver"
 
 
 def test_interpolate_cwd_with_backslash_u_in_path(monkeypatch):

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -351,6 +351,33 @@ def test_run_shell_script_with_pdm_placeholder(project, pdm):
     assert (project.root / "output.txt").read_text().strip().startswith("PDM, version")
 
 
+def test_run_shell_script_with_cwd_placeholder(project, pdm):
+    project.pyproject.settings["scripts"] = {
+        "test_script": {
+            "shell": "echo {PDM_RUN_CWD} > output.txt",
+            "help": "test it won't fail",
+        }
+    }
+    project.pyproject.write()
+    with cd(project.root):
+        result = pdm(["run", "test_script"], obj=project)
+    assert result.exit_code == 0
+    assert (project.root / "output.txt").read_text().strip() == str(project.root)
+
+
+def test_run_cmd_script_with_cwd_placeholder(project, pdm, capfd):
+    project.pyproject.settings["scripts"] = {
+        "test_script": ["python", "-c", "import sys; print(sys.argv[1])", "{PDM_RUN_CWD}"],
+    }
+    project.pyproject.write()
+    capfd.readouterr()
+    with cd(project.root):
+        result = pdm(["run", "test_script"], obj=project)
+    assert result.exit_code == 0
+    out, _ = capfd.readouterr()
+    assert out.strip() == str(project.root)
+
+
 def test_run_expand_env_vars(project, pdm, capfd, monkeypatch):
     (project.root / "test_script.py").write_text("import os; print(os.getenv('FOO'))")
     project.pyproject.settings["scripts"] = {


### PR DESCRIPTION
Fixes #3734

Adds a `{PDM_RUN_CWD}` placeholder for PDM scripts so callers can keep PDM-specific paths out of tools that cannot read environment variables. Works in `cmd`, `shell`, and `composite` scripts; paths with spaces are handled via `shlex.quote`. Includes tests and docs.
