### PR TITLE
fix: Poetry tilde on a short version converts to the wrong upper bound

### DIFF
--- a/news/3858.bugfix.md
+++ b/news/3858.bugfix.md
@@ -1,0 +1,1 @@
+Convert Poetry tilde constraints with fewer than three components to the bounds Poetry means: `~1.2` becomes `<1.3` rather than `<2.0`, and `~1` no longer produces an invalid `~=1` specifier that aborts the import.

--- a/src/pdm/formats/poetry.py
+++ b/src/pdm/formats/poetry.py
@@ -58,11 +58,28 @@ def _caret_upper_bound(version: str) -> str:
     return ".".join(str(number) for number in bumped + [0] * (len(numbers) - index - 1))
 
 
+def _tilde_upper_bound(version: str) -> str:
+    """Return the exclusive upper bound of a Poetry tilde requirement.
+
+    A tilde requirement allows patch-level changes when a minor version is given and
+    minor-level changes otherwise, so ``~1.2.3`` and ``~1.2`` both mean ``<1.3.0``
+    while ``~1`` means ``<2.0.0``. PEP 440's ``~=`` only agrees with that when all
+    three components are present: ``~=1.2`` means ``<2.0``, and ``~=1`` is not even a
+    valid specifier.
+    """
+    numbers = [int(match.group()) if (match := re.match(r"\d+", part)) else 0 for part in version.split(".")]
+    index = min(1, len(numbers) - 1)
+    bumped = numbers[: index + 1]
+    bumped[-1] += 1
+    return ".".join(str(number) for number in bumped + [0] * (len(numbers) - index - 1))
+
+
 def _convert_specifier(version: str) -> str:
     parts = []
     for op, ver in VERSION_RE.findall(str(version)):
         if op == "~":
-            op += "="
+            parts.append(f">={ver},<{_tilde_upper_bound(ver)}")
+            continue
         elif op == "^":
             parts.append(f">={ver},<{_caret_upper_bound(ver)}")
             continue

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -291,7 +291,8 @@ def test_convert_poetry(project):
     assert result["version"] == "1.0.0"
     assert result["license"] == {"text": "MIT"}
     assert "repository" in result["urls"]
-    assert result["requires-python"] == "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<4.0,>=2.7"
+    # `python = "~2.7 || ^3.4"`: Poetry's `~2.7` stops below 2.8, so 2.8 is excluded too.
+    assert result["requires-python"] == "!=2.8.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<4.0,>=2.7"
     assert 'cleo<0.8.0,>=0.7.6; python_version ~= "2.7"' in result["dependencies"]
     assert 'cachecontrol[filecache]<0.13.0,>=0.12.4; python_version ~= "3.4"' in result["dependencies"]
     assert "babel==2.9.0" in result["dependencies"]
@@ -357,6 +358,46 @@ def test_convert_poetry_caret_constraint(project, constraint, expected):
     result, _ = poetry.convert(project, pyproject, ns())
 
     assert result["dependencies"] == [f"foo{expected}"]
+
+
+@pytest.mark.parametrize(
+    "constraint,expected",
+    [
+        # Poetry's tilde allows patch-level changes when a minor is given, and
+        # minor-level changes otherwise.
+        ("~1.2.3", "<1.3.0,>=1.2.3"),
+        ("~1.2", "<1.3,>=1.2"),
+        ("~1", "<2,>=1"),
+        ("~0.2.3", "<0.3.0,>=0.2.3"),
+        ("~0.0", "<0.1,>=0.0"),
+        ("~0", "<1,>=0"),
+    ],
+)
+def test_convert_poetry_tilde_constraint(project, constraint, expected):
+    pyproject = project.root / "pyproject.toml"
+    pyproject.write_text(
+        f'[tool.poetry]\nname = "demo"\nversion = "0.1.0"\n[tool.poetry.dependencies]\nfoo = "{constraint}"\n',
+        encoding="utf-8",
+    )
+    result, _ = poetry.convert(project, pyproject, ns())
+
+    assert result["dependencies"] == [f"foo{expected}"]
+
+
+def test_convert_poetry_tilde_python_constraint(project):
+    """A one-component tilde on `python` used to abort the whole import.
+
+    `~3` became `~=3`, which is not a valid PEP 440 specifier because compatible
+    release requires at least two release segments.
+    """
+    pyproject = project.root / "pyproject.toml"
+    pyproject.write_text(
+        '[tool.poetry]\nname = "demo"\nversion = "0.1.0"\n[tool.poetry.dependencies]\npython = "~3"\n',
+        encoding="utf-8",
+    )
+    result, _ = poetry.convert(project, pyproject, ns())
+
+    assert result["requires-python"] == "<4,>=3"
 
 
 def test_convert_poetry_12(project):


### PR DESCRIPTION
## What's broken

`pdm import -f poetry` converts every tilde constraint to PEP 440's `~=`. That only means the same thing when all three components are present. With a short version it either widens the constraint or produces a specifier that isn't valid at all:

| Poetry | means | `~=` equivalent | pdm imported |
|---|---|---|---|
| `~1.2.3` | `>=1.2.3 <1.3.0` | `>=1.2.3, ==1.2.*` | correct |
| `~1.2` | `>=1.2.0 <1.3.0` | `>=1.2, ==1.*` | **`<2.0`, too wide** |
| `~1` | `>=1.0.0 <2.0.0` | — not a valid specifier | **import aborts** |

`~=` requires at least two release segments, so the one-component case doesn't just import wrongly, it raises.

## Repro

`foo = "~1.2"` and `bar = "~1"` in a Poetry project:

```
before:
dependencies = ["foo~=1.2"]                 # accepts 1.9.9, which Poetry refuses
bar          -> MetaConvertError: dependencies: Invalid specifier for bar: ~=1

after:
dependencies = ["foo<1.3,>=1.2", "bar<2,>=1"]
```

The same path handles `requires-python`, so `python = "~3"` aborts the whole import today:

```
before: InvalidPyVersion: Invalid specifier: ~=3
after:  requires-python = "<4,>=3"
```

## The fix

A tilde allows patch-level changes when a minor version is given and minor-level changes otherwise, so the bumped position is the minor when there is one and the major when there isn't. `_tilde_upper_bound` computes it and the tilde gets an explicit upper bound, the way `_caret_upper_bound` already does for `^` (#3848).

## Verification

`test_convert_poetry_tilde_constraint` is parametrised over Poetry's own tilde table, `~1.2.3` through `~0`, checked against the table in their dependency-specification docs, plus `test_convert_poetry_tilde_python_constraint` for the `requires-python` path. Reverting only `src/pdm/formats/poetry.py` turns 8 of the 9 new cases red; the one that stays green is `~1.2.3`, which `~=` already handled correctly.

One assertion in `test_convert_poetry` had the old bound baked in. The fixture is Poetry's own `pyproject.toml` with `python = "~2.7 || ^3.4"`, so `requires-python` was asserting the bug — `~2.7` stops below 2.8, and the expectation now carries the resulting `!=2.8.*`.

`tests/test_formats.py` passes, 68 tests. Full suite is 1378 passed / 7 failed on this box, and those 7 are identical on a clean checkout — they need symlink privileges, POSIX `echo`/`cat` on PATH, or a working `python3.14`. `ruff check` and `ruff format --check` clean. Windows 11, CPython 3.11.
