### PR TITLE
fix(formats): keep Windows paths intact in requirements option lines

### DIFF
--- a/news/3863.bugfix.md
+++ b/news/3863.bugfix.md
@@ -1,0 +1,1 @@
+Keep native Windows paths intact when parsing `-e` and `-r` lines in a requirements file.

--- a/src/pdm/formats/requirements.py
+++ b/src/pdm/formats/requirements.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import os
 import re
 import shlex
 import urllib.parse
@@ -59,6 +60,20 @@ class RequirementParser:
         """Strip the surrounding whitespaces and comment from the line"""
         return _COMMENT_RE.sub("", line.strip()).strip()
 
+    @staticmethod
+    def _split_args(line: str) -> list[str]:
+        """Split an option line into argv-style tokens.
+
+        ``shlex.split`` runs in POSIX mode, where a backslash is an escape
+        character. On Windows that silently eats the separators of a native
+        path, so ``-e C:\\src\\pkg`` arrived as ``C:srcpkg``. Escape the
+        backslashes there first, leaving quoting to behave as it does
+        everywhere else.
+        """
+        if os.name == "nt":
+            line = line.replace("\\", "\\\\")
+        return shlex.split(line)
+
     def _parse_line(self, filename: str, line: str) -> None:
         if not line.startswith("-"):
             # Starts with a requirement, just ignore all per-requirement options
@@ -69,7 +84,7 @@ class RequirementParser:
                 req.name = req.guess_name()
             self.requirements.append(req)
             return
-        args, _ = self._parser.parse_known_args(shlex.split(line))
+        args, _ = self._parser.parse_known_args(self._split_args(line))
         if args.index_url:
             self.index_url = args.index_url
         if args.no_index:

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -87,6 +87,24 @@ def test_requirements_clean_line_strips_comments(line, expected):
     assert parser._clean_line(line) == expected
 
 
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        # POSIX-mode shlex treats a backslash as an escape, which used to eat the
+        # separators of a native Windows path.
+        (r"-e C:\src\pkg", ["-e", r"C:\src\pkg"]),
+        (r"-r C:\src\reqs.txt", ["-r", r"C:\src\reqs.txt"]),
+        (r'-e "C:\src\my pkg"', ["-e", r"C:\src\my pkg"]),
+        # Anything without a backslash is unaffected.
+        ("-e ./libs/foo", ["-e", "./libs/foo"]),
+        ("--index-url https://example.org/simple", ["--index-url", "https://example.org/simple"]),
+    ],
+)
+def test_requirements_split_args_keeps_windows_paths(monkeypatch, line, expected):
+    monkeypatch.setattr(requirements.os, "name", "nt")
+    assert requirements.RequirementParser._split_args(line) == expected
+
+
 def test_convert_requirements_file_with_tab_before_comment(project):
     req_file = project.root.joinpath("reqs.txt")
     req_file.write_text("webassets==2.0\t# a tab-separated comment\n", encoding="utf-8")


### PR DESCRIPTION
Option lines go through `shlex.split`, which runs in POSIX mode where a backslash escapes the next character. A native Windows path in a `-e` or `-r` line is destroyed before argparse ever sees it:

```python
>>> shlex.split(r"-e C:\src\pkg")
["-e", "C:srcpkg"]
>>> shlex.split(r"-r C:\src\reqs.txt")
["-r", "C:srcreqs.txt"]
```

So `pdm import` of a requirements file that references a local package or a nested requirements file by absolute Windows path silently resolves the wrong location. There is no error - the path just loses its separators.

Escape backslashes on Windows before splitting, which keeps quoting behaving as it does everywhere else:

```python
>>> RequirementParser._split_args(r"-e \"C:\src\my pkg\"")
["-e", "C:\src\my pkg"]
```

POSIX platforms are untouched, since a backslash there is a legitimate escape. Covered by a parametrized test that pins `os.name` so it runs on every platform.