### PR TITLE
fix(formats): resolve nested remote requirement URLs

### DIFF
--- a/news/3850.bugfix.md
+++ b/news/3850.bugfix.md
@@ -1,0 +1,1 @@
+Resolve nested requirement paths relative to remote requirements file URLs.

--- a/src/pdm/formats/requirements.py
+++ b/src/pdm/formats/requirements.py
@@ -83,7 +83,14 @@ class RequirementParser:
         if args.editable:
             self.requirements.append(parse_requirement(" ".join(args.editable), True))
         if args.requirement:
-            referenced_requirements = Path(filename).parent.joinpath(args.requirement).as_posix()
+            reference = urllib.parse.urlparse(args.requirement)
+            source = urllib.parse.urlparse(filename)
+            if reference.scheme in ("http", "https", "file"):
+                referenced_requirements = args.requirement
+            elif source.scheme in ("http", "https", "file"):
+                referenced_requirements = urllib.parse.urljoin(filename, args.requirement)
+            else:
+                referenced_requirements = Path(filename).parent.joinpath(args.requirement).as_posix()
             self.parse_file(referenced_requirements)
 
     def parse_lines(self, lines: Iterable[str], filename: str = "<temp file>") -> None:

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -94,6 +94,31 @@ def test_convert_requirements_file_with_tab_before_comment(project):
     assert result["dependencies"] == ["webassets==2.0"]
 
 
+@pytest.mark.parametrize(
+    "reference,expected_url",
+    [
+        ("child.txt", "https://example.com/base/child.txt"),
+        ("../child.txt", "https://example.com/child.txt"),
+        ("https://other.example/child.txt", "https://other.example/child.txt"),
+    ],
+)
+def test_remote_requirements_resolve_nested_reference(mocker, reference, expected_url):
+    session = mocker.Mock()
+    session.get.side_effect = [
+        mocker.Mock(is_error=False, text=f"-r {reference}"),
+        mocker.Mock(is_error=False, text="webassets==2.0"),
+    ]
+    parser = requirements.RequirementParser(session)
+
+    parser.parse_file("https://example.com/base/requirements.txt")
+
+    assert [call.args[0] for call in session.get.call_args_list] == [
+        "https://example.com/base/requirements.txt",
+        expected_url,
+    ]
+    assert [req.as_line() for req in parser.requirements] == ["webassets==2.0"]
+
+
 def test_convert_requirements_file_without_name(project, vcs):
     req_file = project.root.joinpath("reqs.txt")
     project.root.joinpath("reqs.txt").write_text("git+https://github.com/test-root/demo.git\n")


### PR DESCRIPTION
## Summary

- resolve relative nested `-r` references against a remote requirements file URL
- preserve absolute nested HTTP(S) and `file` URLs
- keep the existing local-file path resolution unchanged
- add offline regression coverage for sibling, parent-directory, and absolute URL references

## Root cause and impact

`RequirementParser._parse_line()` resolved every nested requirements reference with `pathlib.Path`. For a remote parent such as `https://example.com/base/requirements.txt`, this collapsed the URL into `https:/example.com/base/child.txt`, so importing a valid remote requirements tree failed at the first relative `-r` line.

The parser now uses URL joining when the parent is remote, while retaining `Path` joining for local files.

Fixes #3850.

## Validation

- `pytest -q tests/test_formats.py` (`56 passed`)
- `ruff check src/pdm/formats/requirements.py tests/test_formats.py`
- `ruff format --check src/pdm/formats/requirements.py tests/test_formats.py`
- `git diff --check`

## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.
