### PR TITLE
fix: respect group selections in pylock exports

### DIFF
--- a/news/3866.bugfix.md
+++ b/news/3866.bugfix.md
@@ -1,0 +1,1 @@
+Respect dependency group selection options when exporting to `pylock.toml`, producing a single-use lock file that contains only the selected packages.

--- a/src/pdm/cli/commands/export.py
+++ b/src/pdm/cli/commands/export.py
@@ -69,13 +69,15 @@ class Command(BaseCommand):
     def handle(self, project: Project, options: argparse.Namespace) -> None:
         from pdm.models.repositories.lock import Package
 
+        selection = GroupSelection.from_options(project, options)
         if options.format == "pylock":
             locked_repository = project.get_locked_repository()
             if options.self or options.editable_self:
                 locked_repository.add_package(
                     Package(project.make_self_candidate(editable=options.editable_self), [], "")
                 )
-            doc = tomlkit.dumps(PyLockConverter(project, locked_repository).convert())
+            selected_groups = None if selection.is_unset else list(selection)
+            doc = tomlkit.dumps(PyLockConverter(project, locked_repository).convert(selected_groups=selected_groups))
             if options.output:
                 Path(options.output).write_text(doc, encoding="utf-8")
             else:
@@ -83,7 +85,6 @@ class Command(BaseCommand):
             return
         if options.pyproject:
             options.hashes = False
-        selection = GroupSelection.from_options(project, options)
         if options.markers is False:
             project.core.ui.warn(
                 "The --no-markers option is on, the exported requirements can only work on the current platform"

--- a/src/pdm/formats/pylock.py
+++ b/src/pdm/formats/pylock.py
@@ -108,7 +108,18 @@ class PyLockConverter:
                 repo = self.project.get_repository()
                 repo.fetch_hashes(candidates)
 
-    def convert(self, all_groups: Iterable[str] | None = None) -> dict[str, Any]:
+    def convert(
+        self,
+        all_groups: Iterable[str] | None = None,
+        *,
+        selected_groups: Iterable[str] | None = None,
+    ) -> dict[str, Any]:
+        """Convert the repository, optionally limiting it to a single install set.
+
+        When ``selected_groups`` is provided, group metadata and markers are
+        omitted so installers without dependency-group selection can install
+        every package in the exported lock file.
+        """
         doc = tomlkit.document()
         project = self.project
         lockfile = project.lockfile
@@ -120,6 +131,7 @@ class PyLockConverter:
         if all_groups is None:
             all_groups = list(project.iter_groups())
         extras, groups = self.project.split_extras_groups(list(all_groups))
+        selected_groups_list = list(selected_groups) if selected_groups is not None else None
         env_markers: list[Marker] = []
         for target in repository.targets:
             env_markers.append(target.markers_with_python())
@@ -129,29 +141,39 @@ class PyLockConverter:
                 "lock-version": self.lock_version,
                 "requires-python": str(project.python_requires),
                 "environments": make_array([str(marker) for marker in env_markers], multiline=True),
-                "extras": sorted(extras),
-                "dependency-groups": sorted(groups, key=_group_sort_key),
-                "default-groups": ["default"],
-                "created-by": "pdm",
             }
         )
+        if selected_groups_list is None:
+            doc.update(
+                {
+                    "extras": sorted(extras),
+                    "dependency-groups": sorted(groups, key=_group_sort_key),
+                    "default-groups": ["default"],
+                }
+            )
+        doc["created-by"] = "pdm"
         packages = doc.setdefault("packages", tomlkit.aot())
+        if selected_groups_list is None:
+            selected_packages = list(repository.packages.values())
+        else:
+            selected_packages = list(repository.evaluate_candidates(selected_groups_list, evaluate_markers=False))
 
         with cd(project.root):
-            self._populate_hashes(repository.packages.values())
-            for package in repository.packages.values():
+            self._populate_hashes(selected_packages)
+            for package in selected_packages:
                 if package.candidate.req.extras:
                     continue
                 package_table = self.make_package(package)
                 selection_markers: list[BaseMarker] = []
-                if not package.marker.is_any():
-                    selection_markers.append(package.marker)
-                for item in sorted(package.candidate.req.groups, key=_group_sort_key):
-                    item = normalize_name(item)
-                    if item in extras:
-                        selection_markers.append(parse_marker(f"'{item}' in extras"))
-                    else:
-                        selection_markers.append(parse_marker(f"'{item}' in dependency_groups"))
+                if selected_groups_list is None:
+                    if not package.marker.is_any():
+                        selection_markers.append(package.marker)
+                    for item in sorted(package.candidate.req.groups, key=_group_sort_key):
+                        item = normalize_name(item)
+                        if item in extras:
+                            selection_markers.append(parse_marker(f"'{item}' in extras"))
+                        else:
+                            selection_markers.append(parse_marker(f"'{item}' in dependency_groups"))
                 marker = MarkerUnion.of(*selection_markers) if selection_markers else AnyMarker()
                 if package.candidate.req.marker is not None:
                     marker = package.candidate.req.marker.inner & marker

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -601,6 +601,35 @@ def test_export_pylock_toml(core, pdm):
     assert "inherit_metadata strategy is required for pylock format" in result.stderr
 
 
+@pytest.mark.parametrize(
+    ("group_options", "expected_packages"),
+    [
+        (["--prod"], {"chardet", "idna"}),
+        (["--no-default", "-G", "tests"], {"colorama", "py", "pytest", "setuptools"}),
+    ],
+)
+@pytest.mark.parametrize("source_lockfile", ["pdm.lock", "pylock.toml"])
+def test_export_pylock_toml_respects_group_selection(core, pdm, group_options, expected_packages, source_lockfile):
+    project = core.create_project(FIXTURES / "projects/demo")
+
+    result = pdm(
+        ["export", "-f", "pylock", "-L", str(project.root / source_lockfile), *group_options],
+        obj=project,
+        strict=True,
+    )
+    exported = tomllib.loads(result.stdout)
+    package_names = {package["name"] for package in exported["packages"]}
+
+    assert package_names == expected_packages
+    assert "extras" not in exported
+    assert "dependency-groups" not in exported
+    assert "default-groups" not in exported
+    assert all(
+        "extras" not in package.get("marker", "") and "dependency_groups" not in package.get("marker", "")
+        for package in exported["packages"]
+    )
+
+
 def test_export_from_pylock_not_empty(core, pdm):
     """Test that exporting from pylock.toml produces non-empty output (fixes issue #3573)."""
     project = core.create_project(FIXTURES / "projects/demo")


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in news/ describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Respect dependency-group selection options when exporting pylock files.

When a group selection is explicit, export a single-use lock file containing only the selected dependency closure. Group metadata and group markers are omitted so installers without dependency-group selection support can install every exported package. Exports without explicit group options retain the existing multi-use pylock behavior.

The regression coverage exercises production-only and optional-group selections from both pdm.lock and pylock.toml inputs.

Fixes #3866

## Test plan

- [x] Focused export and pylock regression tests
- [x] Ruff check and format check
- [x] Commit hooks: Ruff, codespell, and mypy