### PR TITLE
fix: support old Python targets with dep-logic 0.7

### DIFF
--- a/news/3838.bugfix.md
+++ b/news/3838.bugfix.md
@@ -1,0 +1,1 @@
+Keep environment inspection working for Python 3.9 targets when PDM uses dep-logic 0.7 or newer.

--- a/pdm.lock
+++ b/pdm.lock
@@ -542,16 +542,16 @@ files = [
 
 [[package]]
 name = "dep-logic"
-version = "0.5.2"
-requires_python = ">=3.8"
+version = "0.7.1"
+requires_python = ">=3.10"
 summary = "Python dependency specifications supporting logical operations"
 groups = ["default"]
 dependencies = [
     "packaging>=22",
 ]
 files = [
-    {file = "dep_logic-0.5.2-py3-none-any.whl", hash = "sha256:0e72ab6676afd32fe8702896a8b9886bddd6ccd457b77ba360e7b6c4c95ce4c0"},
-    {file = "dep_logic-0.5.2.tar.gz", hash = "sha256:f8dc4a74d1bad0d35a45c236572cf5d6534b5c2e84de87f2a354c849eec7e562"},
+    {file = "dep_logic-0.7.1-py3-none-any.whl", hash = "sha256:38b96555083a8efdd62a6987e49f65eb3778fe4c8189e83b3429ca6b6412d196"},
+    {file = "dep_logic-0.7.1.tar.gz", hash = "sha256:4bf66e3b323e0c30d2ed268c44efd69c179c10cdf499c28ca316c2cb49e95ee2"},
 ]
 
 [[package]]

--- a/src/pdm/environments/base.py
+++ b/src/pdm/environments/base.py
@@ -14,6 +14,9 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from packaging.specifiers import SpecifierSet
+from packaging.version import InvalidVersion
+
 from pdm._types import NotSet, NotSetType
 from pdm.exceptions import BuildError, PdmUsageError
 from pdm.models.in_process import get_env_spec
@@ -52,6 +55,42 @@ class BaseEnvironment(abc.ABC):
             self._interpreter = project.python
         else:
             self._interpreter = PythonInfo.from_path(python)
+        self._env_spec_compat_lib = (
+            self._ensure_compat_lib() if (self.interpreter.major, self.interpreter.minor) < (3, 10) else None
+        )
+
+    def _ensure_compat_lib(self) -> str:
+        import filelock
+
+        compat_versions = {"dep-logic": "<0.7"}
+        compat_lib = self.project.cache(".compat_libs")
+
+        def is_compatible(pkg: str, specifier: str) -> bool:
+            try:
+                version = WorkingSet([str(compat_lib)])[pkg].version
+                return version in SpecifierSet(specifier)
+            except (InvalidVersion, KeyError):
+                return False
+
+        with filelock.FileLock(compat_lib.with_name(f"{compat_lib.name}.lock"), is_singleton=True):
+            for pkg, specifier in compat_versions.items():
+                if not is_compatible(pkg, specifier):
+                    host_environment = BareEnvironment(self.project)
+                    requirement = f"{pkg}{specifier}"
+                    self.project.core.ui.info(f"Installing {requirement} for Python < 3.10 compatibility")
+                    subprocess.check_call(
+                        [
+                            *host_environment.pip_command,
+                            "install",
+                            "--upgrade",
+                            "--target",
+                            str(compat_lib),
+                            requirement,
+                        ],
+                        stdout=subprocess.DEVNULL,
+                    )
+
+        return str(compat_lib)
 
     @cached_property
     def auth(self) -> PdmBasicAuth:
@@ -189,7 +228,7 @@ class BaseEnvironment(abc.ABC):
 
     @cached_property
     def spec(self) -> EnvSpec:
-        return get_env_spec(self.interpreter.executable.as_posix())
+        return get_env_spec(self.interpreter.executable.as_posix(), self._env_spec_compat_lib)
 
     @property
     def allow_all_spec(self) -> EnvSpec:

--- a/src/pdm/environments/base.py
+++ b/src/pdm/environments/base.py
@@ -55,9 +55,12 @@ class BaseEnvironment(abc.ABC):
             self._interpreter = project.python
         else:
             self._interpreter = PythonInfo.from_path(python)
-        self._env_spec_compat_lib = (
-            self._ensure_compat_lib() if (self.interpreter.major, self.interpreter.minor) < (3, 10) else None
-        )
+
+    @cached_property
+    def _env_spec_compat_lib(self) -> str | None:
+        if (self.interpreter.major, self.interpreter.minor) >= (3, 10):
+            return None
+        return self._ensure_compat_lib()
 
     def _ensure_compat_lib(self) -> str:
         import filelock

--- a/src/pdm/models/in_process/__init__.py
+++ b/src/pdm/models/in_process/__init__.py
@@ -47,14 +47,19 @@ def parse_setup_py(executable: str, path: str) -> dict[str, Any]:
 
 
 @functools.lru_cache
-def get_env_spec(executable: str) -> EnvSpec:
+def get_env_spec(executable: str, compat_lib: str | None = None) -> EnvSpec:
     """Get the environment spec of the python interpreter"""
     import importlib.metadata
 
     from pdm.models.markers import EnvSpec
 
-    required_libs = ["dep_logic", "packaging"]
-    shared_libs = {str(importlib.metadata.distribution(lib).locate_file("")) for lib in required_libs}
+    if compat_lib is None:
+        required_libs = ["dep_logic", "packaging"]
+        shared_libs = list(
+            dict.fromkeys(str(importlib.metadata.distribution(lib).locate_file("")) for lib in required_libs)
+        )
+    else:
+        shared_libs = [compat_lib]
 
     with _in_process_script("env_spec.py") as script:
         return EnvSpec.from_spec(**json.loads(subprocess.check_output([executable, "-EsS", script, *shared_libs])))

--- a/tests/environments/test_environment.py
+++ b/tests/environments/test_environment.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 import sysconfig
 from pathlib import Path
@@ -6,7 +7,9 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
+from pdm.environments.base import BareEnvironment
 from pdm.environments.local import PythonLocalEnvironment
+from pdm.environments.python import PythonEnvironment
 from pdm.utils import pdm_scheme
 
 
@@ -125,6 +128,54 @@ def test_script_kind_posix(local_env):
     # On non-Windows platforms, script_kind should be posix
     if os.name != "nt":
         assert local_env.script_kind == "posix"
+
+
+def test_old_python_installs_compatible_dep_logic(project, mocker):
+    compat_lib = project.cache_dir / ".compat_libs"
+    host_interpreter = project.python
+    interpreter = SimpleNamespace(
+        executable=Path("/python3.9"),
+        major=3,
+        minor=9,
+    )
+    mocker.patch(
+        "pdm.environments.base.PythonInfo.from_path",
+        side_effect=lambda path: interpreter if Path(path) == interpreter.executable else host_interpreter,
+    )
+    mocker.patch.object(BareEnvironment, "pip_command", ["host-python", "-m", "pip"])
+    working_set = mocker.patch("pdm.environments.base.WorkingSet")
+    working_set.return_value.__getitem__.side_effect = KeyError("dep-logic")
+    check_call = mocker.patch("pdm.environments.base.subprocess.check_call")
+    get_env_spec = mocker.patch("pdm.environments.base.get_env_spec", return_value=mocker.sentinel.spec)
+
+    environment = PythonEnvironment(project, python=str(interpreter.executable))
+
+    check_call.assert_called_once_with(
+        [
+            "host-python",
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "--target",
+            str(compat_lib),
+            "dep-logic<0.7",
+        ],
+        stdout=subprocess.DEVNULL,
+    )
+    assert environment.spec is mocker.sentinel.spec
+    get_env_spec.assert_called_once_with(str(interpreter.executable), str(compat_lib))
+
+
+def test_compatible_dep_logic_is_reused(project, mocker):
+    environment = PythonLocalEnvironment(project)
+    distribution = SimpleNamespace(version="0.6.0")
+    working_set = mocker.patch("pdm.environments.base.WorkingSet")
+    working_set.return_value.__getitem__.return_value = distribution
+    check_call = mocker.patch("pdm.environments.base.subprocess.check_call")
+
+    assert environment._ensure_compat_lib() == str(project.cache_dir / ".compat_libs")
+    check_call.assert_not_called()
 
 
 def test_which_python_variants(local_env):

--- a/tests/environments/test_environment.py
+++ b/tests/environments/test_environment.py
@@ -150,6 +150,8 @@ def test_old_python_installs_compatible_dep_logic(project, mocker):
 
     environment = PythonEnvironment(project, python=str(interpreter.executable))
 
+    check_call.assert_not_called()
+    assert environment.spec is mocker.sentinel.spec
     check_call.assert_called_once_with(
         [
             "host-python",
@@ -163,8 +165,7 @@ def test_old_python_installs_compatible_dep_logic(project, mocker):
         ],
         stdout=subprocess.DEVNULL,
     )
-    assert environment.spec is mocker.sentinel.spec
-    get_env_spec.assert_called_once_with(str(interpreter.executable), str(compat_lib))
+    get_env_spec.assert_called_once_with(interpreter.executable.as_posix(), str(compat_lib))
 
 
 def test_compatible_dep_logic_is_reused(project, mocker):


### PR DESCRIPTION
Fixes #3838.

## Summary

- install `dep-logic<0.7` into `CACHE_DIR/.compat_libs` when inspecting a Python target older than 3.10
- use the compatibility directory only for the target-interpreter environment probe while keeping `dep-logic==0.7.1` in PDM's lockfile
- serialize compatibility installs and reuse an existing compatible package

## Test plan

- [x] `pytest -p no:rerunfailures tests/environments -q`
- [x] `pdm lock --check`
- [x] Ruff check and format
- [x] codespell and mypy commit hooks

## Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.
