### PR TITLE
use_uv: Support adding local files

### DIFF
--- a/news/3822.bugfix.md
+++ b/news/3822.bugfix.md
@@ -1,0 +1,1 @@
+Make `use_uv` support adding local files.

--- a/src/pdm/formats/uv.py
+++ b/src/pdm/formats/uv.py
@@ -181,6 +181,8 @@ class _UvFileBuilder:
         elif isinstance(req, FileRequirement):
             if req.editable:
                 return {"editable": req.str_path}
+            elif req.path:
+                return {"path": req.str_path}
             else:
                 return {"url": req.url}
         else:
@@ -195,10 +197,14 @@ class _UvFileBuilder:
             "version": candidate.version,
             "source": self._build_lock_source(req),
         }
+        is_local = isinstance(req, FileRequirement) and req.path
         for file_hash in candidate.hashes:
             filename = file_hash.get("url", file_hash.get("file", ""))
             is_wheel = filename.endswith(".whl")
-            item = {"url": file_hash.get("url", filename), "hash": file_hash["hash"]}
+            if is_local:
+                item = {"filename": file_hash.get("file", filename), "hash": file_hash["hash"]}
+            else:
+                item = {"url": file_hash.get("url", filename), "hash": file_hash["hash"]}
             if is_wheel:
                 result.setdefault("wheels", []).append(item)
             else:

--- a/src/pdm/resolver/uv.py
+++ b/src/pdm/resolver/uv.py
@@ -133,7 +133,7 @@ class UvResolver(Resolver):
             return req.as_line()
 
         def make_hash(item: dict[str, Any], fallback_url: str | None = None) -> FileHash:
-            url = item.get("url") or fallback_url
+            url = item.get("url") or fallback_url or item.get("filename")
             if url is None:
                 raise KeyError("url")
             link = Link(url)

--- a/tests/resolver/test_uv_resolver.py
+++ b/tests/resolver/test_uv_resolver.py
@@ -122,3 +122,45 @@ def test_parse_uv_lock_with_source_url_fallback(project):
         "file": "mdformat-py-edu-fr.tar.gz",
         "hash": "sha256:124488d1796a7ad5f98b1365fe00ff3e71846fd1f91d46e54f8b73c0cdbd78a1",
     }
+
+
+def test_parse_uv_lock_with_local_path_wheel(project):
+    from pdm.resolver.uv import UvResolver
+
+    lock_path = project.root / "uv.lock"
+    lock_path.write_text(
+        dedent(
+            """
+            version = 1
+            requires-python = ">=3.8"
+
+            [[package]]
+            name = "my-local-pkg"
+            version = "0.1.0"
+            source = { path = "./wheels/my_local_pkg-0.1.0-py3-none-any.whl" }
+
+            [[package.wheels]]
+            filename = "my_local_pkg-0.1.0-py3-none-any.whl"
+            hash = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+
+    resolver = UvResolver(
+        project.environment,
+        requirements=[],
+        target=project.environment.spec,
+        update_strategy="all",
+        strategies=set(),
+    )
+    resolution = resolver._parse_uv_lock(lock_path)
+    candidate = next(iter(resolution.packages)).candidate
+
+    assert candidate.req.path is not None
+    assert candidate.name == "my-local-pkg"
+    assert candidate.hashes[0] == {
+        "url": "my_local_pkg-0.1.0-py3-none-any.whl",
+        "file": "my_local_pkg-0.1.0-py3-none-any.whl",
+        "hash": "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    }

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -100,6 +100,43 @@ def test_build_uv_pyproject_toml_with_workspace(project):
     assert data["tool"]["uv"]["sources"]["bar"] == {"workspace": True}
 
 
+def test_build_uv_lock_with_local_path_wheel(project):
+    from pdm.models.candidates import Candidate
+    from pdm.models.repositories import Package
+    from pdm.models.requirements import FileRequirement
+
+    wheel_name = "first-2.0.2-py2.py3-none-any.whl"
+    wheel_path = FIXTURES / "artifacts" / wheel_name
+    req = FileRequirement.create(path=str(wheel_path), name="first")
+    req.groups = ["default"]
+    candidate = Candidate(req, name="first", version="2.0.2")
+    candidate.hashes.append(
+        {
+            "url": wheel_name,
+            "file": wheel_name,
+            "hash": "sha256:dummy",
+        }
+    )
+    package = Package(candidate, [], "")
+
+    locked_repo = LockedRepository({}, project.sources, project.environment)
+    locked_repo.add_package(package)
+
+    with uv_file_builder(project, ">=3.8", [req], locked_repo) as builder:
+        path = builder.build_uv_lock()
+        with path.open("rb") as fp:
+            data = tomllib.load(fp)
+
+    pkg = next(p for p in data["package"] if p["name"] == "first")
+    assert "path" in pkg["source"], "local wheel source should use 'path', not 'url'"
+    assert "url" not in pkg["source"]
+    wheel_entry = pkg["wheels"][0]
+    assert "filename" in wheel_entry, "local wheel entry should use 'filename', not 'url'"
+    assert "url" not in wheel_entry
+    assert wheel_entry["filename"] == wheel_name
+    assert wheel_entry["hash"] == "sha256:dummy"
+
+
 def test_convert_poetry(project):
     golden_file = FIXTURES / "pyproject.toml"
     assert poetry.check_fingerprint(project, golden_file)


### PR DESCRIPTION
In a project configured `use_uv = true`, this fails:
```
$ pdm add /path/to/file.whl
...
[KeyError]: 'url'
```

Fix this:

src/pdm/resolver/uv.py:make_hash:
- Fallback to `filename` if `url` is missing
- This is the only part which I did by myself, using debug prints. The rest was done by Claude, with rather-shallow review by me.

src/pdm/formats/uv.py:_build_lock_source:
- Support `path`

src/pdm/formats/uv.py:_build_lock_entry:
- Write `filename` if entry is a local file

tests/resolver/test_uv_resolver.py:
- Add a suitable test

tests/test_formats.py:
- Add a suitable test

Assisted-By: Claude Code (Opus 4.6)

## Pull Request Checklist

- [ ] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.