### PR TITLE
fix(lock): --append adds packages that get installed on other targets

### DIFF
--- a/news/3261.bugfix.md
+++ b/news/3261.bugfix.md
@@ -1,0 +1,1 @@
+Restrict a locked package to the platform it was resolved for when it doesn't belong to every lock target, so `pdm lock --platform ... --append` no longer adds entries that get installed on the other targets.

--- a/src/pdm/models/repositories/lock.py
+++ b/src/pdm/models/repositories/lock.py
@@ -13,7 +13,7 @@ from dep_logic.markers import AnyMarker, BaseMarker
 from pdm.cli.utils import normalize_name
 from pdm.exceptions import CandidateNotFound, PdmException
 from pdm.models.candidates import Candidate
-from pdm.models.markers import EnvSpec, exclude_multi, get_marker
+from pdm.models.markers import EnvSpec, Marker, exclude_multi, get_marker
 from pdm.models.repositories.base import BaseRepository, CandidateMetadata
 from pdm.models.requirements import FileRequirement, Requirement, parse_line
 from pdm.utils import cd, url_to_path, url_without_fragments
@@ -34,6 +34,34 @@ class Package:
     dependencies: list[str] | None = None
     summary: str = ""
     marker: BaseMarker = dataclasses.field(default_factory=AnyMarker)
+
+
+def _platform_markers(env_spec: EnvSpec, others: list[EnvSpec]) -> tuple[Marker, Marker] | None:
+    """Build a ``(only, without)`` marker pair for the platform of ``env_spec``.
+
+    ``only`` matches that platform alone while ``without`` matches all the others.
+    ``platform_machine`` is added only when another target shares the same
+    ``sys_platform``, to keep the markers short. Return ``None`` for a target that
+    isn't restricted to a platform.
+    """
+    platform = env_spec.platform
+    if platform is None:
+        return None
+    pairs = [("sys_platform", platform.sys_platform)]
+    if any(other.platform is not None and other.platform.sys_platform == platform.sys_platform for other in others):
+        pairs.append(("platform_machine", platform.platform_machine))
+    only = get_marker(" and ".join(f'{name} == "{value}"' for name, value in pairs))
+    without = get_marker(" or ".join(f'{name} != "{value}"' for name, value in pairs))
+    return only, without
+
+
+def _restrict_marker(entry: Package, marker: Marker, excluded: list[EnvSpec]) -> None:
+    """Narrow the marker of ``entry`` with ``marker``, unless it already excludes ``excluded``."""
+    old_marker = entry.candidate.req.marker
+    if old_marker is not None and not any(old_marker.matches(target) for target in excluded):
+        return
+    new_marker = marker if old_marker is None else old_marker & marker
+    entry.candidate.req = dataclasses.replace(entry.candidate.req, marker=new_marker)
 
 
 class LockedRepository(BaseRepository):
@@ -271,12 +299,23 @@ class LockedRepository(BaseRepository):
             yield package
 
     def merge_result(self, env_spec: EnvSpec, result: Iterable[Package]) -> None:
-        if env_spec not in self.targets:
+        is_new_target = env_spec not in self.targets
+        previous_targets = list(self.targets)
+        if is_new_target:
             self.targets.append(env_spec)
+        # Markers are inherited from the requirements only, so a package exclusive to one
+        # target can still carry a marker matching the others, e.g. when a platform-specific
+        # wheel declares its dependencies unconditionally. Keep such packages out of the
+        # targets they were not resolved for.
+        markers = _platform_markers(env_spec, previous_targets) if is_new_target and previous_targets else None
+        resolved: set[CandidateKey] = set()
         for entry in result:
             key = self._identify_candidate(entry.candidate)
+            resolved.add(key)
             existing = self.packages.get(key)
             if existing is None:
+                if markers is not None:
+                    _restrict_marker(entry, markers[0], previous_targets)
                 self.packages[key] = entry
             else:
                 # merge markers
