### PR TITLE
feat: allow disabling managed Python selection

### DIFF
--- a/docs/usage/project.md
+++ b/docs/usage/project.md
@@ -97,6 +97,15 @@ pdm python install --min
 The same principles apply to [`pdm use`](../reference/cli.md#use) (incl. an automatic installation feature)
 which make it a good unattended set up command for CI/CD or 'fresh start with existing pyproject.toml' use-cases.
 
+To use only Python interpreters installed outside PDM, disable managed Python:
+
+```bash
+pdm config python.use_managed false
+```
+
+You can also set `PDM_NO_MANAGED_PYTHON=true` for a command or environment. PDM will not select or install
+an interpreter from its managed Python directory, but explicit external interpreter paths remain available.
+
 ### Virtualenv or not
 
 After you select the Python interpreter, PDM will ask you whether you want to create a virtual environment for the project.

--- a/news/3753.feature.md
+++ b/news/3753.feature.md
@@ -1,0 +1,1 @@
+Add a `python.use_managed` setting and `PDM_NO_MANAGED_PYTHON` override to use only separately installed Python interpreters.

--- a/src/pdm/cli/commands/use.py
+++ b/src/pdm/cli/commands/use.py
@@ -89,11 +89,13 @@ class Command(BaseCommand):
                 project.core.ui.error(
                     f"The last selection is corrupted. {path!r}",
                 )
-            elif version_matcher(cached_python):
+            elif version_matcher(cached_python) and (
+                project.use_managed_python or not project._is_managed_python(cached_python)
+            ):
                 project.core.ui.info("Using the last selection, add '-i' to ignore it.")
                 return cached_python
 
-        if not python and not first and (auto_install_min or auto_install_max):
+        if not python and not first and (auto_install_min or auto_install_max) and project.use_managed_python:
             match = project.get_best_matching_cpython_version(auto_install_min)
             if match is None:
                 req = f'requires-python="{project.python_requires}"'

--- a/src/pdm/project/config.py
+++ b/src/pdm/project/config.py
@@ -203,6 +203,9 @@ class Config(MutableMapping[str, str]):
             "List of python provider names for findpython", default=[], coerce=split_by_comma
         ),
         "python.use_pyenv": ConfigItem("Use the pyenv interpreter", True, coerce=ensure_boolean),
+        "python.use_managed": ConfigItem(
+            "Use Python interpreters managed by PDM", True, env_var="PDM_USE_MANAGED_PYTHON", coerce=ensure_boolean
+        ),
         "python.use_venv": ConfigItem(
             "Use virtual environments when available", True, env_var="PDM_USE_VENV", coerce=ensure_boolean
         ),

--- a/src/pdm/project/core.py
+++ b/src/pdm/project/core.py
@@ -6,6 +6,7 @@ import itertools
 import operator
 import os
 import shutil
+import subprocess
 import sys
 from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
 from copy import deepcopy
@@ -245,6 +246,13 @@ class Project:
         return collections.ChainMap(self.project_config, self.global_config)
 
     @property
+    def use_managed_python(self) -> bool:
+        """Whether PDM may select or install a Python interpreter it manages."""
+        if ensure_boolean(os.getenv("PDM_NO_MANAGED_PYTHON")):
+            return False
+        return self.config["python.use_managed"]
+
+    @property
     def scripts(self) -> dict[str, str | dict[str, str]]:
         return self.pyproject.settings.get("scripts", {})
 
@@ -329,15 +337,20 @@ class Project:
         saved_path = self._saved_python
         if saved_path and not ensure_boolean(os.getenv("PDM_IGNORE_SAVED_PYTHON")):
             python = PythonInfo.from_path(saved_path)
-            if match_version(python):
+            policy_rejected = False
+            if match_version(python) and (self.use_managed_python or not self._is_managed_python(python)):
                 return python
             elif not python.valid:
                 note("The saved Python interpreter does not exist or broken. Trying to find another one.")
+            elif match_version(python) and not self.use_managed_python and self._is_managed_python(python):
+                note("The saved Python interpreter is managed by PDM. Trying to find another one.")
+                policy_rejected = True
             else:
                 note(
                     "The saved Python interpreter doesn't match the project's requirement. Trying to find another one."
                 )
-            self._saved_python = None  # Clear the saved path if it doesn't match
+            if not policy_rejected:
+                self._saved_python = None  # Clear the saved path if it doesn't match
 
         if config.get("python.use_venv") and not self.is_global:
             # Resolve virtual environments from env-vars
@@ -975,7 +988,7 @@ class Project:
             if filter_func is None or filter_func(interpreter):
                 found = True
                 yield interpreter
-        if found or self.is_global:
+        if found or self.is_global or not self.use_managed_python:
             return
 
         if not python_spec:  # handle both empty string and None
