### PR TITLE
fix(export): pylock export ignores the dependency group selection

### DIFF
--- a/news/3866.bugfix.md
+++ b/news/3866.bugfix.md
@@ -1,0 +1,1 @@
+Respect the dependency group selection options when exporting to the `pylock` format.

--- a/src/pdm/cli/commands/export.py
+++ b/src/pdm/cli/commands/export.py
@@ -70,12 +70,19 @@ class Command(BaseCommand):
         from pdm.models.repositories.lock import Package
 
         if options.format == "pylock":
+            selected_groups = list(GroupSelection.from_options(project, options))
             locked_repository = project.get_locked_repository()
+            # Keep only the packages required by the selected groups, the whole lock file
+            # would otherwise be exported no matter which groups were asked for.
+            selected = list(locked_repository.evaluate_candidates(selected_groups, evaluate_markers=False))
+            locked_repository.packages.clear()
+            for package in selected:
+                locked_repository.add_package(package)
             if options.self or options.editable_self:
                 locked_repository.add_package(
                     Package(project.make_self_candidate(editable=options.editable_self), [], "")
                 )
-            doc = tomlkit.dumps(PyLockConverter(project, locked_repository).convert())
+            doc = tomlkit.dumps(PyLockConverter(project, locked_repository).convert(selected_groups))
             if options.output:
                 Path(options.output).write_text(doc, encoding="utf-8")
             else:

--- a/src/pdm/formats/pylock.py
+++ b/src/pdm/formats/pylock.py
@@ -131,7 +131,7 @@ class PyLockConverter:
                 "environments": make_array([str(marker) for marker in env_markers], multiline=True),
                 "extras": sorted(extras),
                 "dependency-groups": sorted(groups, key=_group_sort_key),
-                "default-groups": ["default"],
+                "default-groups": ["default"] if "default" in groups else [],
                 "created-by": "pdm",
             }
         )

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -706,6 +706,23 @@ def test_export_pylock_toml(core, pdm):
     assert "inherit_metadata strategy is required for pylock format" in result.stderr
 
 
+def test_export_pylock_toml_respects_group_selection(core, pdm):
+    project = core.create_project(FIXTURES / "projects/demo")
+    result = pdm(["export", "-f", "pylock", "--prod"], obj=project, strict=True)
+    doc = tomllib.loads(result.stdout)
+    assert doc["extras"] == []
+    assert doc["dependency-groups"] == ["default"]
+    assert doc["default-groups"] == ["default"]
+    assert {package["name"] for package in doc["packages"]} == {"chardet", "idna"}
+
+    result = pdm(["export", "-f", "pylock", "--no-default", "-G", "tests"], obj=project, strict=True)
+    doc = tomllib.loads(result.stdout)
+    assert doc["extras"] == ["tests"]
+    assert doc["dependency-groups"] == []
+    assert doc["default-groups"] == []
+    assert {package["name"] for package in doc["packages"]} == {"colorama", "py", "pytest", "setuptools"}
+
+
 def test_export_from_pylock_not_empty(core, pdm):
     """Test that exporting from pylock.toml produces non-empty output (fixes issue #3573)."""
     project = core.create_project(FIXTURES / "projects/demo")


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Fixes #3866.

`pdm export --format pylock` ignored `--prod`, `-G/--with`, `--without`, `--no-default` and `-d/--dev`. The flags parsed fine — `groups_group.add_to_parser(parser)` registers them — but the `pylock` branch of `Command.handle` returns before `GroupSelection.from_options` is ever called, so the whole lock file was exported no matter what was selected.

Reproduced on `main`, with one default dependency (`idna`) and one dev dependency (`iniconfig`):

```
$ pdm export --prod -f requirements --no-hashes
idna==3.19

$ pdm export --prod -f pylock
dependency-groups = ["default", "dev"]
[[packages]] name = "idna"
[[packages]] name = "iniconfig"     # marker = '"dev" in dependency_groups'
```

### Changes

- `src/pdm/cli/commands/export.py`: build a `GroupSelection` on the `pylock` path, narrow the locked repository through the existing `LockedRepository.evaluate_candidates(groups, evaluate_markers=False)` — the same group predicate the `requirements` exporter already uses — and pass the selection to `PyLockConverter.convert()`. The converter already took an `all_groups` argument (`PyLock.format_lockfile` passes it); the export command simply never did, so `extras` / `dependency-groups` were filled from `lockfile.groups`.
- `src/pdm/formats/pylock.py`: emit `default-groups = []` instead of `["default"]` when `default` is not in the selection. PEP 751 requires `default-groups` to be a subset of `dependency-groups`, so `--no-default` previously produced an invalid document.

After the change:

```
$ pdm export --prod -f pylock
extras = []
dependency-groups = ["default"]
default-groups = ["default"]
[[packages]] name = "idna"

$ pdm export --no-default -G dev -f pylock
extras = []
dependency-groups = ["dev"]
default-groups = []
[[packages]] name = "iniconfig"
```

### Compatibility

`pdm export -f pylock` with no selection flags is unchanged — an unset `GroupSelection` resolves to the locked groups — so the `tests/fixtures/projects/demo/pylock.toml` golden file in `test_export_pylock_toml` still matches byte for byte. Writing a `pylock.toml` lock file (`lock.format = pylock`) goes through `PyLock.format_lockfile`, which is untouched; verified by hand that `pdm lock` still writes all locked groups.

### Tests

`test_export_pylock_toml_respects_group_selection` added next to the existing pylock export tests, covering `--prod` and `--no-default -G tests` against the `projects/demo` fixture. It fails on `main` (`assert ['security', 'tests'] == []`) and passes with the patch.

`pytest -n auto -m "not integration and not network and not uv"` on Windows 11 / Python 3.12: 1354 passed, 10 skipped, and the same 29 failures before and after the change (all pre-existing on a clean tree, caused by spaces in my local clone path). `ruff check`, `ruff format --check` and `mypy` are clean on the touched files.
