### PR TITLE
fix(versions): name the version part that could not be read

### DIFF
--- a/news/3880.bugfix.md
+++ b/news/3880.bugfix.md
@@ -1,0 +1,1 @@
+Report the version part that could not be read, instead of blaming a postrelease for every parse failure.

--- a/src/pdm/models/versions.py
+++ b/src/pdm/models/versions.py
@@ -51,8 +51,17 @@ class Version:
                         self.pre = (pre_type, pre_n)
                         break  # pre release version is only at the end
                     else:
+                        # This branch is reached by anything the two cases above
+                        # did not read, not only by a postrelease. An epoch
+                        # (``1!1.0``), a local version (``1.0+local``), a dev
+                        # release (``1.0.dev1``) and a plain typo all landed
+                        # here and were all reported as postreleases, which
+                        # sends the reader looking for a segment that is not
+                        # there. Name the part that failed instead.
                         raise InvalidPyVersion(
-                            f"{version_str}: postreleases are not supported for python version specifiers."
+                            f"{version_str}: {v!r} is not a valid part of a python version "
+                            "specifier. Expected a number, a trailing '*', or a trailing "
+                            "prerelease such as 'a1', 'b2' or 'rc1'."
                         ) from None
             version = tuple(bits)
         self._version: tuple[VersionBit, ...] = version

--- a/tests/models/test_versions.py
+++ b/tests/models/test_versions.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from pdm.models.versions import InvalidPyVersion, Version
@@ -6,6 +8,27 @@ from pdm.models.versions import InvalidPyVersion, Version
 def test_unsupported_post_version() -> None:
     with pytest.raises(InvalidPyVersion):
         Version("3.10.0post1")
+
+
+@pytest.mark.parametrize(
+    ("version", "part"),
+    [
+        ("1!1.0", "1!1"),
+        ("1.0+local", "0+local"),
+        ("1.0.dev1", "dev1"),
+        ("1.0.post1", "post1"),
+        ("3.10.0post1", "0post1"),
+        ("3.x", "x"),
+    ],
+)
+def test_invalid_version_part_is_named_in_the_error(version: str, part: str) -> None:
+    """The message must point at the part that failed.
+
+    Every one of these used to be reported as a postrelease, including the
+    epoch, the local version and the plain typo, none of which contain one.
+    """
+    with pytest.raises(InvalidPyVersion, match=re.escape(repr(part))):
+        Version(version)
 
 
 def test_support_prerelease_version() -> None:


### PR DESCRIPTION
Fixes #3880

The catch-all `else` in `Version.__init__` reported every part it could not read as a postrelease. An epoch, a local version, a dev release and a plain typo all arrived there and all got the same answer, which points the reader at a segment their string does not contain.

The message now names the part that failed and lists what the parser accepts:

```
1!1.0: '1!1' is not a valid part of a python version specifier.
Expected a number, a trailing '*', or a trailing prerelease such as 'a1', 'b2' or 'rc1'.
```

Nothing about what parses changes. Only the exception text moved. `InvalidPyVersion` is still what gets raised, so the two handlers in `models/candidates.py` are unaffected.

Six parametrized cases cover the misreported forms, plus `1.0.post1` so the one accurate use of the old wording stays pinned. All six fail on the parent commit. `tests/models/`: 228 passed, and `ruff check` and `ruff format --check` are clean.