### PR TITLE
fix: don't mutate the cached Version when stripping a local segment

### DIFF
--- a/news/3817.bugfix.md
+++ b/news/3817.bugfix.md
@@ -1,0 +1,1 @@
+Keep the cached parsed version intact when stripping the local segment in `comparable_version()`.

--- a/src/pdm/utils.py
+++ b/src/pdm/utils.py
@@ -380,31 +380,9 @@ def comparable_version(version: str) -> Version:
     if parsed.local is not None:
         # strip the local part to make
         # comparable_version("1.2.3+local1") == Version("1.2.3")
-        if hasattr(parsed, "__replace__"):  # packaging >= 26
-            parsed = parsed.__replace__(local=None)
-        else:
-            # packaging < 26 does not have __replace__ method
-            # In this version, we need to manually update _version and recompute _key
-            # Note: In packaging >= 26, _key is a read-only property, but this else branch
-            # only executes on packaging < 26 where _key is a regular attribute that can be
-            # assigned. We use object.__setattr__() instead of direct assignment to satisfy
-            # type checkers that analyze based on the current packaging version.
-            from packaging.version import _cmpkey
-
-            parsed._version = parsed._version._replace(local=None)
-
-            object.__setattr__(
-                parsed,
-                "_key",
-                _cmpkey(
-                    parsed._version.epoch,
-                    parsed._version.release,
-                    parsed._version.pre,
-                    parsed._version.post,
-                    parsed._version.dev,
-                    parsed._version.local,
-                ),
-            )
+        # Build a new Version rather than editing this one: parse_version() is
+        # cached, so the instance is shared with every other caller.
+        parsed = Version(parsed.public)
 
     return parsed
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -481,6 +481,17 @@ def test_comparable_version():
     assert utils.comparable_version("1.2.3a1+local1") == utils.parse_version("1.2.3a1")
 
 
+def test_comparable_version_keeps_parsed_version_intact():
+    # parse_version() is lru_cached, so stripping the local segment in place would
+    # rewrite the instance every other caller shares.
+    cached = utils.parse_version("4.5.6+cu118")
+
+    assert str(utils.comparable_version("4.5.6+cu118")) == "4.5.6"
+
+    assert str(cached) == "4.5.6+cu118"
+    assert utils.parse_version("4.5.6+cu118") > utils.parse_version("4.5.6")
+
+
 @pytest.mark.parametrize("name", ["foO", "f", "3d", "f3", "333", "foo.bar", "foo-bar", "foo_bar", "foo-_.bar"])
 def test_validate_project_name(name):
     assert utils.validate_project_name(name)


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Fixes #3817.

`parse_version()` is `lru_cache`d, so the `Version` it returns is shared with every other caller. `comparable_version()` stripped the local segment by writing through to that instance (`parsed._version = ...` plus an `object.__setattr__` on `_key`), which rewrote the cached object process-wide. After one call, `parse_version("2.1.0+cu118")` returned `2.1.0` and `2.1.0+cu118 > 2.1.0` became `False`.

This replaces both branches with `Version(parsed.public)`, which builds a new object. `Version.public` exists throughout the supported `packaging>22.0` range, so one branch now covers what the `hasattr(__replace__)` split covered, and the private `_version` / `_key` / `_cmpkey` access goes away.

Two things worth flagging for review:

- **Only `packaging < 26` was affected.** The `>= 26` branch already rebound to a new object via `__replace__` and was correct. But `pdm.lock` pins `packaging 26.2`, so CI only ever ran the correct branch — the buggy one is the one users on `packaging < 26` get, and it was never exercised by the test suite. Collapsing to a single path means CI now covers the behavior on any `packaging` version.
- The new regression test is therefore **green on `packaging 26.2` with or without this fix**. I verified red→green on `packaging 25.0`, where the old code fails on `assert str(cached) == "4.5.6+cu118"`. If you'd rather the suite pin this down explicitly on both, I'm happy to add a parametrized case or a `packaging<26` job — say the word.

### Testing

- `test_comparable_version_keeps_parsed_version_intact` fails on `packaging 25.0` before the change (`assert '4.5.6' == '4.5.6+cu118'`) and passes after. The existing `test_comparable_version` passes throughout, so the strip behavior itself is unchanged.
- Ran the suites covering every `comparable_version` call site — `save_version_specifiers` (`cli/utils.py`), `as_pinned_version` (`models/requirements.py`), `as_lockfile_entry` (`models/candidates.py`) — plus the `finder.py` sort-key consumer: `tests/test_utils.py tests/models/ tests/resolver/ tests/cli/test_add.py tests/cli/test_lock.py tests/cli/test_update.py tests/cli/test_list.py tests/cli/test_install.py tests/cli/test_remove.py tests/test_project.py` → **675 passed, 1 skipped** on both `packaging 25.0` and `packaging 26.2`.
- `ruff check`, `ruff format --check`, `mypy src/pdm/utils.py`, and `codespell` are clean.
- I did not run the full suite or a live network resolution.

Disclosure: I used an AI coding assistant (Claude Code) to find this and to help write the fix. I ran the repro and the suites myself against this checkout and I understand the change; happy to answer anything about it.
