### PR TITLE
fix(poetry): add an optional dependency to every extra that lists it

### DIFF
--- a/news/3831.bugfix.md
+++ b/news/3831.bugfix.md
@@ -1,0 +1,1 @@
+Add a Poetry optional dependency to every extra that lists it when importing, instead of only the first one.

--- a/src/pdm/formats/poetry.py
+++ b/src/pdm/formats/poetry.py
@@ -167,9 +167,9 @@ class PoetryMetaConverter(MetaConverter):
             optional = getattr(req_dict, "items", None) and req_dict.pop("optional", False)
             for req in _convert_req(key, req_dict):
                 if optional:
-                    extra = next((k for k, v in extras.items() if key in v), None)
-                    if extra:
-                        self._data.setdefault("optional-dependencies", {}).setdefault(extra, []).append(req)
+                    for extra, members in extras.items():
+                        if key in members:
+                            self._data.setdefault("optional-dependencies", {}).setdefault(extra, []).append(req)
                 else:
                     rv.append(req)
         del source["dependencies"]

--- a/tests/fixtures/pyproject.toml
+++ b/tests/fixtures/pyproject.toml
@@ -38,6 +38,7 @@ demo = { path = "./artifacts/demo-0.0.1-py2.py3-none-any.whl" }
 [tool.poetry.extras]
 mysql = ["mysqlclient"]
 pgsql = ["psycopg2"]
+all = ["mysqlclient", "psycopg2"]
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/python-poetry/poetry/issues"

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -172,6 +172,16 @@ def test_convert_poetry(project):
     assert build["excludes"] == ["my_package/excluded.py"]
 
 
+def test_convert_poetry_optional_dependency_in_multiple_extras(project):
+    golden_file = FIXTURES / "pyproject.toml"
+    with cd(FIXTURES):
+        result, _ = poetry.convert(project, golden_file, ns())
+
+    assert result["optional-dependencies"]["mysql"] == ["mysqlclient<2.0,>=1.3"]
+    assert result["optional-dependencies"]["pgsql"] == ["psycopg2<3.0,>=2.7"]
+    assert result["optional-dependencies"]["all"] == ["psycopg2<3.0,>=2.7", "mysqlclient<2.0,>=1.3"]
+
+
 def test_convert_poetry_12(project):
     golden_file = FIXTURES / "poetry-new.toml"
     with cd(FIXTURES):


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

### The problem

Poetry projects routinely declare a "meta" extra that bundles the members of several
narrower ones. `pdm import` silently drops it.

`pyproject.toml` of the project being imported:

```toml
[tool.poetry]
name = "demo"
version = "0.1.0"
description = "demo"
authors = ["Test <test@example.com>"]

[tool.poetry.dependencies]
python = "^3.10"
mysqlclient = { version = "^1.3", optional = true }
psycopg2 = { version = "^2.7", optional = true }

[tool.poetry.extras]
mysql = ["mysqlclient"]
pgsql = ["psycopg2"]
all = ["mysqlclient", "psycopg2"]
```

`pdm import ../pyproject.toml`, reading `[project.optional-dependencies]` out of the
generated file:

| extra | expected | `main` @ `b3cb02ed` | this PR |
|---|---|---|---|
| `mysql` | `["mysqlclient<2.0,>=1.3"]` | `["mysqlclient<2.0,>=1.3"]` | `["mysqlclient<2.0,>=1.3"]` |
| `pgsql` | `["psycopg2<3.0,>=2.7"]` | `["psycopg2<3.0,>=2.7"]` | `["psycopg2<3.0,>=2.7"]` |
| **`all`** | `["mysqlclient<2.0,>=1.3", "psycopg2<3.0,>=2.7"]` | **key absent** | `["mysqlclient<2.0,>=1.3", "psycopg2<3.0,>=2.7"]` |

Verbatim, same input through both source versions:

```
=== [project.optional-dependencies] with poetry.py from: main ===
  mysql = ['mysqlclient<2.0,>=1.3']
  pgsql = ['psycopg2<3.0,>=2.7']
  keys: ['mysql', 'pgsql']

=== [project.optional-dependencies] with poetry.py from: pr ===
  mysql = ['mysqlclient<2.0,>=1.3']
  all = ['mysqlclient<2.0,>=1.3', 'psycopg2<3.0,>=2.7']
  pgsql = ['psycopg2<3.0,>=2.7']
  keys: ['mysql', 'all', 'pgsql']
```

There is no error and no warning — the extra just is not in the imported project. Any
extra whose members are all claimed by an extra declared earlier disappears the same way.