@@ -299,6 +338,10 @@ class LockedRepository(BaseRepository):
                 for file in entry.candidate.hashes:
                     if file not in existing.candidate.hashes:
                         existing.candidate.hashes.append(file)
+        if markers is not None:
+            for key, package in self.packages.items():
+                if key not in resolved:
+                    _restrict_marker(package, markers[1], [env_spec])
         # clear caches
         if "all_candidates" in self.__dict__:
             del self.__dict__["all_candidates"]

--- a/tests/models/test_locked_repository.py
+++ b/tests/models/test_locked_repository.py
@@ -180,6 +180,35 @@ def test_merge_result_adds_and_merges_packages(mocker):
     assert "all_candidates" not in repository.__dict__
 
 
+def test_merge_result_keeps_packages_out_of_foreign_targets(mocker):
+    repository = make_repository(mocker)
+    windows = EnvSpec.from_spec(requires_python=">=3.9", platform="windows")
+    linux = EnvSpec.from_spec(requires_python=">=3.9", platform="linux")
+
+    def candidate(name):
+        return Candidate(parse_requirement(name), name=name, version="1.0")
+
+    shared, windows_only = candidate("shared"), candidate("windows-only")
+    marked = candidate("marked")
+    marked.req = parse_requirement("marked; sys_platform == 'win32'")
+    repository.merge_result(windows, [Package(shared), Package(windows_only), Package(marked)])
+
+    # The first target doesn't restrict anything, there is nothing to be excluded from yet.
+    assert all(can.req.marker is None for can in (shared, windows_only))
+
+    linux_only = candidate("linux-only")
+    repository.merge_result(linux, [Package(candidate("shared")), Package(linux_only)])
+
+    # A package resolved for the new target only, without a marker excluding the old ones.
+    assert str(linux_only.req.marker) == 'sys_platform == "linux"'
+    # A package missing from the new target's resolution.
+    assert str(windows_only.req.marker) == 'sys_platform != "linux"'
+    # Markers that already exclude the other target are left alone.
+    assert str(marked.req.marker) == 'sys_platform == "win32"'
+    # Packages resolved for both targets stay unrestricted.
+    assert repository.packages[repository._identify_candidate(shared)].candidate.req.marker is None
+
+
 def test_get_hashes_returns_candidate_hashes(mocker):
     repository = make_repository(mocker)
     candidate = make_candidate()


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Fixes #3261.

`merge_result` writes a package resolved for one lock target straight into the lockfile with whatever marker dependency inheritance produced. That marker is built only from requirement markers, so a package reachable only on one target can still match the others, and `pdm install` then tries to install it there.

That is what the reporter hit. The `+cu118` linux wheel declares `Requires-Dist: triton (==2.1.0)` with no marker, because the wheel tag already implies linux; the PyPI wheel declares `platform_system == "Linux"`, which is why plain `torch==2.1.0` looked fine.

`merge_result` now narrows two cases against the platform of the target being merged: a package new to the lockfile is kept out of the targets locked before it, and a package missing from this target's resolution is kept out of this one. Markers that already exclude the other targets are untouched, so ordinary multi-target locks are unchanged.

<details>
<summary>Verification</summary>

Minimal reproduction: local index, `foo` ships a linux wheel requiring `bar` unmarked and a windows wheel with no dependencies, `bar` is linux-only.

```console
$ pdm lock --platform windows --python 3.11
$ pdm lock --platform linux --python 3.11 --append
```

Before, on Windows:

```
bar      marker=None
foo      marker=None
$ pdm install --dry-run
Packages to add:
  - bar 1.0
  - foo 1.0
```

After:

```
bar      marker='sys_platform == "linux"'
foo      marker=None
$ pdm install --dry-run
Packages to add:
  - foo 1.0
```

Locking linux first and appending windows gives `bar marker='sys_platform != "win32"'`, also correct.

`pytest -n auto -m "not integration"` on Windows/CPython 3.13: 1351 passed, 1 failed, 25 skipped. The failure is `test_link_python`, which needs symlink privilege and fails identically on unpatched `394fe28`. Linux CI not run locally.

</details>
