### PR TITLE
fix(formats): --trusted-host ignores the port on import and drops it on export

### DIFF
--- a/news/3845.bugfix.md
+++ b/news/3845.bugfix.md
@@ -1,0 +1,1 @@
+Match `--trusted-host` on host and port when importing a `requirements.txt` file, and keep the port when exporting one.

--- a/src/pdm/formats/requirements.py
+++ b/src/pdm/formats/requirements.py
@@ -125,12 +125,34 @@ def check_fingerprint(project: Project, filename: PathLike) -> bool:
             return False
 
 
+def _split_host_port(netloc: str) -> tuple[str, int | None]:
+    """Split a ``host[:port]`` string into a lowercased host and an optional port.
+
+    ``urlsplit`` is used so that a bracketed IPv6 literal such as ``[::1]:8443``
+    is split on the right colon. An unparsable port is reported as absent rather
+    than raising, so a malformed value can never abort the import.
+    """
+    parsed = urllib.parse.urlsplit(f"//{netloc}")
+    try:
+        port = parsed.port
+    except ValueError:  # pragma: no cover - malformed port, e.g. `host:abc`
+        port = None
+    return (parsed.hostname or "").lower(), port
+
+
 def _is_url_trusted(url: str, trusted_hosts: list[str]) -> bool:
-    parsed = urllib.parse.urlparse(url)
-    netloc, host = parsed.netloc, parsed.hostname
+    """Check whether *url* is covered by one of pip's ``--trusted-host`` values.
+
+    Matching is done on host and port only. The userinfo part of the URL is not
+    compared, so credentials embedded in an index URL don't defeat the match, and
+    a trusted host given without a port matches the URL whatever its port is,
+    which is how pip treats it.
+    """
+    host, port = _split_host_port(urllib.parse.urlparse(url).netloc)
 
     for trusted in trusted_hosts:
-        if trusted in (host, netloc):
+        trusted_host, trusted_port = _split_host_port(trusted)
+        if trusted_host == host and trusted_port in (None, port):
             return True
     return False
 