@@ -1020,52 +1033,76 @@ class Project:
                 if os.name == "nt":
                     pyenv_shim += ".bat"
                 if os.path.exists(pyenv_shim):
-                    yield PythonInfo.from_path(pyenv_shim)
+                    python_info = PythonInfo.from_path(pyenv_shim)
+                    if self.use_managed_python or not self._is_managed_python(python_info):
+                        yield python_info
                 elif os.path.exists(pyenv_shim.replace("python3", "python")):
-                    yield PythonInfo.from_path(pyenv_shim.replace("python3", "python"))
+                    python_info = PythonInfo.from_path(pyenv_shim.replace("python3", "python"))
+                    if self.use_managed_python or not self._is_managed_python(python_info):
+                        yield python_info
             python = shutil.which("python") or shutil.which("python3")
             if python:
-                yield PythonInfo.from_path(python)
+                python_info = PythonInfo.from_path(python)
+                if self.use_managed_python or not self._is_managed_python(python_info):
+                    yield python_info
         else:
             if not all(c.isdigit() for c in python_spec.split(".")):
                 path = Path(python_spec)
                 if path.exists():
                     python = find_python_in_path(python_spec)
                     if python:
-                        yield PythonInfo.from_path(python)
-                        return
+                        python_info = PythonInfo.from_path(python)
+                        if self.use_managed_python or not self._is_managed_python(python_info):
+                            yield python_info
+                            return
                 if len(path.parts) == 1:  # only check for spec with only one part
                     python = shutil.which(python_spec)
                     if python:
-                        yield PythonInfo.from_path(python)
-                        return
+                        python_info = PythonInfo.from_path(python)
+                        if self.use_managed_python or not self._is_managed_python(python_info):
+                            yield python_info
+                            return
             finder_arg = python_spec
         if search_venv is None:
             search_venv = cast(bool, config["python.use_venv"])
         finder = self._get_python_finder(search_venv)
         for entry in finder.find_all(finder_arg, allow_prereleases=True):
-            yield PythonInfo(entry)
+            python_info = PythonInfo(entry)
+            if self.use_managed_python or not self._is_managed_python(python_info):
+                yield python_info
         if not python_spec:
             # Lastly, return the host Python as well
             this_python = getattr(sys, "_base_executable", sys.executable)
-            yield PythonInfo.from_path(this_python)
+            python_info = PythonInfo.from_path(this_python)
+            if self.use_managed_python or not self._is_managed_python(python_info):
+                yield python_info
+
+    def _is_managed_python(self, python: PythonInfo) -> bool:
+        install_root = Path(self.config["python.install_root"]).expanduser().resolve()
+        try:
+            target = python.executable
+        except (OSError, subprocess.SubprocessError):
+            return True
+        return is_path_relative_to(target.resolve(), install_root)
 
     def _get_python_finder(self, search_venv: bool = True) -> Finder:
         from findpython import Finder
 
         from pdm.cli.commands.venv.utils import VenvProvider
 
-        providers: list[str] = self.config["python.providers"]
+        configured_providers = list(self.config["python.providers"])
+        providers = configured_providers.copy()
         venv_pos = -1
         if not providers:
             venv_pos = 0
         elif "venv" in providers:
             venv_pos = providers.index("venv")
             providers.remove("venv")
+        selected_providers: list[str] | None = providers if configured_providers else None
         old_rye_root = os.getenv("RYE_PY_ROOT")
         os.environ["RYE_PY_ROOT"] = os.path.expanduser(self.config["python.install_root"])
         try:
-            finder = Finder(resolve_symlinks=True, selected_providers=providers or None)
+            finder = Finder(resolve_symlinks=True, selected_providers=selected_providers)
         finally:
             if old_rye_root:  # pragma: no cover
                 os.environ["RYE_PY_ROOT"] = old_rye_root

