### PR TITLE
fix(flit): don't emit null values when importing a flit project

### DIFF
--- a/news/3832.bugfix.md
+++ b/news/3832.bugfix.md
@@ -1,0 +1,1 @@
+Do not write null values into the generated `pyproject.toml` when importing a flit project that omits `author-email`/`maintainer-email` or sets only one of `include` and `exclude` in `[tool.flit.sdist]`.

--- a/src/pdm/formats/flit.py
+++ b/src/pdm/formats/flit.py
@@ -35,9 +35,11 @@ def check_fingerprint(project: Project | None, filename: PathLike) -> bool:
 
 
 def _get_author(metadata: dict[str, Any], type_: str = "author") -> list[str]:
-    name = metadata.pop(type_)
+    author = {"name": metadata.pop(type_)}
     email = metadata.pop(f"{type_}-email", None)
-    return cast(list[str], array_of_inline_tables([{"name": name, "email": email}]))
+    if email is not None:
+        author["email"] = email
+    return cast(list[str], array_of_inline_tables([author]))
 
 
 def get_docstring_and_version_via_ast(
@@ -137,9 +139,11 @@ class FlitMetaConverter(MetaConverter):
 
     @convert_from("sdist")
     def includes(self, value: dict[str, list[str]]) -> None:
-        self.settings.setdefault("build", {}).update(
-            {"excludes": value.get("exclude"), "includes": value.get("include")}
-        )
+        build = self.settings.setdefault("build", {})
+        if "exclude" in value:
+            build["excludes"] = value["exclude"]
+        if "include" in value:
+            build["includes"] = value["include"]
         raise Unset()
 
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -215,6 +215,38 @@ def test_convert_flit(project):
     assert build["excludes"] == ["doc/*.html"]
 
 
+def test_convert_flit_author_and_maintainer_without_email(project, tmp_path):
+    pyproject_file = tmp_path / "pyproject.toml"
+    pyproject_file.write_text(
+        '[tool.flit.metadata]\nmodule = "flit"\nauthor = "Thomas Kluyver"\nmaintainer = "Frost Ming"\n',
+        encoding="utf-8",
+    )
+    result, _ = flit.convert(project, pyproject_file, None)
+
+    assert result["authors"] == [{"name": "Thomas Kluyver"}]
+    assert result["maintainers"] == [{"name": "Frost Ming"}]
+
+
+@pytest.mark.parametrize(
+    "sdist_table,expected_build",
+    [
+        ('include = ["doc/"]', {"includes": ["doc/"]}),
+        ('exclude = ["doc/*.html"]', {"excludes": ["doc/*.html"]}),
+    ],
+)
+def test_convert_flit_sdist_with_one_of_include_and_exclude(project, tmp_path, sdist_table, expected_build):
+    pyproject_file = tmp_path / "pyproject.toml"
+    pyproject_file.write_text(
+        '[tool.flit.metadata]\nmodule = "flit"\nauthor = "Thomas Kluyver"\n'
+        'author-email = "thomas@kluyver.me.uk"\n\n'
+        f"[tool.flit.sdist]\n{sdist_table}\n",
+        encoding="utf-8",
+    )
+    _, settings = flit.convert(project, pyproject_file, None)
+
+    assert settings["build"] == expected_build
+
+
 def test_convert_error_preserve_metadata(project):
     pyproject_file = FIXTURES / "poetry-error.toml"
     try:


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

### The problem

Two optional keys in `[tool.flit.*]` make `pdm import` abort. In both cases the importer
builds a value of `None`, which tomlkit cannot represent, so the import fails and nothing
is written to `pyproject.toml`.

**1. A modern PEP 621 flit project that sets only `exclude` in `[tool.flit.sdist]`**

The project being imported — no `[tool.flit.metadata]` at all, this is the layout
flit_core ≥ 3.2 recommends:

```toml
[build-system]
requires = ["flit_core >=3.2,<4"]
build-backend = "flit_core.buildapi"

[project]
name = "mymod"
version = "0.1.0"
description = "A modern flit project"
authors = [{name = "Test Author", email = "t@example.com"}]
requires-python = ">=3.9"
dependencies = ["requests>=2.6"]

[tool.flit.sdist]
exclude = ["doc/*.html"]
```

`check_fingerprint` only looks for a `tool.flit` table, so a bare `pdm import` auto-detects
this as flit — no `-f` needed:

```
=== pdm import (bare, auto-detect) with flit.py from: main ===
[ConvertError]: Unable to convert an object of <class 'NoneType'> to a TOML item
WARNING: Add '-v' to see the detailed traceback
--- resulting [tool.pdm.build] ---
(absent)

=== pdm import (bare, auto-detect) with flit.py from: thispr ===
Changes are written to pyproject.toml.
--- resulting [tool.pdm.build] ---
[tool.pdm.build]
excludes = ["doc/*.html"]
```

Setting only one of the two keys is valid: flit_core reads them independently, each
defaulting to `[]` — `flit_core/config.py:153-161`, flit_core 3.12.0:

```python
loaded_cfg.sdist_include_patterns = _check_glob_patterns(
    dtool['sdist'].get('include', []), 'include'
)
exclude = [
    "**/__pycache__",
    "**.pyc",
] + dtool['sdist'].get('exclude', [])
loaded_cfg.sdist_exclude_patterns = _check_glob_patterns(
    exclude, 'exclude'
)
```

**2. A legacy-layout project with an author name and no email**

```toml
[tool.flit.metadata]
module = "mymod"
author = "Test Author"
```

```
$ pdm import -f flit ../pyproject.toml
[MetaConvertError]:
name: Unable to convert an object of <class 'NoneType'> to a TOML item
```

Also valid: `author-email` is in flit_core's `metadata_allowed_fields` but
`metadata_required_fields` is only `{module, author}` — `flit_core/config.py:51-54`,
flit_core 3.12.0:

```python
metadata_required_fields = {
    'module',
    'author',
}
```

Same for `maintainer` without `maintainer-email`.

| input | expected | `main` @ `b3cb02ed` |
|---|---|---|
| PEP 621 project, `[tool.flit.sdist]` with only `exclude` | `[tool.pdm.build] excludes = [...]` | `ConvertError`, import aborts, nothing written |
| PEP 621 project, `[tool.flit.sdist]` with only `include` | `[tool.pdm.build] includes = [...]` | `ConvertError`, import aborts, nothing written |
| `author` without `author-email` | `authors = [{name = "Test Author"}]` | `MetaConvertError`, import aborts |
| `maintainer` without `maintainer-email` | `maintainers = [{name = "..."}]` | `MetaConvertError`, import aborts |

### The cause

Both sites write the optional key unconditionally.

`src/pdm/formats/flit.py:38-40`:

```python
name = metadata.pop(type_)
email = metadata.pop(f"{type_}-email", None)
return cast(list[str], array_of_inline_tables([{"name": name, "email": email}]))
```

`src/pdm/formats/flit.py:140-142`:

```python
self.settings.setdefault("build", {}).update(
    {"excludes": value.get("exclude"), "includes": value.get("include")}
)
```

When the source omits the key, `email` — respectively the missing `get()` — is `None`.
`tomlkit.inline_table().update(...)` raises immediately for the author case; the sdist
case survives conversion and blows up when `[tool.pdm.build]` is written in
`import_cmd.do_import`.

### The fix

Only set the key when the source provides it. This is what the Poetry importer already
does for a missing email: `parse_name_email` filters out the `None` groups of the
name/email regex match (`src/pdm/formats/poetry.py:116-126`).

The `excludes`-before-`includes` insertion order is deliberately preserved, so a project
that sets **both** keys — the common case, and what the `flit-demo` fixture uses —
generates a byte-identical file. Running `pdm import -f flit` on
`tests/fixtures/projects/flit-demo/pyproject.toml` under both source versions:

```
### main vs this PR ###
no differences
5edda2664b636d03c3f7488ab55939fedf3d0daf37769ae83c40a05114a29ae7  out_main/pyproject.toml
5edda2664b636d03c3f7488ab55939fedf3d0daf37769ae83c40a05114a29ae7  out_thispr/pyproject.toml
```

### Tests

Two new tests in `tests/test_formats.py`, next to `test_convert_flit`:

- `test_convert_flit_author_and_maintainer_without_email`
- `test_convert_flit_sdist_with_one_of_include_and_exclude`, parametrised over
  include-only and exclude-only

The sdist fixture carries an `author-email` on purpose, so it fails for the sdist reason
and not the author one — the two halves are proven independently.

**I verified all three fail without the fix.** Reverting only `src/pdm/formats/flit.py` to
`origin/main` and keeping the tests:

```
    def test_convert_flit_author_and_maintainer_without_email(project, tmp_path):
>       result, _ = flit.convert(project, pyproject_file, None)
>           raise MetaConvertError(errors, data=self._data, settings=self.settings)
E           pdm.formats.base.MetaConvertError:
E           name: Unable to convert an object of <class 'NoneType'> to a TOML item

    def test_convert_flit_sdist_with_one_of_include_and_exclude(project, tmp_path, sdist_table, expected_build):
>       assert settings["build"] == expected_build
E       AssertionError: assert {'excludes': ...es': ['doc/']} == {'includes': ['doc/']}
E         Left contains 1 more item:
E         {'excludes': None}
E         Full diff:
E           {
E         +     'excludes': None,
E               'includes': [
E                   'doc/',
E               ],
E           }

    def test_convert_flit_sdist_with_one_of_include_and_exclude(project, tmp_path, sdist_table, expected_build):
>       assert settings["build"] == expected_build
E       AssertionError: assert {'excludes': ...cludes': None} == {'excludes': ['doc/*.html']}
E         Left contains 1 more item:
E         {'includes': None}
E         Full diff:
E           {
E               'excludes': [
E                   'doc/*.html',
E               ],
E         +     'includes': None,
E           }

3 failed, 21 deselected in 0.93s
```

Restoring the file: `4 passed, 20 deselected in 0.74s` (the three new ones plus the
pre-existing `test_convert_flit`).

Beyond the unit tests I ran the real CLI against both inputs in a scratch project; the
transcripts above are that run.

### What I ran

| command | `main` @ `b3cb02ed` | this PR |
|---|---|---|
| `pytest -n auto -m "not integration and not network" -q` | 1292 passed, 1 skipped | **1295 passed, 1 skipped** |
| `prek run --all-files` | ruff / ruff format / codespell / mypy all Passed | all Passed |

The one skip is `tests/test_utils.py:171` (Windows-only) on both. I did not run the
`integration`/`network` marked tests or the tox matrix.

---

*Disclosure: I used an AI coding assistant (Claude Code) to find this and to help write
the fix.*
