### PR TITLE
fix(formats): survive an unparseable module when importing from flit

### DIFF
--- a/news/3864.bugfix.md
+++ b/news/3864.bugfix.md
@@ -1,0 +1,1 @@
+Leave the version and description empty instead of aborting when a flit module cannot be parsed.

--- a/src/pdm/formats/flit.py
+++ b/src/pdm/formats/flit.py
@@ -53,7 +53,13 @@ def get_docstring_and_version_via_ast(
     # read as bytes to enable custom encodings
     if not target.exists():
         return None, None
-    node = ast.parse(target.read_bytes())
+    try:
+        node = ast.parse(target.read_bytes())
+    except (SyntaxError, ValueError):
+        # The module isn't parseable by the running interpreter, so there is
+        # nothing to read out of it. The caller already warns about the fields
+        # that stayed empty, which beats aborting the whole import.
+        return None, None
     for child in node.body:
         # Only use the version from the given module if it's a simple
         # string assignment to __version__

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -456,6 +456,29 @@ def test_convert_flit_author_and_maintainer_without_email(project, tmp_path):
 
 
 @pytest.mark.parametrize(
+    "source",
+    [
+        "__version__ = '1.0'\nprint 'not python 3'\n",  # invalid syntax
+        "__version__ = '1.0'\x00\n",  # a null byte
+    ],
+)
+def test_convert_flit_unparseable_module(project, tmp_path, source):
+    """An unreadable module leaves version/description empty instead of aborting."""
+    pyproject_file = tmp_path / "pyproject.toml"
+    pyproject_file.write_text(
+        '[tool.flit.metadata]\nmodule = "demo"\nauthor = "Thomas Kluyver"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "demo.py").write_text(source, encoding="utf-8", newline="")
+
+    result, _ = flit.convert(project, pyproject_file, None)
+
+    assert result["name"] == "demo"
+    assert result["version"] == ""
+    assert result["description"] == ""
+
+
+@pytest.mark.parametrize(
     "sdist_table,expected_build",
     [
         ('include = ["doc/"]', {"includes": ["doc/"]}),


### PR DESCRIPTION
`get_docstring_and_version_via_ast` says in its own docstring:

> If docstring or version can't be retrieved by this function, they are just left empty.

But `ast.parse` raises straight through the caller, so a module the running interpreter cannot parse aborts the entire import instead:

```python
>>> get_docstring_and_version_via_ast(Path("demo.py"))   # contains `print "x"`
SyntaxError: Missing parentheses in call to 'print'
>>> get_docstring_and_version_via_ast(Path("demo.py"))   # contains a null byte
SyntaxError: source code string cannot contain null bytes
```

That is reachable for a project still carrying a module targeting another Python, or any file that is not valid source - and the failure is unrelated to the metadata being imported.

Catch the parse failure and return nothing, which is what the docstring already promises. `warn_against_dynamic_version_or_docstring` then reports the fields it could not fill in, which is more useful than a traceback.

`ValueError` is caught alongside `SyntaxError` because the null-byte case has been raised as either depending on the version.

Covered by a parametrized test; both cases fail without the change.