--- a/tests/cli/test_python.py
+++ b/tests/cli/test_python.py
@@ -198,8 +198,10 @@ def test_no_managed_python_preserves_saved_selection(project, mocker, monkeypatc
 
 def test_no_managed_python_finds_linked_python_by_version(project, mocker):
     project.global_config["python.use_managed"] = False
-    linked_path = Path(project.config["python.install_root"]) / "cpython@3.14.0" / (
-        "python.exe" if sys.platform == "win32" else "bin/python3"
+    linked_path = (
+        Path(project.config["python.install_root"])
+        / "cpython@3.14.0"
+        / ("python.exe" if sys.platform == "win32" else "bin/python3")
     )
     linked = FindPythonVersion(
         linked_path,
@@ -221,8 +223,10 @@ def test_no_managed_python_skips_managed_path_lookup(project, mocker):
     project.global_config["python.use_managed"] = False
     wrapper = project.root.parent / "python-wrapper"
     wrapper.touch()
-    managed_python = Path(project.config["python.install_root"]) / "cpython@3.14.0" / (
-        "python.exe" if sys.platform == "win32" else "bin/python3"
+    managed_python = (
+        Path(project.config["python.install_root"])
+        / "cpython@3.14.0"
+        / ("python.exe" if sys.platform == "win32" else "bin/python3")
     )
     mocker.patch("pdm.project.core.shutil.which", return_value=str(wrapper))
     mocker.patch("findpython.python.PythonVersion._get_interpreter", return_value=str(managed_python))
@@ -242,8 +246,10 @@ def test_no_managed_python_skips_managed_pyenv_shim(project, mocker, shim_name):
     pyenv_shim = pyenv_root / "shims" / (shim_name + ".bat" if sys.platform == "win32" else shim_name)
     pyenv_shim.parent.mkdir(parents=True, exist_ok=True)
     pyenv_shim.touch()
-    managed_python = Path(project.config["python.install_root"]) / "cpython@3.14.0" / (
-        "python.exe" if sys.platform == "win32" else "bin/python3"
+    managed_python = (
+        Path(project.config["python.install_root"])
+        / "cpython@3.14.0"
+        / ("python.exe" if sys.platform == "win32" else "bin/python3")
     )
     mocker.patch("pdm.project.core.PYENV_ROOT", str(pyenv_root))
     mocker.patch("pdm.project.core.shutil.which", return_value=None)

--- a/tests/cli/test_python.py
+++ b/tests/cli/test_python.py
@@ -3,8 +3,10 @@ import sys
 from pathlib import Path
 
 import pytest
+from findpython import PythonVersion as FindPythonVersion
 from pbs_installer import PythonVersion
 
+from pdm.exceptions import NoPythonVersion
 from pdm.models.python import PythonInfo
 from pdm.utils import parse_version
 
@@ -137,6 +139,122 @@ def test_use_no_auto_install(project, pdm, mocker):
     pdm(["use", "-f"], obj=project, strict=True)
     installer.assert_not_called()
     mock_best_match.assert_not_called()
+
+
+def test_use_no_managed_python(project, pdm, mocker, monkeypatch):
+    monkeypatch.setenv("PDM_NO_MANAGED_PYTHON", "true")
+    mock_find_interpreters = mocker.patch("pdm.project.Project.find_interpreters", return_value=[])
+    mock_install = mocker.patch(
+        "pdm.cli.commands.python.InstallCommand.install_python", return_value=PythonInfo.from_path(sys.executable)
+    )
+
+    result = pdm(["use", "3.10.8"], obj=project)
+
+    assert result.exit_code != 0
+    mock_find_interpreters.assert_called_once()
+    mock_install.assert_not_called()
+
+
+def test_use_auto_install_strategy_respects_no_managed_python(project, pdm, mocker, monkeypatch):
+    monkeypatch.setenv("PDM_NO_MANAGED_PYTHON", "true")
+    mock_find_interpreters = mocker.patch("pdm.project.Project.find_interpreters", return_value=[])
+    mock_best_match = mocker.patch(
+        "pdm.project.core.Project.get_best_matching_cpython_version", return_value=PythonVersion("cpython", 3, 10, 8)
+    )
+    mock_install = mocker.patch(
+        "pdm.cli.commands.python.InstallCommand.install_python", return_value=PythonInfo.from_path(sys.executable)
+    )
+
+    result = pdm(["use", "--auto-install-min"], obj=project)
+
+    assert result.exit_code != 0
+    mock_find_interpreters.assert_called_once()
+    mock_best_match.assert_not_called()
+    mock_install.assert_not_called()
+
+
+def test_no_managed_python_keeps_managed_provider_for_links(project, mocker):
+    project.global_config["python.use_managed"] = False
+    finder = mocker.patch("findpython.Finder")
+
+    project._get_python_finder(search_venv=False)
+
+    providers = finder.call_args.kwargs["selected_providers"]
+    assert providers is None or "rye" in providers
+
+
+def test_no_managed_python_preserves_saved_selection(project, mocker, monkeypatch):
+    monkeypatch.setenv("PDM_NO_MANAGED_PYTHON", "true")
+    saved_python = Path(sys.executable)
+    project.global_config["python.install_root"] = str(saved_python.parent)
+    project._saved_python = saved_python.as_posix()
+    mocker.patch.object(project, "iter_interpreters", return_value=iter(()))
+
+    with pytest.raises(NoPythonVersion):
+        project.resolve_interpreter()
+
+    assert project._saved_python == saved_python.as_posix()
+
+
+def test_no_managed_python_finds_linked_python_by_version(project, mocker):
+    project.global_config["python.use_managed"] = False
+    linked_path = Path(project.config["python.install_root"]) / "cpython@3.14.0" / (
+        "python.exe" if sys.platform == "win32" else "bin/python3"
+    )
+    linked = FindPythonVersion(
+        linked_path,
+        _interpreter=Path(sys.executable),
+        _version=parse_version(platform.python_version()),
+    )
+    finder = mocker.Mock()
+    finder.find_all.return_value = [linked]
+    mocker.patch.object(project, "_get_python_finder", return_value=finder)
+
+    interpreters = list(project.find_interpreters("3.14", search_venv=False))
+
+    assert len(interpreters) == 1
+    assert interpreters[0].path == linked_path
+    assert interpreters[0].executable == Path(sys.executable)
+
+
+def test_no_managed_python_skips_managed_path_lookup(project, mocker):
+    project.global_config["python.use_managed"] = False
+    wrapper = project.root.parent / "python-wrapper"
+    wrapper.touch()
+    managed_python = Path(project.config["python.install_root"]) / "cpython@3.14.0" / (
+        "python.exe" if sys.platform == "win32" else "bin/python3"
+    )
+    mocker.patch("pdm.project.core.shutil.which", return_value=str(wrapper))
+    mocker.patch("findpython.python.PythonVersion._get_interpreter", return_value=str(managed_python))
+    finder = mocker.Mock()
+    finder.find_all.return_value = []
+    mocker.patch.object(project, "_get_python_finder", return_value=finder)
+
+    interpreters = list(project.find_interpreters("python", search_venv=False))
+
+    assert not interpreters
+
+
+@pytest.mark.parametrize("shim_name", ["python3", "python"])
+def test_no_managed_python_skips_managed_pyenv_shim(project, mocker, shim_name):
+    project.global_config["python.use_managed"] = False
+    pyenv_root = project.root.parent / "pyenv"
+    pyenv_shim = pyenv_root / "shims" / (shim_name + ".bat" if sys.platform == "win32" else shim_name)
+    pyenv_shim.parent.mkdir(parents=True, exist_ok=True)
+    pyenv_shim.touch()
+    managed_python = Path(project.config["python.install_root"]) / "cpython@3.14.0" / (
+        "python.exe" if sys.platform == "win32" else "bin/python3"
+    )
+    mocker.patch("pdm.project.core.PYENV_ROOT", str(pyenv_root))
+    mocker.patch("pdm.project.core.shutil.which", return_value=None)
+    mocker.patch("findpython.python.PythonVersion._get_interpreter", return_value=str(managed_python))
+    finder = mocker.Mock()
+    finder.find_all.return_value = []
+    mocker.patch.object(project, "_get_python_finder", return_value=finder)
+
+    interpreters = list(project.find_interpreters(search_venv=False))
+
+    assert all(interpreter.path != pyenv_shim for interpreter in interpreters)
 
 
 def test_use_auto_install_strategy_max(project, pdm, mock_install, mocker):


### PR DESCRIPTION
Closes #3753.

PDM currently has no way to require a separately installed Python. In
particular, `PDM_NO_MANAGED_PYTHON` is not recognized, and Python selection can
continue to use or install an interpreter under PDM's managed directory. This
prevents organizations from enforcing centrally approved Python installations.

The change adds the `python.use_managed` setting, enabled by default, together
with the `PDM_NO_MANAGED_PYTHON=true` environment override. When managed Python
is disabled, saved selections, automatic installation, PATH lookups, and pyenv
shims are checked against the managed install root. Explicit external
interpreters, including interpreters linked into that root, remain selectable.

### How this was tested

The issue reproduces at the base commit: `pdm python install
--no-managed-python cpython@3.12` exits 2 with `unrecognized arguments`.

With the new regression tests retained and the source change reverted, 8
managed-Python policy tests failed and 11 tests were deselected. With the
change restored, the focused suite passes 17 tests with 2 deselected:

```text
python -m pytest tests/cli/test_python.py -q -k "not link_python"
17 passed, 2 deselected
```

The passing command was run by Mailman in a clean candidate workspace on
Windows 11 with Python 3.14.3. The unfiltered file has one unrelated Windows
symlink-permission test, so `link_python` is excluded from this focused gate.
Optional ruff and mypy checks were unavailable in the run environment.

### An alternative I did not take

I considered adding a one-off flag only to `pdm use`. A persisted setting plus
an environment override applies the same policy to saved selections,
discovery, and automatic installation, which is the organization-wide control
requested here. The trade-off is two configuration surfaces instead of a
single command-line flag.

### AI disclosure

This change was drafted with AI assistance (codex (`gpt-5.6-luna`) wrote the
patch, and codex (`gpt-5.6-luna`) reviewed it), running under Mailman. The test
results above come from the harness executing the commands itself, not from
either agent's account of its own work. The submitting human must read, test,
and take responsibility for every line before filing.