@@ -244,6 +266,10 @@ def export(
                 raise ValueError(f"Unknown source type: {source_type}")
         lines.append(f"{prefix} {url}\n")
         if source.verify_ssl is False:
-            host = urllib.parse.urlparse(url).hostname
-            lines.append(f"--trusted-host {host}\n")
+            # Keep the port: `--trusted-host example.org` does not cover
+            # `https://example.org:8443/simple` for pip.
+            host, port = _split_host_port(urllib.parse.urlparse(url).netloc)
+            if ":" in host:  # an IPv6 literal has to stay bracketed
+                host = f"[{host}]"
+            lines.append(f"--trusted-host {host}{f':{port}' if port else ''}\n")
     return "".join(lines)

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -344,6 +344,60 @@ def test_export_find_links(project, monkeypatch):
     assert result.strip().splitlines()[-1] == f"--find-links {url}"
 
 
+@pytest.mark.parametrize(
+    "url,trusted_host",
+    [
+        # A port in the trusted host must not be lost when matching.
+        ("https://mirror.example.org:8443/simple", "mirror.example.org:8443"),
+        # Credentials in the index URL are not part of the host.
+        ("https://user:pw@mirror.example.org:8443/simple", "mirror.example.org:8443"),
+        ("https://user@mirror.example.org/simple", "mirror.example.org"),
+        # A trusted host without a port matches whatever port the URL uses.
+        ("https://mirror.example.org:8443/simple", "mirror.example.org"),
+        # Host comparison is case-insensitive.
+        ("https://Mirror.Example.ORG/simple", "mirror.example.org"),
+        # IPv6 literals stay bracketed.
+        ("https://[::1]:8443/simple", "[::1]:8443"),
+    ],
+)
+def test_import_requirements_trusted_host(project, tmp_path, url, trusted_host):
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text(f"--index-url {url}\n--trusted-host {trusted_host}\n", encoding="utf-8")
+    _, settings = requirements.convert(project, req_file, ns())
+    assert settings["source"] == [{"name": "pypi", "url": url, "verify_ssl": False}]
+
+
+@pytest.mark.parametrize(
+    "url,trusted_host",
+    [
+        ("https://mirror.example.org:8443/simple", "mirror.example.org:8443"),
+        ("https://user:pw@mirror.example.org:8443/simple", "mirror.example.org:8443"),
+        ("https://mirror.example.org/simple", "mirror.example.org"),
+        ("https://[::1]:8443/simple", "[::1]:8443"),
+    ],
+)
+def test_export_trusted_host_keeps_port(project, url, trusted_host):
+    project.pyproject.settings["source"] = [{"url": url, "name": "pypi", "verify_ssl": False}]
+    result = requirements.export(project, [], ns())
+    assert result.strip().splitlines()[-1] == f"--trusted-host {trusted_host}"
+
+
+@pytest.mark.parametrize(
+    "url,trusted_host",
+    [
+        # A different port is not covered by the trusted host.
+        ("https://mirror.example.org:8443/simple", "mirror.example.org:9999"),
+        ("https://mirror.example.org/simple", "mirror.example.org:8443"),
+        ("https://other.example.org:8443/simple", "mirror.example.org:8443"),
+    ],
+)
+def test_import_requirements_untrusted_host(project, tmp_path, url, trusted_host):
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text(f"--index-url {url}\n--trusted-host {trusted_host}\n", encoding="utf-8")
+    _, settings = requirements.convert(project, req_file, ns())
+    assert settings["source"] == [{"name": "pypi", "url": url, "verify_ssl": True}]
+
+
 def test_export_replace_project_root(project):
     artifact = FIXTURES / "artifacts/first-2.0.2-py2.py3-none-any.whl"
     shutil.copy2(artifact, project.root)


### PR DESCRIPTION
`--trusted-host` with a port is ignored on import, and the port is dropped on
export, so an index on a non-default port does not round-trip.

`requirements.txt` with `--trusted-host mirror.example.com:8443` and an index URL
carrying credentials:

```
before:
url = "https://user:pw@mirror.example.com:8443/simple"
verify_ssl = true            <- the trusted host was not matched
--trusted-host localhost     <- exported without the port

after:
url = "https://user:pw@mirror.example.com:8443/simple"
verify_ssl = false
--trusted-host mirror.example.com:8443
```

The import side is the one that bites: the source is silently recorded as
`verify_ssl = true`, so pdm then rejects a certificate the user explicitly said
to trust.

## Cause

Two halves of the same round trip.

On import, the trusted host is compared by membership against two values:

```python
netloc, host = parsed.netloc, parsed.hostname
for trusted in trusted_hosts:
    if trusted in (host, netloc):
```

`host` has no port, so `mirror.example.com:8443` never equals it. `netloc` has
the port but also the userinfo, so for `user:pw@mirror.example.com:8443` it does
not match either. It only works when the URL has a port and no credentials.

On export the port is thrown away:

```python
host = urllib.parse.urlparse(url).hostname
lines.append(f"--trusted-host {host}\n")
```

pip does not treat a portless `--trusted-host` as covering an explicit port in
the URL, so the exported file does not reproduce the input.

## The fix

Compare host and port explicitly, and keep the port on the way out. I took the
semantics from pip's own `is_secure_origin` and `add_trusted_host` rather than
guessing:

- host compared case-insensitively, matching
  `origin_host.lower() != secure_host.lower()`
- userinfo excluded, since pip compares `parsed.hostname`
- a trusted host with no port matches any port, matching pip's
  `secure_port is not None` check and its wildcard-port mount

IPv6 literals are split with `urlsplit` so `[::1]:8443` breaks on the right
colon, and are re-bracketed on export. A malformed port is treated as absent
rather than raising, so a bad value in a requirements file cannot abort the
import.

## Verification

Reverting the matching logic to the membership test fails the import test:

```
E  At index 0 diff: {'url': 'https://user:pw@mirror.example.org:8443/simple', 'verify_ssl': True}
                 != {'url': 'https://user:pw@mirror.example.org:8443/simple', 'verify_ssl': False}
```

Reverting the export to `.hostname` fails the export tests, including the IPv6
one:

```
E  - --trusted-host mirror.example.org:8443
E  + --trusted-host mirror.example.org
E  AssertionError: assert '--trusted-host ::1' == '--trusted-host [::1]:8443'
```

`tests/test_formats.py` is 46 passed. On the wider suite the baseline is 1346
passed on a stashed tree and 1359 passed with this change, no failures either
way; the difference is the new tests.

Two tests are excluded from that count because they fail identically on an
unmodified tree here for environment reasons:
`test_create_venv_in_project[venv-True]` and the OIDC tests in
`tests/cli/test_publish.py`.

`ruff check` and `ruff format --check` are clean.

## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

*Disclosure: written with AI assistance (Claude Code). I produced the before and after by running `pdm import` and `pdm export`, read pip's `is_secure_origin` and `add_trusted_host` from an installed pip to confirm the matching rules rather than relying on memory, and ran both mutation checks and the suite baseline myself.*
