### PR TITLE
fix(formats): don't crash on an unusual Poetry author entry

### DIFF
--- a/news/3861.bugfix.md
+++ b/news/3861.bugfix.md
@@ -1,0 +1,1 @@
+Keep importing a Poetry project when an author or maintainer entry does not fit the `Name <email>` pattern.

--- a/src/pdm/formats/poetry.py
+++ b/src/pdm/formats/poetry.py
@@ -142,17 +142,31 @@ NAME_EMAIL_RE = re.compile(
 )
 
 
+#: A permissive fallback for entries ``NAME_EMAIL_RE`` rejects, such as a name
+#: containing a character outside its set. It always matches, so the address is
+#: still split off instead of being buried in the name.
+NAME_EMAIL_FALLBACK_RE = re.compile(r"^\s*(?P<name>.*?)\s*(?:<(?P<email>[^<>]*)>)?\s*$", re.UNICODE)
+
+
+def _parse_one_name_email(item: str) -> dict[str, str]:
+    """Split a single Poetry author/maintainer entry into ``name`` and ``email``.
+
+    Poetry only documents the ``Name <email>`` form, but a project can carry
+    anything in there. An entry that doesn't fit used to abort the whole import
+    with ``AttributeError: 'NoneType' object has no attribute 'groupdict'``,
+    because the strict pattern's ``None`` result was indexed directly.
+    """
+    match = NAME_EMAIL_RE.match(item) or NAME_EMAIL_FALLBACK_RE.match(item)
+    assert match is not None  # the fallback pattern matches any string
+    parsed = {k: v for k, v in match.groupdict().items() if v}
+    # A bare address carries no name, so report it as the email it is.
+    if set(parsed) == {"name"} and "@" in parsed["name"] and " " not in parsed["name"]:
+        return {"email": parsed["name"]}
+    return parsed
+
+
 def parse_name_email(name_email: list[str]) -> list[dict]:
-    return array_of_inline_tables(
-        [
-            {
-                k: v
-                for k, v in NAME_EMAIL_RE.match(item).groupdict().items()  # type: ignore[union-attr]
-                if v is not None
-            }
-            for item in name_email
-        ]
-    )
+    return array_of_inline_tables([_parse_one_name_email(item) for item in name_email])
 
 
 class PoetryMetaConverter(MetaConverter):

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -400,6 +400,31 @@ def test_convert_poetry_tilde_python_constraint(project):
     assert result["requires-python"] == "<4,>=3"
 
 
+@pytest.mark.parametrize(
+    "author,expected",
+    [
+        ("Jane Doe <jane@example.com>", {"name": "Jane Doe", "email": "jane@example.com"}),
+        ("Acme, Inc. (Support) <s@acme.io>", {"name": "Acme, Inc. (Support)", "email": "s@acme.io"}),
+        ("Jane Doe", {"name": "Jane Doe"}),
+        # Characters outside the strict pattern used to abort the whole import.
+        ("Foo [Bar] <a@b.com>", {"name": "Foo [Bar]", "email": "a@b.com"}),
+        ("Team A/B <a@b.com>", {"name": "Team A/B", "email": "a@b.com"}),
+        # A bare address is an address, not a name.
+        ("jane@example.com", {"email": "jane@example.com"}),
+        ("<only@example.com>", {"email": "only@example.com"}),
+    ],
+)
+def test_convert_poetry_unusual_author(project, author, expected):
+    pyproject = project.root / "pyproject.toml"
+    pyproject.write_text(
+        f'[tool.poetry]\nname = "demo"\nversion = "0.1.0"\nauthors = ["{author}"]\n[tool.poetry.dependencies]\n',
+        encoding="utf-8",
+    )
+    result, _ = poetry.convert(project, pyproject, ns())
+
+    assert result["authors"] == [expected]
+
+
 def test_convert_poetry_12(project):
     golden_file = FIXTURES / "poetry-new.toml"
     with cd(FIXTURES):


### PR DESCRIPTION
`parse_name_email` called `.groupdict()` directly on the match object, so any entry `NAME_EMAIL_RE` rejects took down the whole import. The `# type: ignore[union-attr]` on that line was already flagging it.

```python
>>> from pdm.formats.poetry import parse_name_email
>>> parse_name_email(["jane@example.com"])
AttributeError: 'NoneType' object has no attribute 'groupdict'
>>> parse_name_email(["Foo [Bar] <a@b.com>"])
AttributeError: 'NoneType' object has no attribute 'groupdict'
```

The strict pattern's name class is `[- .,\w'’"():&]+`, so a bare address, or any name containing a character outside it (`[`, `]`, `/`, `+`, `|`, ...), aborts `pdm import` with a bare traceback and no indication of which field is at fault.

This adds a permissive fallback that always matches, so the address is still split off rather than buried in the name, and reports a bare address as `email` instead of `name`:

| entry | result |
| --- | --- |
| `Jane Doe <jane@example.com>` | `{name, email}` (unchanged) |
| `Foo [Bar] <a@b.com>` | `{name: "Foo [Bar]", email: "a@b.com"}` |
| `jane@example.com` | `{email: "jane@example.com"}` |
| `<only@example.com>` | `{email: "only@example.com"}` |

The strict pattern is tried first, so nothing that parsed before changes. Covered by a parametrized test.