### PR TITLE
fix: Poetry caret on a 0.x version converts to the wrong upper bound

### DIFF
--- a/news/3848.bugfix.md
+++ b/news/3848.bugfix.md
@@ -1,0 +1,1 @@
+Convert a Poetry caret constraint on a `0.x` version to the upper bound Poetry documents, so `^0.2.3` becomes `<0.3.0` and `^0.0.3` becomes `<0.0.4` instead of `<1.0.0`.

--- a/src/pdm/formats/poetry.py
+++ b/src/pdm/formats/poetry.py
@@ -44,15 +44,27 @@ def check_fingerprint(project: Project | None, filename: Path | str) -> bool:
 VERSION_RE = re.compile(r"([^\d\s]*)\s*(\d.*?)\s*(?=,|$)")
 
 
+def _caret_upper_bound(version: str) -> str:
+    """Return the exclusive upper bound of a Poetry caret requirement.
+
+    A caret requirement allows changes that do not modify the leftmost non-zero
+    component, so ``^0.2.3`` means ``<0.3.0`` and ``^0.0.3`` means ``<0.0.4``.
+    If every component is zero, the last one is bumped, matching ``^0.0`` -> ``<0.1``.
+    """
+    numbers = [int(match.group()) if (match := re.match(r"\d+", part)) else 0 for part in version.split(".")]
+    index = next((i for i, number in enumerate(numbers) if number), len(numbers) - 1)
+    bumped = numbers[: index + 1]
+    bumped[-1] += 1
+    return ".".join(str(number) for number in bumped + [0] * (len(numbers) - index - 1))
+
+
 def _convert_specifier(version: str) -> str:
     parts = []
     for op, ver in VERSION_RE.findall(str(version)):
         if op == "~":
             op += "="
         elif op == "^":
-            major, *vparts = ver.split(".")
-            next_major = ".".join([str(int(major) + 1)] + ["0"] * len(vparts))
-            parts.append(f">={ver},<{next_major}")
+            parts.append(f">={ver},<{_caret_upper_bound(ver)}")
             continue
         elif not op:
             op = "=="

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -187,8 +187,8 @@ def test_convert_poetry(project):
     assert result["license"] == {"text": "MIT"}
     assert "repository" in result["urls"]
     assert result["requires-python"] == "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<4.0,>=2.7"
-    assert 'cleo<1.0.0,>=0.7.6; python_version ~= "2.7"' in result["dependencies"]
-    assert 'cachecontrol[filecache]<1.0.0,>=0.12.4; python_version ~= "3.4"' in result["dependencies"]
+    assert 'cleo<0.8.0,>=0.7.6; python_version ~= "2.7"' in result["dependencies"]
+    assert 'cachecontrol[filecache]<0.13.0,>=0.12.4; python_version ~= "3.4"' in result["dependencies"]
     assert "babel==2.9.0" in result["dependencies"]
     assert "mysql" in result["optional-dependencies"]
     assert "psycopg2<3.0,>=2.7" in result["optional-dependencies"]["pgsql"]
@@ -209,6 +209,30 @@ def test_convert_poetry_optional_dependency_in_multiple_extras(project):
     assert result["optional-dependencies"]["mysql"] == ["mysqlclient<2.0,>=1.3"]
     assert result["optional-dependencies"]["pgsql"] == ["psycopg2<3.0,>=2.7"]
     assert result["optional-dependencies"]["all"] == ["psycopg2<3.0,>=2.7", "mysqlclient<2.0,>=1.3"]
+
+
+@pytest.mark.parametrize(
+    "constraint,expected",
+    [
+        # Poetry's caret keeps the leftmost non-zero component unchanged.
+        ("^1.2.3", "<2.0.0,>=1.2.3"),
+        ("^1.2", "<2.0,>=1.2"),
+        ("^1", "<2,>=1"),
+        ("^0.2.3", "<0.3.0,>=0.2.3"),
+        ("^0.0.3", "<0.0.4,>=0.0.3"),
+        ("^0.0", "<0.1,>=0.0"),
+        ("^0", "<1,>=0"),
+    ],
+)
+def test_convert_poetry_caret_constraint(project, constraint, expected):
+    pyproject = project.root / "pyproject.toml"
+    pyproject.write_text(
+        f'[tool.poetry]\nname = "demo"\nversion = "0.1.0"\n[tool.poetry.dependencies]\nfoo = "{constraint}"\n',
+        encoding="utf-8",
+    )
+    result, _ = poetry.convert(project, pyproject, ns())
+
+    assert result["dependencies"] == [f"foo{expected}"]
 
 
 def test_convert_poetry_12(project):


### PR DESCRIPTION
## What's broken

`pdm import -f poetry` converts every caret constraint by bumping the major component, so a `0.x` caret gets a far wider bound than Poetry means. The imported project then accepts releases Poetry would have refused.

## Repro

`attrs = "^0.2.3"`, `tinylib = "^0.0.3"`, `requests = "^2.28.1"` in a Poetry project:

```
before:
dependencies = ["attrs<1.0.0,>=0.2.3", "tinylib<1.0.0,>=0.0.3", "requests<3.0.0,>=2.28.1"]

after:
dependencies = ["attrs<0.3.0,>=0.2.3", "tinylib<0.0.4,>=0.0.3", "requests<3.0.0,>=2.28.1"]
```

## The fix

A caret allows changes that do not modify the leftmost non-zero component, so the bumped position depends on where that component is. `_caret_upper_bound` finds it instead of assuming the major.

## Verification

`test_convert_poetry_caret_constraint` is parametrised over all seven rows of Poetry's own caret table, `^1.2.3` through `^0`, checked against the table in their dependency-specification docs. Forcing the index back to 0 fails three of them with assertion errors.

Two assertions in `test_convert_poetry` had the old bounds baked in, `cleo<1.0.0` for `^0.7.6` and `cachecontrol<1.0.0` for `^0.12.4`. Both fixture constraints are `0.x`, so those were asserting the bug; they now read `<0.8.0` and `<0.13.0`.

`tests/test_formats.py` passes, 53 tests. The wider run has one failure, `test_create_venv_in_project[venv-True]`, identical on a clean checkout here because this box has no `ensurepip`. `ruff check` and `ruff format --check` clean.
