### PR TITLE
fix(formats): parse multi-constraint and v-prefixed Poetry versions

### DIFF
--- a/news/3860.bugfix.md
+++ b/news/3860.bugfix.md
@@ -1,0 +1,1 @@
+Keep the separating comma out of the operator and accept a `v` prefix when converting Poetry version constraints.

--- a/src/pdm/formats/poetry.py
+++ b/src/pdm/formats/poetry.py
@@ -41,7 +41,11 @@ def check_fingerprint(project: Project | None, filename: Path | str) -> bool:
     return "tool" in data and "poetry" in data["tool"]
 
 
-VERSION_RE = re.compile(r"([^\d\s]*)\s*(\d.*?)\s*(?=,|$)")
+#: A single Poetry version constraint: an optional operator, an optional ``v``
+#: prefix, then the version itself. The operator is restricted to the characters
+#: Poetry actually uses -- matching any non-digit instead swallowed the separating
+#: comma of a multi-constraint string, so ``>=1.0,<2.0`` produced ``>=1.0,,<2.0``.
+VERSION_RE = re.compile(r"([<>=!~^]*)\s*v?\s*(\d.*?)\s*(?=,|$)")
 
 
 def _caret_upper_bound(version: str) -> str:

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -441,6 +441,31 @@ def test_convert_poetry_unusual_author(project, author, expected):
     assert result["authors"] == [expected]
 
 
+@pytest.mark.parametrize(
+    "constraint,expected",
+    [
+        # A multi-constraint string used to keep the separating comma as part of
+        # the next operator, emitting `>=1.0,,<2.0`.
+        (">=1.0,<2.0", "<2.0,>=1.0"),
+        (">=1.2,!=1.5,<2.0", "!=1.5,<2.0,>=1.2"),
+        (">= 1.0, < 2.0", "<2.0,>=1.0"),
+        # Poetry accepts a `v` prefix on the version.
+        ("^v1.2.3", "<2.0.0,>=1.2.3"),
+        ("~v1.2", "<1.3,>=1.2"),
+        ("v1.2.3", "==1.2.3"),
+    ],
+)
+def test_convert_poetry_multi_and_v_prefixed_constraint(project, constraint, expected):
+    pyproject = project.root / "pyproject.toml"
+    pyproject.write_text(
+        f'[tool.poetry]\nname = "demo"\nversion = "0.1.0"\n[tool.poetry.dependencies]\nfoo = "{constraint}"\n',
+        encoding="utf-8",
+    )
+    result, _ = poetry.convert(project, pyproject, ns())
+
+    assert result["dependencies"] == [f"foo{expected}"]
+
+
 def test_convert_poetry_12(project):
     golden_file = FIXTURES / "poetry-new.toml"
     with cd(FIXTURES):


### PR DESCRIPTION
## Summary
- Poetry version specifiers with multiple constraints (e.g. `^2.7,<3.0`) and versions prefixed with `v` (e.g. `v1.2.3`) previously failed to parse.
- Both are now handled by the Poetry format parser; tests cover the two cases.

## Testing
- Added regression tests in `tests/test_formats.py`.