### PR TITLE
fix(venv): escape glob characters in the venv lookup prefix

### DIFF
--- a/src/pdm/cli/commands/venv/utils.py
+++ b/src/pdm/cli/commands/venv/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import glob
 import hashlib
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -60,7 +61,10 @@ def iter_venvs(project: Project) -> Iterable[tuple[str, VirtualEnv]]:
         yield "in-project", in_project_venv
     venv_prefix = get_venv_prefix(project)
     venv_parent = get_venv_parent(project)
-    for path in venv_parent.glob(f"{venv_prefix}*"):
+    # The project directory name is part of the prefix and may legally contain
+    # glob metacharacters (e.g. `my[project]`), which would otherwise be treated
+    # as a pattern and fail to match the venv that `venv create` wrote to disk.
+    for path in venv_parent.glob(f"{glob.escape(venv_prefix)}*"):
         ident = path.name[len(venv_prefix) :]
         venv = VirtualEnv.get(path)
         if venv is not None:

--- a/tests/cli/test_venv.py
+++ b/tests/cli/test_venv.py
@@ -141,6 +141,29 @@ def test_venv_list_with_tilde_location(pdm, project, monkeypatch, tmp_path):
     assert result.output.strip() == venv_path
 
 
+@pytest.mark.parametrize("dirname", ["my[project]", "downloads[1]"])
+def test_iter_venvs_with_glob_chars_in_project_path(project, tmp_path, dirname):
+    """A project directory name may legally contain glob metacharacters.
+
+    ``venv create`` names the venv with the literal directory name, so the
+    lookup must match that same literal name rather than treating it as a
+    pattern.
+    """
+    from pdm.cli.commands.venv.utils import get_venv_parent, iter_venvs
+
+    project.root = tmp_path / dirname
+    project.root.mkdir()
+
+    venv_parent = get_venv_parent(project)
+    venv_parent.mkdir(parents=True, exist_ok=True)
+    venv_dir = venv_parent / f"{get_venv_prefix(project)}3.13"
+    bin_dir = venv_dir / ("Scripts" if sys.platform == "win32" else "bin")
+    bin_dir.mkdir(parents=True)
+    bin_dir.joinpath("python.exe" if sys.platform == "win32" else "python").touch()
+
+    assert {ident: venv.root for ident, venv in iter_venvs(project)} == {"3.13": venv_dir}
+
+
 @pytest.mark.usefixtures("fake_create")
 def test_venv_remove(pdm, project):
     project.project_config["venv.in_project"] = False


### PR DESCRIPTION
`get_venv_prefix` builds the prefix from the project directory name, and `venv create` writes that name to disk literally. `iter_venvs` then feeds the same string to `Path.glob`, where `[` and `]` are pattern metacharacters and are legal in Windows directory names. A project in `my[project]`, or the common browser-download form `downloads[1]`, produces a pattern that never matches its own venv, so `venv list`, `venv remove`, `venv activate`, `pdm use --venv` and interpreter discovery all silently see nothing. No error is raised.

On the unpatched source the added test reports:

```
assert {} == {'3.13': WindowsPath('.../venvs/downloads[1]-dS0SdxMQ-3.13')}
```

`iter_venvs` yields nothing while the venv it should find is on disk.

`glob.escape` rather than `iterdir()` and `startswith`, because `glob` returns empty for a missing venv parent directory while `iterdir()` raises `FileNotFoundError`, which is the normal state on a fresh machine. The `ident` slice keeps the unescaped length, since it indexes the real on-disk name rather than the pattern.

Scoped suite on Windows 11, CPython 3.13.5: 481 passed, 5 skipped.