### The cause

`PoetryMetaConverter.dependencies` resolves each optional dependency to exactly **one**
extra (`src/pdm/formats/poetry.py:170`):

```python
extra = next((k for k, v in extras.items() if key in v), None)
if extra:
    self._data.setdefault("optional-dependencies", {}).setdefault(extra, []).append(req)
```

`next()` returns the first match and stops, so `mysqlclient` only ever lands in `mysql`
and `psycopg2` only in `pgsql`; `all` never gets created.

Extra membership is not exclusive in Poetry. poetry-core walks *all* of
`[tool.poetry.extras]` and **appends** each match to a per-dependency `_in_extras` list —
`poetry/core/factory.py:440-453`, poetry-core 2.4.1:

```python
for extra_name, requirements in extras.items():
    extra_name = canonicalize_name(extra_name)
    package_extras[extra_name] = []

    # Checking for dependency
    for req in requirements:
        req = Dependency(req, "*")

        for dep in package.requires:
            if dep.name == req.name:
                dep._in_extras = [*dep._in_extras, extra_name]
                package_extras[extra_name].append(dep)
```

So one dependency can belong to any number of extras, and every extra listed in the table
must appear in the built metadata. This has been the behaviour since the line was written;
`git log -L` shows it untouched since the Ruff migration in #1715.

### The fix

Iterate over every extra instead of stopping at the first match:

```python
for extra, members in extras.items():
    if key in members:
        self._data.setdefault("optional-dependencies", {}).setdefault(extra, []).append(req)
```

Three lines in `src/pdm/formats/poetry.py`. No behaviour change for a project where each
optional dependency appears in exactly one extra — the loop then matches once and does
what `next()` did.

### Tests

`tests/fixtures/pyproject.toml` — the Poetry golden file, which already declares
`mysqlclient`/`psycopg2` as optional with `mysql`/`pgsql` extras — gains one line:

```toml
all = ["mysqlclient", "psycopg2"]
```

and `tests/test_formats.py::test_convert_poetry_optional_dependency_in_multiple_extras`
asserts all three extras.

**I verified the test fails without the fix.** Reverting only `src/pdm/formats/poetry.py`
and keeping the test:

```
    def test_convert_poetry_optional_dependency_in_multiple_extras(project):
        golden_file = FIXTURES / "pyproject.toml"
        with cd(FIXTURES):
            result, _ = poetry.convert(project, golden_file, ns())

        assert result["optional-dependencies"]["mysql"] == ["mysqlclient<2.0,>=1.3"]
        assert result["optional-dependencies"]["pgsql"] == ["psycopg2<3.0,>=2.7"]
>       assert result["optional-dependencies"]["all"] == ["psycopg2<3.0,>=2.7", "mysqlclient<2.0,>=1.3"]
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       KeyError: 'all'

tests/test_formats.py:182: KeyError
FAILED tests/test_formats.py::test_convert_poetry_optional_dependency_in_multiple_extras - KeyError: 'all'
1 failed in 0.69s
```

Restoring the file: `1 passed in 0.68s`.

That golden file is also the input to
`tests/cli/test_others.py::test_import_other_format_file`, so the end-to-end `pdm import`
path now covers the shared-dependency case too, at no extra cost.

### What I ran

| command | `main` @ `b3cb02ed` | this PR |
|---|---|---|
| `pytest -n auto -m "not integration and not network" -q` | 1292 passed, 1 skipped | **1293 passed, 1 skipped** |
| `prek run --all-files` | ruff / ruff format / codespell / mypy all Passed | all Passed |

The one skip is `tests/test_utils.py:171` (Windows-only) on both. I did not run the
`integration`/`network` marked tests or the tox matrix.

### An alternative you may prefer

The emitted order **within** an extra follows `[tool.poetry.dependencies]` declaration
order, not the order written in the extra's member list, because the outer loop is over
dependencies. In the example above `all` comes out as `["mysqlclient…", "psycopg2…"]`
because that is how the dependencies are declared; the test fixture declares `psycopg2`
first and so asserts the reverse. poetry-core orders by the extras list instead.

Making the output follow the extras list means restructuring the loop to iterate extras
outside dependencies, which is a bigger change than the bug warrants — but say the word
and I will switch.

Separately, poetry-core `canonicalize_name()`s the extra name (PEP 685) and this importer
does not. That is a pre-existing gap unrelated to this bug, so I left it alone rather than
bundle it in; happy to file it separately if you want it fixed.

---

*Disclosure: I used an AI coding assistant (Claude Code) to find this and to help write
the fix.*
