### PR TITLE
docs: clarify dependency command state changes

### DIFF
--- a/docs/usage/lockfile.md
+++ b/docs/usage/lockfile.md
@@ -1,6 +1,6 @@
 # Lock file
 
-PDM installs packages exclusively from the existing lock file named `pdm.lock`. This file serves as the sole source of truth for installing dependencies. The lock file contains essential information such as:
+PDM synchronizes dependencies using a locked resolution, normally stored in `pdm.lock`. Depending on the command, PDM can reuse that resolution or create a new one before installing packages. The lock file contains essential information such as:
 
 - All packages and their versions
 - The file names and hashes of the packages
@@ -13,19 +13,69 @@ To create or overwrite the lock file, run [`pdm lock`](../reference/cli.md#lock)
 
     It depends. If your goal is to make CI use the same dependency versions as local development and avoid unexpected failures, you should add the `pdm.lock` file to version control. Otherwise, if your project is a library and you want CI to mimic the installation on user site to ensure that the current version on PyPI doesn't break anything, then do not submit the `pdm.lock` file.
 
-## Install the packages pinned in lock file
+## Command effects
 
-There are a few similar commands to do this job with slight differences:
+There are three separate pieces of project state:
 
-- [`pdm sync`](../reference/cli.md#sync) installs packages from the lock file.
-- [`pdm update`](../reference/cli.md#update) will update the lock file, then `pdm sync`.
-- [`pdm install`](../reference/cli.md#install) will check the project file for changes, update the lock file if needed, then `pdm sync`.
+1. **`pyproject.toml` declares requirements.** It records the packages you request, acceptable version ranges, dependency groups, and other resolution inputs. It is not a list of the exact versions currently installed.
+2. **The lock file records a resolution.** It pins versions and artifacts for the groups included when locking. It can contain packages for several Python versions or platforms, not all of which will be installed in the current environment.
+3. **The environment contains installed packages.** It can lag behind the lock file or contain packages that are not in it. Installing a selected set of dependencies does not, by default, remove everything else.
 
-`pdm sync` also has a few options to manage installed packages:
+The following table describes normal successful invocations, without flags such as `--dry-run` or `--frozen-lockfile`. Commands operate in stages: an installation error can occur after the lock file has already been updated.
 
-- `--clean`: will remove packages no longer in the lockfile
-- `--clean-unselected` (or `--only-keep`): more thorough version of `--clean` that will also remove packages not in the groups specified by the `-G`, `-d`, and `--prod` options.
-  Note: by default, `pdm sync` selects all groups from the lockfile, so `--clean-unselected` is identical to `--clean` unless `-G`, `-d`, and `--prod` are used.
+| Command | Requirements and group arguments | `pyproject.toml` | Lock file | Installed packages |
+| --- | --- | --- | --- | --- |
+| [`pdm add`](../reference/cli.md#add) | Add or change the requested requirements in one target group (`default` unless selected otherwise). | Writes the target group's declarations. | Resolves the previously locked groups plus the target group. A new lock includes `default` and the target group. | Installs the target group's dependencies; keeps unrelated packages. |
+| [`pdm lock`](../reference/cli.md#lock) | Resolve the selected groups, or reuse the recorded group selection when none is specified. | Reads, but does not change, declarations. | Creates or updates the resolution; may select new versions according to the update strategy. | Does not install or remove packages. |
+| [`pdm install`](../reference/cli.md#install) | Install selected groups. A new lock uses the requested groups; refreshing an existing lock preserves its group selection. | Reads, but does not change, declarations. | Creates a missing lock or updates an outdated one, reusing compatible pins where possible. A fresh lock is reused. | Installs selected dependencies; keeps unrelated packages. |
+| [`pdm sync`](../reference/cli.md#sync) | Select groups already included in an existing lock. | Reads group selections without changing declarations. | Reads the locked resolution without creating or updating it. | Installs selected pinned versions; keeps unrelated packages unless a cleanup option is used. |
+| [`pdm update`](../reference/cli.md#update) | Update named packages or the selected groups, using the existing constraints and update strategy. | Keeps declarations unless `--unconstrained` is used. | Updates the resolution while preserving the locked groups. | Installs the selected dependencies; keeps unrelated packages. |
+
+`pdm update` does not add new dependencies: use `pdm add` for that. Named update targets can be declared requirements or transitive packages already in the lock. For a requirement declared outside the default group, specify its group with `-G`. Without package names, the selected groups determine the update targets.
+
+When the project is a distributable package and the `default` group is selected, synchronization also installs the project itself unless `--no-self` is given. A project configured with `distribution = false` is not installed itself.
+
+### Select groups for locking and installation
+
+Groups declared in `pyproject.toml`, groups included in the lock file, and groups selected for installation are distinct sets. The native `pdm.lock` format records the locked set in `metadata.groups`.
+
+- For `lock`, `install`, `sync`, and `update`, omitting group-selection options reuses the recorded groups that still exist in the project. Running plain `pdm lock` does not automatically add every newly declared group.
+- Without a recorded selection, the default selection includes `default` and development groups, but not optional groups. `pdm add` instead starts a new lock with `default` and its target group.
+- `-G:all` explicitly selects all declared groups. `--prod` excludes development groups. See [dependency group selection](./dependency.md#select-a-subset-of-dependency-groups-to-install) for combinations with `-G`, `--without`, and `--no-default`.
+- Selecting a group for installation does not by itself add that group to an existing lock file. `install`, `sync`, or `update` can report `Requested groups not in lockfile` even when the group is declared in `pyproject.toml`.
+
+For example, if a lock was created with `pdm lock --prod`, and you later want to install a declared `docs` group, first include the desired groups in the lock:
+
+```bash
+# Resolve all declared groups, including docs and development groups.
+pdm lock -G:all
+# Install the requested group selection from that lock.
+pdm install -G docs
+```
+
+If you intentionally maintain a smaller lock, use explicit group-selection options instead of `-G:all`. A stale-lock refresh by `pdm install` preserves the previously locked groups; it is not a replacement for selecting new groups with `pdm lock`.
+
+Lock strategy flags, such as `static_urls`, are also persisted in `metadata.strategy` and reused by later locking operations. This is separate from the [update strategy](./dependency.md#about-update-strategy), which controls which existing versions the resolver tries to reuse. See [lock strategies](#lock-strategies) for changing the stored flags. These metadata field names describe the native `pdm` format; see [lock file formats](#change-lock-file-format) for the alternative `pylock` format.
+
+### Keep or clean installed packages
+
+Ordinary `install`, `sync`, `add`, and `update` invocations do not remove unrelated installed packages. For example, removing a requirement from `pyproject.toml` and running `pdm install` can update the lock without uninstalling that now-unneeded package.
+
+Use `pdm sync` when you want cleanup:
+
+- `--clean` removes eligible installed packages absent from the **entire lock file**. Packages locked in an unselected group are kept.
+- `--clean-unselected` (also spelled `--only-keep`) additionally removes eligible packages outside the **selected groups**.
+
+By default, `sync` selects the recorded locked groups, so the two cleanup modes differ when you select a subset, such as `pdm sync --prod --clean-unselected`. Installer-managed packages are protected from removal.
+
+### Control resolution, writes, and installation separately
+
+- `pdm add --no-sync` and `pdm update --no-sync` leave installed packages unchanged while updating the project/lock state described above.
+- `pdm lock --check` checks freshness and exits without installing packages. `pdm install --check` refuses a missing or outdated lock, but **still installs** the selected dependencies when the lock is fresh.
+- `pdm lock --refresh` refreshes lock input metadata and artifact hashes without changing the pinned versions. It does not resolve a new set of dependency versions.
+- `--frozen-lockfile` prevents **writing** the lock file; it does not prohibit resolution. For example, `pdm install --frozen-lockfile` can resolve and install dependencies without creating a lock file. `pdm add --frozen-lockfile --no-sync` can change declarations without resolving or installing them.
+
+Use `install --check`, not `--frozen-lockfile` alone, when installation must fail if the committed lock is missing or outdated. See [freshness checks](#lock-file-freshness) below for what makes a lock outdated.
 
 ## Lock file freshness
 

--- a/news/2681.doc.md
+++ b/news/2681.doc.md
@@ -1,0 +1,1 @@
+Clarify dependency command effects on project declarations, lock metadata, and installed packages in the guide and CLI help.

--- a/src/pdm/cli/commands/add.py
+++ b/src/pdm/cli/commands/add.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 
 class Command(BaseCommand):
-    """Add package(s) to pyproject.toml and install them"""
+    """Add requirements, update the lockfile, and install the target group"""
 
     arguments = (
         *BaseCommand.arguments,
@@ -49,6 +49,12 @@ class Command(BaseCommand):
     )
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.epilog = (
+            "Writes the requested requirements to pyproject.toml, resolves them with the previously locked groups, "
+            "and updates the lockfile. The target dependency group is added to the locked groups; a new lockfile "
+            "includes the default and target groups. Installs packages from the target group without removing "
+            "unrelated installed packages. Use --no-sync to leave the environment unchanged."
+        )
         parser.add_argument(
             "-d",
             "--dev",

--- a/src/pdm/cli/commands/install.py
+++ b/src/pdm/cli/commands/install.py
@@ -20,7 +20,7 @@ from pdm.project import Project
 
 
 class Command(BaseCommand):
-    """Install dependencies from lock file"""
+    """Check the lockfile, resolve if needed, and install dependencies"""
 
     arguments = (
         *BaseCommand.arguments,
@@ -35,6 +35,13 @@ class Command(BaseCommand):
     )
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.epilog = (
+            "Creates a missing lockfile or updates an outdated one, then installs the selected locked packages. "
+            "Does not change dependency declarations in pyproject.toml or remove unrelated installed packages. "
+            "Refreshing an existing lockfile preserves its locked groups; run pdm lock with the desired groups "
+            "before installing a group not yet locked. --check refuses a missing or outdated lockfile but still "
+            "installs when it is fresh. --frozen-lockfile prevents lockfile writes, not dependency resolution."
+        )
         parser.add_argument(
             "--check",
             action="store_true",

--- a/src/pdm/cli/commands/lock.py
+++ b/src/pdm/cli/commands/lock.py
@@ -36,7 +36,7 @@ def _parse_exclude_newer_override(value: str) -> tuple[str, datetime | None]:
 
 
 class Command(BaseCommand):
-    """Resolve and lock dependencies"""
+    """Resolve dependencies and write the lockfile without installing packages"""
 
     arguments = (
         *BaseCommand.arguments,
@@ -50,6 +50,12 @@ class Command(BaseCommand):
     )
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.epilog = (
+            "Reads requirements from pyproject.toml for the selected groups and writes the selected lockfile. Does "
+            "not change pyproject.toml. Does not install or remove packages. With no group-selection options, an "
+            "existing lockfile keeps its recorded groups; use -G:all to lock all declared groups. Lock strategy "
+            "flags are also remembered unless changed with --strategy."
+        )
         parser.add_argument(
             "--refresh",
             action="store_true",

--- a/src/pdm/cli/commands/sync.py
+++ b/src/pdm/cli/commands/sync.py
@@ -16,7 +16,7 @@ from pdm.project import Project
 
 
 class Command(BaseCommand):
-    """Synchronize the current working set with lock file"""
+    """Install selected locked packages without updating the lockfile"""
 
     arguments = (
         *BaseCommand.arguments,
@@ -30,6 +30,12 @@ class Command(BaseCommand):
     )
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.epilog = (
+            "Reads group selections from pyproject.toml without changing it. Requires an existing lockfile and "
+            "installs its pinned versions for the selected groups. Does not resolve new versions or update the "
+            "lockfile. Keeps unrelated installed packages by default. --clean removes packages absent from the "
+            "whole lockfile; --clean-unselected also removes packages outside the selected groups."
+        )
         parser.add_argument(
             "-r",
             "--reinstall",

--- a/src/pdm/cli/commands/update.py
+++ b/src/pdm/cli/commands/update.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 
 class Command(BaseCommand):
-    """Update package(s) in pyproject.toml"""
+    """Update locked dependency versions and install them"""
 
     arguments = (
         *BaseCommand.arguments,
@@ -48,6 +48,12 @@ class Command(BaseCommand):
     )
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.epilog = (
+            "Resolves updates for the requested packages or selected groups, writes the lockfile, and installs the "
+            "selected dependencies. Version constraints in pyproject.toml are kept unless --unconstrained is given. "
+            "Existing locked groups are preserved, and the update strategy controls which pins are reused. Use "
+            "--no-sync to leave installed packages unchanged."
+        )
         parser.add_argument(
             "-t",
             "--top",

--- a/tasks/doc_templates/cli.md.in
+++ b/tasks/doc_templates/cli.md.in
@@ -2,4 +2,6 @@
 
 # CLI Reference
 
+For how dependency commands affect `pyproject.toml`, the lock file, and installed packages, see [Command effects](../usage/lockfile.md#command-effects).
+
 {{ cli_reference }}

--- a/tasks/render_reference_docs.py
+++ b/tasks/render_reference_docs.py
@@ -67,6 +67,9 @@ def render_parser(parser: argparse.ArgumentParser, title: str, heading_level: in
             result.append(line)
         result.append("")
 
+    if parser.epilog:
+        result.append(clean_help(parser.epilog))
+
     return "\n".join(result).rstrip()
 
 

--- a/tests/cli/test_others.py
+++ b/tests/cli/test_others.py
@@ -32,6 +32,22 @@ def test_help_option(pdm):
     assert "usage: pdm [-h]" in result.output.lower()
 
 
+@pytest.mark.parametrize(
+    "command, detail",
+    [
+        ("add", "Use --no-sync to leave the environment unchanged."),
+        ("lock", "Does not install or remove packages."),
+        ("install", "Creates a missing lockfile"),
+        ("sync", "Does not resolve new versions or update the lockfile."),
+        ("update", "Version constraints in pyproject.toml are kept unless --unconstrained is given."),
+    ],
+)
+def test_command_help_explains_state_effects(pdm, command, detail):
+    result = pdm([command, "--help"], strict=True)
+    assert detail in " ".join(result.output.split())
+    assert detail not in pdm(["--help"], strict=True).output
+
+
 def test_pep582_option(pdm):
     result = pdm(["--pep582", "bash"])
     assert result.exit_code == 0

--- a/tests/test_doc_generation.py
+++ b/tests/test_doc_generation.py
@@ -1,0 +1,14 @@
+import argparse
+
+from tasks.render_reference_docs import render_parser
+
+
+def test_cli_reference_includes_command_notes():
+    parser = argparse.ArgumentParser(description="Command summary", epilog="Keep pyproject.toml and pdm.lock.")
+    parser.add_argument("--check", action="store_true", help="Check the saved state")
+
+    rendered = render_parser(parser, "example")
+
+    assert "> Command summary" in rendered
+    assert "Keep `pyproject.toml` and `pdm.lock`." in rendered
+    assert rendered.index("--check") < rendered.index("Keep `pyproject.toml`")


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Fixes #2681.

Documents the distinction between declared requirements, the locked resolution (including stored groups and strategy flags), and installed packages.

- Add a [command-effects table and troubleshooting guidance](https://github.com/fzlzjerry/pdm/blob/ff16ef1a1d10a40f108a43504ada338138a7e527/docs/usage/lockfile.md#command-effects) for `add`, `lock`, `install`, `sync`, and `update`.
- Explain missing/stale lockfiles, selecting groups that have not been locked, retaining/removing extra installed packages, and the difference between `--check`, `--no-sync`, and `--frozen-lockfile`.
- Correct the short command summaries and add detailed help epilogs while keeping the top-level command list compact.
- Include those epilogs in the generated CLI reference and link the reference to the guide. Generated reference files remain untracked as intended by the repository; the source template and renderer are updated.
- Add six regression cases and the documentation news fragment.

The dependency-management algorithms are unchanged. An AST comparison of all five command modules, excluding their help strings and `parser.epilog` assignments, matches the upstream implementations.

### Validation

- **32 real CLI operations** with locally generated wheels and dedicated project virtual environments. Compared project/lock hashes, locked versions/groups/strategies, and installed distributions before and after each command. These include expected failures, such as missing/unlocked groups, rather than only successful commands.
- The six new help/rendering regression cases fail before the changes and pass after them.
- `pdm run test -n 4`: **1,455 passed, 1 Windows-only skip**, after rebasing onto current upstream. The multi-interpreter integration cases ran with Python 3.10 and 3.13 available.
- `pdm run lint`: Ruff, formatting, codespell, and mypy pass.
- `pdm run doc-build`: successful; checked the built guide and CLI reference contain the new sections and descriptions.
- `git diff --check`: passes.

One important distinction confirmed by the CLI checks is that `install --check` still installs when the lock is fresh, whereas `--frozen-lockfile` only prevents lockfile writes and can still resolve dependencies. Another is that plain locking preserves an existing group selection, so selecting a newly declared group for installation is not the same as adding it to the lock.
