### PR TITLE
perf: defer Python installer import

### DIFF
--- a/news/3673.feature.md
+++ b/news/3673.feature.md
@@ -1,1 +1,1 @@
-Defer command action imports until the corresponding command executes.
+Defer command action and Python installer imports until their corresponding runtime paths execute.

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import tomlkit
-from pbs_installer import PythonVersion
 
 from pdm._types import NotSet, NotSetType, RepositoryConfig
 from pdm.compat import CompatibleSequence, tomllib
@@ -47,6 +46,7 @@ from pdm.utils import (
 
 if TYPE_CHECKING:
     from findpython import Finder
+    from pbs_installer import PythonVersion
 
     from pdm.core import Core
     from pdm.environments import BaseEnvironment

--- a/tests/cli/test_venv.py
+++ b/tests/cli/test_venv.py
@@ -32,7 +32,7 @@ def fake_create(monkeypatch):
     monkeypatch.setattr(backends.CondaBackend, "perform_create", fake_create)
 
 
-def test_core_registration_does_not_import_venv_runtime_helpers():
+def test_core_registration_does_not_import_runtime_helpers():
     code = """
 import sys
 from pdm.core import Core
@@ -41,6 +41,7 @@ Core()
 lazy_modules = {
     "pdm.cli.commands.venv.backends",
     "pdm.cli.commands.venv.utils",
+    "pbs_installer",
     "shellingham",
 }
 loaded = sorted(lazy_modules.intersection(sys.modules))


### PR DESCRIPTION
Fixes #3673.

## Summary

- move the `PythonVersion` import behind `TYPE_CHECKING`, so command registration does not load `pbs_installer`
- extend the clean-subprocess startup regression to cover the Python installer package
- update the existing #3673 news fragment

## Why

`pdm.project.core` only uses `PythonVersion` in deferred annotations. Importing it at module load time also imports the Python installer stack for commands that never install a Python interpreter.

## Validation

- the startup regression failed before the change with `pbs_installer` loaded and passes after the change
- targeted startup and minimum/maximum matching tests: 3 passed
- `tests/cli/test_venv.py` and `tests/test_project.py`: 104 passed, 3 skipped
- non-integration suite: 1279 passed, 25 skipped, 1 xfailed; the remaining 4 Windows environment failures were reproduced on unchanged `main` (symlink privilege and unavailable POSIX `cat`/`echo` commands)
- Ruff check and format check passed for the changed Python files
- Codespell and `git diff --check` passed
- Mypy passed for `src/pdm/project/core.py`; the full locally resolved run had the same 38 dependency-version errors on this branch and unchanged `main`