### PR TITLE
docs: update PEP 621 license example

### DIFF
--- a/docs/reference/pep621.md
+++ b/docs/reference/pep621.md
@@ -76,7 +76,7 @@ see https://peps.python.org/pep-0639/#deprecate-license-classifiers -->
 The license is specified as the string `license`:
 
 ```toml
-license = {text = "BSD-2-Clause"}
+license = "BSD-2-Clause"
 classifiers = [
     "License :: OSI Approved :: BSD License",
     ...

--- a/news/3877.doc.md
+++ b/news/3877.doc.md
@@ -1,0 +1,1 @@
+Update the PEP 621 license example to use a string value.


### PR DESCRIPTION
Closes #3877.

The PEP 621 reference still showed the license metadata in the deprecated table form, which could lead readers to copy an outdated example into their `pyproject.toml`.

The example was stale documentation rather than a runtime problem. The fix keeps the existing `BSD-2-Clause` value and changes its TOML representation to the string form used by current PEP 621 guidance. The required `news/3877.doc.md` fragment is included, and no runtime code changes are involved.

### How this was tested

- Before the change, the diff-pinned checker exited 1 with `LEGACY_LICENSE_EXAMPLE_PRESENT`.
- After the change, it exited 0 twice with `PEP621_LICENSE_EXAMPLE_UPDATED`.
- `git diff --check` passed.

The focused pytest command was attempted, but the run environment produced 16 passed tests and 73 setup errors while creating pytest temporary directories (`WinError 5`). The Towncrier and Zensical checks were unavailable because those packages were not installed. The recorded verification ran on Windows 11 with Python 3.14.3.

### Alternative considered

The example keeps `BSD-2-Clause` instead of replacing it with a different license value, and the change is limited to the affected reference example rather than changing unrelated fixtures or generated metadata.

### AI disclosure

This change was drafted with AI assistance: Codex (`gpt-5.6-luna`) wrote the patch and Codex (`gpt-5.6-luna`) reviewed it under Mailman. The verification results above were run by the harness itself.
