### PR TITLE
fix(workspace): resolve the root before making member paths relative

### DIFF
--- a/news/3874.bugfix.md
+++ b/news/3874.bugfix.md
@@ -1,0 +1,1 @@
+Resolve the workspace root before making member paths relative, so a root given as a relative path or reached through a symlink no longer raises `ValueError`.

--- a/src/pdm/project/workspace.py
+++ b/src/pdm/project/workspace.py
@@ -76,12 +76,16 @@ class WorkspaceManager:
         workspace_project = self.project or self.owner
         if not workspace_project.workspace.is_root:
             return
+        # ``iter_members()`` yields resolved paths, so the root has to be resolved too:
+        # ``Project.root`` is only made absolute, and a root given as ``pdm -p ../workspace``
+        # or reached through a symlink keeps a form ``relative_to()`` cannot match.
+        root = workspace_project.root.resolve()
         for member in workspace_project.workspace.iter_members():
             member_project = workspace_project.core.create_project(member)
             if not member_project.name or not member_project.is_distribution:
                 continue
             with cd(workspace_project.root):
-                req = parse_requirement("./" + member.relative_to(workspace_project.root).as_posix(), True)
+                req = parse_requirement("./" + member.relative_to(root).as_posix(), True)
                 req.relocate(workspace_project.backend)  # type: ignore[attr-defined]
             req.name = member_project.name
             req.groups = ["default"]

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -150,6 +150,29 @@ def test_workspace_root_adds_members_as_implicit_editable_dependencies(project):
     assert member_dependency.str_path == "./packages/foo"
 
 
+def test_workspace_root_reached_through_a_relative_path(project, core):
+    """`pdm -p ../<workspace>` must still resolve the members' relative paths."""
+    project.pyproject.settings["workspace"] = {"members": ["packages/*"]}
+    project.pyproject.write()
+    member_path = project.root / "packages" / "foo"
+    member_path.mkdir(parents=True)
+    member_path.joinpath("pyproject.toml").write_text(
+        '[project]\nname = "foo"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    sibling = project.root.parent / "elsewhere"
+    sibling.mkdir(exist_ok=True)
+    # Project.root is only made absolute, so a `..` survives into it.
+    indirect = core.create_project(sibling / ".." / project.root.name)
+
+    dependencies = indirect.get_dependencies("default")
+
+    member_dependency = dependencies[-1]
+    assert member_dependency.name == "foo"
+    assert member_dependency.editable
+    assert member_dependency.str_path == "./packages/foo"
+
+
 def test_workspace_member_declared_in_dev_group_not_forced_into_default(project, pdm):
     """Workspace members already in other groups must not be re-added to default (#3816)."""
     project.pyproject.settings["workspace"] = {"members": ["packages/*"]}


### PR DESCRIPTION
`iter_members()` yields resolved paths, but `Project.root` is only made absolute (`core.py:109`), so it keeps `..` segments and does not follow symlinks. `iter_dependencies` then called `member.relative_to(workspace_project.root)` against a root of a different shape and raised an unhandled `ValueError`.

Reproduced on unpatched `main` with a two-package workspace:

```
$ pdm list -p ws            # from the parent
| name | version | location |     <- fine

$ pdm list -p ../ws         # from a sibling directory
[ValueError]: '...\pdmws\ws\packages\foo' is not in the subpath of '...\pdmws\elsewhere\..\ws'
```

A root reached through a symlink or a Windows directory junction fails the same way. Since `_resolve_dependencies` calls this for every workspace root with a `default` group, `list`, `install`, `lock`, `add` and `update` all hit it.

The three sibling methods already resolve the root before calling `relative_to`: `content_hash` at line 120, `add_member` at 139, `remove_member` at 154. This makes `iter_dependencies` consistent with them. `relocate()` needed no change, since `os.path.relpath` normalises both sides.

Suite with `-m "not network and not integration and not uv"`: 1392 passed before, 1393 after, with one pre-existing failure either side (`test_link_python`, `WinError 1314`). That same missing privilege is why I demonstrated the symlink case with a junction.

A member that genuinely resolves outside the root still raises. `add_member` turns that into a `PdmUsageError`; matching it here looked like scope creep.
