### PR TITLE
chore(news): add the missing news fragment for #3869

### DIFF
--- a/news/3869.bugfix.md
+++ b/news/3869.bugfix.md
@@ -1,0 +1,1 @@
+Escape glob characters in the virtualenv lookup prefix, so a project whose directory name contains `[` or `]` can find its own virtualenv.


### PR DESCRIPTION
PR #3869 merged without a news fragment, so this bug fix would not appear in the changelog. `CONTRIBUTING.md` asks for `news/<issue_num>.<issue_type>.md`, and towncrier collects it at release time regardless of when it lands.

One file, one sentence. Close it if you would rather the entry read differently.
