### PR TITLE
fix(formats): do not write ">=None" when a Pipfile pins no python

### DIFF
--- a/news/3862.bugfix.md
+++ b/news/3862.bugfix.md
@@ -1,0 +1,1 @@
+Skip `requires-python` when a Pipfile `[requires]` table has no python version, instead of writing `>=None`.

--- a/src/pdm/formats/pipfile.py
+++ b/src/pdm/formats/pipfile.py
@@ -56,8 +56,12 @@ def convert(project: Project, filename: PathLike, options: Namespace | None) -> 
     if "pipenv" in data and "allow_prereleases" in data["pipenv"]:
         settings.setdefault("resolution", {})["allow-prereleases"] = data["pipenv"]["allow_prereleases"]
     if "requires" in data:
+        # `[requires]` may carry only other markers, e.g. `platform_system`. Writing
+        # the missing version out anyway produced `requires-python = ">=None"`, which
+        # is not a valid specifier and breaks the generated pyproject.toml.
         python_version = data["requires"].get("python_full_version") or data["requires"].get("python_version")
-        result["requires-python"] = f">={python_version}"
+        if python_version:
+            result["requires-python"] = f">={python_version}"
     if "source" in data:
         settings["source"] = data["source"]
     result["dependencies"] = make_array(  # type: ignore[assignment]

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -45,6 +45,22 @@ def test_convert_pipfile(project):
     assert settings["source"][0]["url"] == "https://pypi.python.org/simple"
 
 
+@pytest.mark.parametrize(
+    "requires",
+    [
+        "",  # an empty [requires] table
+        'platform_system = "Linux"\n',  # only non-python markers
+    ],
+)
+def test_convert_pipfile_requires_without_python(project, requires):
+    """`[requires]` without a python key used to emit `requires-python = ">=None"`."""
+    pipfile_path = project.root / "Pipfile"
+    pipfile_path.write_text(f"[requires]\n{requires}", encoding="utf-8")
+    result, _ = pipfile.convert(project, pipfile_path, None)
+
+    assert "requires-python" not in result
+
+
 @pytest.mark.parametrize("is_dev", [True, False])
 def test_convert_requirements_file(project, is_dev):
     golden_file = FIXTURES / "requirements.txt"


### PR DESCRIPTION
A Pipfile `[requires]` table does not have to carry a python version - pipenv allows other markers in there:

```toml
[requires]
platform_system = "Linux"
```

The converter read `python_full_version or python_version`, got `None`, and formatted it anyway:

```python
result["requires-python"] = f">={python_version}"   # ">=None"
```

which packaging rejects outright:

```python
>>> SpecifierSet(">=None")
InvalidSpecifier: Invalid specifier: '>=None'
```

so the generated `pyproject.toml` is unusable. An empty `[requires]` table does the same thing.

Only emit the key when a version is actually there. Covered by a parametrized test for both the empty table and the markers-only table.