### PR TITLE
perf: defer command action imports

### DIFF
--- a/news/3673.feature.md
+++ b/news/3673.feature.md
@@ -1,0 +1,1 @@
+Defer command action imports until the corresponding command executes.

--- a/src/pdm/cli/commands/init.py
+++ b/src/pdm/cli/commands/init.py
@@ -5,7 +5,6 @@ import sys
 from typing import TYPE_CHECKING, Any, cast
 
 from pdm import termui
-from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.hooks import HookManager
 from pdm.cli.options import skip_option
@@ -329,4 +328,6 @@ class Command(BaseCommand):
         project.maybe_add_to_workspace()
         project.core.ui.echo("Project is initialized successfully", style="primary")
         if self.interactive:
+            from pdm.cli import actions
+
             actions.ask_for_import(project)

--- a/src/pdm/cli/commands/install.py
+++ b/src/pdm/cli/commands/install.py
@@ -3,7 +3,6 @@ import sys
 import sysconfig
 
 from pdm import termui
-from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.filters import GroupSelection
 from pdm.cli.hooks import HookManager
@@ -64,6 +63,8 @@ class Command(BaseCommand):
         project.core.ui.echo(f"Plugins are installed successfully into [primary]{plugin_root}[/].")
 
     def handle(self, project: Project, options: argparse.Namespace) -> None:
+        from pdm.cli import actions
+
         if not project.pyproject.is_valid and termui.is_interactive():
             actions.ask_for_import(project)
 

--- a/src/pdm/cli/commands/list.py
+++ b/src/pdm/cli/commands/list.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from fnmatch import fnmatch
 
-from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.options import venv_option
 from pdm.cli.utils import (
@@ -154,6 +153,8 @@ class Command(BaseCommand):
         # Resolve all the requirements. Map the candidates to distributions.
         requirements = [r for g in selected_groups if g != SUBDEP_GROUP_LABEL for r in project.get_dependencies(g)]
         if options.resolve:
+            from pdm.cli import actions
+
             candidates = actions.resolve_candidates_from_lockfile(
                 project, requirements, groups=selected_groups - {SUBDEP_GROUP_LABEL}
             )

--- a/src/pdm/cli/commands/lock.py
+++ b/src/pdm/cli/commands/lock.py
@@ -4,7 +4,6 @@ import sys
 from typing import cast
 
 from pdm import termui
-from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.filters import GroupSelection
 from pdm.cli.hooks import HookManager
@@ -85,6 +84,8 @@ class Command(BaseCommand):
         target_group.add_argument("--append", action="store_true", help="Append the result to the current lock file")
 
     def handle(self, project: Project, options: argparse.Namespace) -> None:
+        from pdm.cli import actions
+
         if options.check:
             strategy = actions.check_lockfile(project, False)
             if strategy:

--- a/src/pdm/cli/commands/sync.py
+++ b/src/pdm/cli/commands/sync.py
@@ -1,6 +1,5 @@
 import argparse
 
-from pdm.cli import actions
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.filters import GroupSelection
 from pdm.cli.hooks import HookManager
@@ -39,6 +38,8 @@ class Command(BaseCommand):
         )
 
     def handle(self, project: Project, options: argparse.Namespace) -> None:
+        from pdm.cli import actions
+
         actions.check_lockfile(project)
         selection = GroupSelection.from_options(project, options)
         actions.do_sync(

--- a/tests/cli/test_venv.py
+++ b/tests/cli/test_venv.py
@@ -59,6 +59,26 @@ if loaded:
     assert result.returncode == 0, result.stdout or result.stderr
 
 
+def test_core_registration_does_not_import_command_actions():
+    code = """
+import sys
+from pdm.core import Core
+
+Core()
+if "pdm.cli.actions" in sys.modules:
+    raise SystemExit("pdm.cli.actions was imported during command registration")
+"""
+    env = os.environ.copy()
+    src = Path(__file__).resolve().parents[2] / "src"
+    pythonpath = [str(src)]
+    if env.get("PYTHONPATH"):
+        pythonpath.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath)
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, env=env, text=True)
+
+    assert result.returncode == 0, result.stdout or result.stderr
+
+
 @pytest.mark.usefixtures("fake_create")
 def test_venv_create(pdm, project):
     project._saved_python = None


### PR DESCRIPTION
## Summary

- I deferred imports from `pdm.cli.actions` until the `init`, `install`, `list --resolve`, `lock`, or `sync` execution path needs them.
- I added a subprocess regression test that verifies command registration does not import `pdm.cli.actions`.
- I added the required news fragment for #3673.

## Why

`Core.init_parser()` imports command modules to register their arguments. Those modules previously imported the lock and install action layer even for commands such as `pdm --version` and `pdm --help`.

## Validation

- `ruff check` and `ruff format --check` on all changed Python files passed.
- Targeted CLI tests passed: 62 passed, 2 skipped because `uv` is not installed locally.
- `python -X importtime -m pdm --version` no longer loads `pdm.cli.actions` during startup.
- In nine local `python -m pdm --version` runs on Windows, the average decreased from about 1083 ms to 1014 ms. The module-level regression test is the primary guard because wall-clock timing varies by machine.

## Checklist

- [x] A news fragment is included.
- [x] Test coverage is included for the changed startup behavior.
