### PR TITLE
fix(publish): accept --no-verify-ssl as the option name

### DIFF
--- a/news/3857.bugfix.md
+++ b/news/3857.bugfix.md
@@ -1,0 +1,1 @@
+Accept `--no-verify-ssl` on `pdm publish`, which was misspelled as `--no-very-ssl`. The old spelling keeps working as an alias.

--- a/src/pdm/cli/commands/publish/__init__.py
+++ b/src/pdm/cli/commands/publish/__init__.py
@@ -75,7 +75,12 @@ class Command(BaseCommand):
         )
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
-            "--no-very-ssl", action="store_false", dest="verify_ssl", help="Disable SSL verification", default=None
+            "--no-verify-ssl",
+            "--no-very-ssl",
+            action="store_false",
+            dest="verify_ssl",
+            help="Disable SSL verification",
+            default=None,
         )
         group.add_argument(
             "--ca-certs",

--- a/tests/cli/test_publish.py
+++ b/tests/cli/test_publish.py
@@ -209,6 +209,16 @@ def test_publish_cli_args_and_env_var_precedence(project, monkeypatch, mocker):
         )
 
 
+def test_publish_parse_no_verify_ssl_option(core):
+    core.init_parser()
+    parser = core.parser
+
+    assert parser.parse_args(["publish", "--no-verify-ssl"]).verify_ssl is False
+    # Kept as an alias for backward compatibility.
+    assert parser.parse_args(["publish", "--no-very-ssl"]).verify_ssl is False
+    assert parser.parse_args(["publish"]).verify_ssl is None
+
+
 def test_repository_get_credentials_from_keyring(project, keyring, mocker):
     keyring.save_auth_info("https://test.org/upload", "foo", "barbaz")
     config = RepositoryConfig(config_prefix="repository", name="test", url="https://test.org/upload")


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

`pdm publish` spells the flag `--no-very-ssl` (`src/pdm/cli/commands/publish/__init__.py:78`), so `pdm publish --no-verify-ssl` exits with `unrecognized arguments`. The commit that added it, 2d6f4c7, is titled "feat: add --no-verify-ssl option to publish command", and that same commit wrote `--no-verify-ssl` into the zsh and PowerShell completions while the parser got `--no-very-ssl`. The `dest="verify_ssl"` and the `pypi.verify_ssl` config key agree with the commit title. codespell misses it because "very" is a word.

I did not rename the flag outright. `--no-very-ssl` has been public since 2.7.0, so removing it would need a `break` news fragment. `--no-verify-ssl` is now the first option string, so it is what `--help` and the argcomplete completions offer, and the old spelling keeps working. This follows #3029, which added `--clean-unselected` alongside `--only-keep`.

Residual limitation: the misspelling stays accepted until someone deprecates it deliberately.

`pytest -m "not integration"` gives 1377 passed, 1 skipped, 1 xfailed, against 1376 passed on `main`. ruff 0.16.1 and codespell 2.4.3 pass; mypy reports no issues in 129 files. Reverting the parser change alone fails the new `--no-verify-ssl` assertion. The alias and default assertions in that test pass either way and are pins.

Written with Claude Code.
